### PR TITLE
Add use HTTPS redirect to Core API

### DIFF
--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -154,6 +154,7 @@ namespace FoundationaLLM.Core.API
                     }
                 });
 
+            app.UseHttpsRedirection();
             app.MapControllers();
 
             app.UseCors(allowAllCorsOrigins);


### PR DESCRIPTION
# Add use HTTPS redirect to Core API

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Core not forcing an HTTPS redirect.

## Details on the issue fix or feature implementation

Add HTTPS redirect middleware.

## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [X]  I have included inline docs for my changes, where applicable
- [X]  I have successfully run a local build