### PR TITLE
Fixed token count on blob storage agent call

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/blob_storage_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/blob_storage_agent.py
@@ -79,12 +79,12 @@ class BlobStorageAgent(AgentBase):
             Returns a CompletionResponse with the generated summary, the user_prompt,
             and token utilization and execution cost details.
         """
-        try:
-            index = self.__get_vector_index()
-            query = self.prompt_prefix + build_message_history(self.message_history) + "Request: "+ prompt + "\n"            
-            completion = index.query(query, self.llm)
+        try:          
        
             with get_openai_callback() as cb:
+                index = self.__get_vector_index()
+                query = self.prompt_prefix + build_message_history(self.message_history) + "Request: "+ prompt + "\n"            
+                completion = index.query(query, self.llm)
                 return CompletionResponse(
                     completion = completion,
                     user_prompt = prompt,


### PR DESCRIPTION
# Fixed token count on blob storage agent call

## The issue or feature being addressed

The blob storage agent was not returning valid token usage counts on the responses. This PR fixes this issue.

## Details on the issue fix or feature implementation

Include token counts on response.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build