### PR TITLE
Add Authorize option to Swagger pages

### DIFF
--- a/src/dotnet/AgentFactoryAPI/Program.cs
+++ b/src/dotnet/AgentFactoryAPI/Program.cs
@@ -8,6 +8,7 @@ using FoundationaLLM.AgentFactory.Models.ConfigurationOptions;
 using FoundationaLLM.AgentFactory.Services;
 using FoundationaLLM.Common.Authentication;
 using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Extensions;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Middleware;
 using FoundationaLLM.Common.Models.Authentication;
@@ -129,6 +130,9 @@ namespace FoundationaLLM.AgentFactory.API
 
                     // Integrate xml comments
                     options.IncludeXmlComments(filePath);
+
+                    // Adds auth via X-API-KEY header
+                    options.AddAPIKeyAuth();
                 });
 
             var app = builder.Build();

--- a/src/dotnet/Common/Constants/Swagger.cs
+++ b/src/dotnet/Common/Constants/Swagger.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The OpenAPI security definition name.
         /// </summary>
-        public const string SecurityDefinitionName = "API Key";
+        public const string SecurityDefinitionName = "ApiKey";
 
         /// <summary>
         /// The OpenAPI security scheme name.

--- a/src/dotnet/Common/Constants/Swagger.cs
+++ b/src/dotnet/Common/Constants/Swagger.cs
@@ -1,0 +1,28 @@
+﻿namespace FoundationaLLM.Common.Constants
+{
+    /// <summary>
+    /// Common Swagger strings used throughout the FoundationaLLM infrastructure.
+    /// </summary>
+    public static class Swagger
+    {
+        /// <summary>
+        /// The OpenAPI security definition name.
+        /// </summary>
+        public const string SecurityDefinitionName = "API Key";
+
+        /// <summary>
+        /// The OpenAPI security scheme name.
+        /// </summary>
+        public const string SecuritySchemeName = "ApiKeyScheme";
+
+        /// <summary>
+        /// The OpenAPI security scheme description.
+        /// </summary>
+        public const string SecuritySchemeDescription = "API Key auth";
+
+        /// <summary>
+        /// The OpenAPI security scheme reference identifier.
+        /// </summary>
+        public const string SecuritySchemeReferenceId = "ApiKey";
+    }
+}

--- a/src/dotnet/Common/Extensions/SwaggerGenOptionsExtensions.cs
+++ b/src/dotnet/Common/Extensions/SwaggerGenOptionsExtensions.cs
@@ -1,0 +1,44 @@
+﻿using FoundationaLLM.Common.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace FoundationaLLM.Common.Extensions
+{
+    /// <summary>
+    /// Extends the SwaggerGenOptions with common options used by the FoundationaLLM APIs.
+    /// </summary>
+    public static class SwaggerGenOptionsExtensions
+    {
+        /// <summary>
+        /// Extension method that configures API Key auth for the APIs that use it.
+        /// </summary>
+        /// <param name="options">The base options.</param>
+        public static void AddAPIKeyAuth(this SwaggerGenOptions options)
+        {
+            options.AddSecurityDefinition(Swagger.SecurityDefinitionName, new OpenApiSecurityScheme
+            {
+                Name = HttpHeaders.APIKey,
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.ApiKey,
+                Description = Swagger.SecuritySchemeDescription,
+                Scheme = Swagger.SecuritySchemeName
+            });
+
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                {
+                    new OpenApiSecurityScheme()
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = Swagger.SecuritySchemeReferenceId
+                        },
+                        In = ParameterLocation.Header
+                    },
+                    new List<string>()
+                }
+            });
+        }
+    }
+}

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Azure.Identity;
 using FoundationaLLM.Common.Authentication;
 using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Extensions;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Middleware;
 using FoundationaLLM.Common.Models.Authentication;
@@ -114,29 +115,8 @@ namespace FoundationaLLM.Gatekeeper.API
                     // Integrate xml comments
                     options.IncludeXmlComments(filePath);
 
-                    options.AddSecurityDefinition(Swagger.SecurityDefinitionName, new OpenApiSecurityScheme
-                    {
-                        Name = HttpHeaders.APIKey,
-                        In = ParameterLocation.Header,
-                        Type = SecuritySchemeType.ApiKey,
-                        Description = Swagger.SecuritySchemeDescription,
-                        Scheme = Swagger.SecuritySchemeName
-                    });
-
-                    options.AddSecurityRequirement(new OpenApiSecurityRequirement {
-                        {
-                            new OpenApiSecurityScheme()
-                            {
-                                Reference = new OpenApiReference
-                                {
-                                    Type = ReferenceType.SecurityScheme,
-                                    Id = Swagger.SecuritySchemeReferenceId
-                                },
-                                In = ParameterLocation.Header
-                            },
-                            new List<string>()
-                        }
-                    });
+                    // Adds auth via X-API-KEY header
+                    options.AddAPIKeyAuth();
                 });
 
             var app = builder.Build();

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -13,6 +13,7 @@ using FoundationaLLM.Gatekeeper.Core.Models.ConfigurationOptions;
 using FoundationaLLM.Gatekeeper.Core.Services;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
 using Polly;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -112,6 +113,30 @@ namespace FoundationaLLM.Gatekeeper.API
 
                     // Integrate xml comments
                     options.IncludeXmlComments(filePath);
+
+                    options.AddSecurityDefinition(Swagger.SecurityDefinitionName, new OpenApiSecurityScheme
+                    {
+                        Name = HttpHeaders.APIKey,
+                        In = ParameterLocation.Header,
+                        Type = SecuritySchemeType.ApiKey,
+                        Description = Swagger.SecuritySchemeDescription,
+                        Scheme = Swagger.SecuritySchemeName
+                    });
+
+                    options.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                        {
+                            new OpenApiSecurityScheme()
+                            {
+                                Reference = new OpenApiReference
+                                {
+                                    Type = ReferenceType.SecurityScheme,
+                                    Id = Swagger.SecuritySchemeReferenceId
+                                },
+                                In = ParameterLocation.Header
+                            },
+                            new List<string>()
+                        }
+                    });
                 });
 
             var app = builder.Build();

--- a/src/dotnet/SemanticKernelAPI/Program.cs
+++ b/src/dotnet/SemanticKernelAPI/Program.cs
@@ -1,8 +1,9 @@
 using Azure.Identity;
 using FoundationaLLM.Common.Authentication;
+using FoundationaLLM.Common.Extensions;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration;
-using FoundationaLLM.Common.Services;
+using FoundationaLLM.Common.OpenAPI;
 using FoundationaLLM.SemanticKernel.Core.Interfaces;
 using FoundationaLLM.SemanticKernel.Core.Models.ConfigurationOptions;
 using FoundationaLLM.SemanticKernel.Core.Services;
@@ -42,7 +43,22 @@ namespace FoundationaLLM.SemanticKernel.API
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+
+            builder.Services.AddSwaggerGen(
+                options =>
+                {
+                    // Add a custom operation filter which sets default values
+                    options.OperationFilter<SwaggerDefaultValues>();
+
+                    var fileName = typeof(Program).Assembly.GetName().Name + ".xml";
+                    var filePath = Path.Combine(AppContext.BaseDirectory, fileName);
+
+                    // Integrate xml comments
+                    options.IncludeXmlComments(filePath);
+
+                    // Adds auth via X-API-KEY header
+                    options.AddAPIKeyAuth();
+                });
 
             builder.Services.AddOptions<SemanticKernelServiceSettings>()
                 .Bind(builder.Configuration.GetSection("FoundationaLLM:SemanticKernalAPI"));


### PR DESCRIPTION
# Add Authorize option to Swagger pages

## The issue or feature being addressed

The Swagger page is missing the "Authorize" option for Gatekeeper API, Agent Factory API, and Semantic Kernel API

## Details on the issue fix or feature implementation

Adds auth support to the Swagger pages of Gatekeeper API, Agent Factory API, and Semantic Kernel API

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build