### PR TITLE
Deactivate Cosmos Db change feeds

### DIFF
--- a/src/dotnet/Core/Services/CosmosDbService.cs
+++ b/src/dotnet/Core/Services/CosmosDbService.cs
@@ -94,7 +94,7 @@ namespace FoundationaLLM.Core.Services
             _leases = database?.GetContainer(_settings.ChangeFeedLeaseContainer)
                 ?? throw new ArgumentException($"Unable to connect to the {_settings.ChangeFeedLeaseContainer} container required to listen to the CosmosDB change feed.");
 
-            Task.Run(() => StartChangeFeedProcessors());
+            //Task.Run(() => StartChangeFeedProcessors());
             _logger.LogInformation("Cosmos DB service initialized.");
         }
 


### PR DESCRIPTION
# Deactivate Cosmos Db change feeds

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Cosmos Db change feed monitoring is not used currently.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build