### PR TITLE
Add type to deployed AgentMetadata

### DIFF
--- a/deploy/data/agents/default.json
+++ b/deploy/data/agents/default.json
@@ -1,5 +1,6 @@
 {
 	"name": "default",
+	"type": "blob-storage",
 	"description": "Useful for answering questions from users.",
 	"allowed_data_source_names": [ "about-foundationallm" ],
 	"language_model": {


### PR DESCRIPTION
# Add type to deployed AgentMetadata

## The issue or feature being addressed

AgentMetadata introduced the type property in a recent PR. Need to introduce this to the deployed metadata file.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build