### PR TITLE
Add ClientBrandingConfiguration to CoreServiceTests

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -36,7 +36,7 @@ public class CoreService : ICoreService
         ICosmosDbService cosmosDbService,
         IGatekeeperAPIService gatekeeperAPIService,
         ILogger<CoreService> logger,
-            IOptions<ClientBrandingConfiguration> settings)
+        IOptions<ClientBrandingConfiguration> settings)
     {
         _cosmosDbService = cosmosDbService;
         _gatekeeperAPIService = gatekeeperAPIService;

--- a/tests/dotnet/Core.Tests/Services/CoreServiceTests.cs
+++ b/tests/dotnet/Core.Tests/Services/CoreServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using FoundationaLLM.Common.Models.Chat;
+using FoundationaLLM.Common.Models.Configuration.Branding;
 using FoundationaLLM.Common.Models.Orchestration;
 using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Core.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 
@@ -15,10 +17,11 @@ namespace FoundationaLLM.Core.Tests.Services
         private readonly ICosmosDbService _cosmosDbService = Substitute.For<ICosmosDbService>();
         private readonly IGatekeeperAPIService _gatekeeperAPIService = Substitute.For<IGatekeeperAPIService>();
         private readonly ILogger<CoreService> _logger = Substitute.For<ILogger<CoreService>>();
+        private readonly IOptions<ClientBrandingConfiguration> _brandingConfig = Substitute.For<IOptions<ClientBrandingConfiguration>>();
 
         public CoreServiceTests()
         {
-            _testedService = new CoreService(_cosmosDbService, _gatekeeperAPIService, _logger);
+            _testedService = new CoreService(_cosmosDbService, _gatekeeperAPIService, _logger, _brandingConfig);
         }
 
         #region GetAllChatSessionsAsync
@@ -28,7 +31,7 @@ namespace FoundationaLLM.Core.Tests.Services
         {
             // Arrange
             var expectedSessions = new List<Session>() { new Session() };
-            _cosmosDbService.GetSessionsAsync().Returns(expectedSessions);
+            _cosmosDbService.GetSessionsAsync(Arg.Any<string>()).Returns(expectedSessions);
 
             // Act
             var actualSessions = await _testedService.GetAllChatSessionsAsync();


### PR DESCRIPTION
# Add ClientBrandingConfiguration to CoreServiceTests

## The issue or feature being addressed

Core.Tests project fails to build due to recent changes in CoreService.

## Details on the issue fix or feature implementation

Add ClientBrandingConfiguration settings to CoreService in CoreServiceTests

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build