### PR TITLE
AgentHub - list implementation

### DIFF
--- a/src/python/AgentHubAPI/AgentHubAPI.pyproj
+++ b/src/python/AgentHubAPI/AgentHubAPI.pyproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="app\dependencies.py" />
     <Compile Include="app\main.py" />
+    <Compile Include="app\routers\list.py" />
     <Compile Include="app\routers\resolve.py" />
     <Compile Include="app\routers\status.py" />
     <Compile Include="app\routers\__init__.py" />

--- a/src/python/AgentHubAPI/app/main.py
+++ b/src/python/AgentHubAPI/app/main.py
@@ -1,6 +1,6 @@
 import uvicorn
 from fastapi import FastAPI
-from app.routers import resolve, status
+from app.routers import resolve, status, list
 
 app = FastAPI(
     title='FoundationaLLM AgentHubAPI',
@@ -22,6 +22,7 @@ app = FastAPI(
 )
 
 app.include_router(resolve.router)
+app.include_router(list.router)
 app.include_router(status.router)
 
 @app.get('/')

--- a/src/python/AgentHubAPI/app/routers/list.py
+++ b/src/python/AgentHubAPI/app/routers/list.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from app.dependencies import validate_api_key_header
+from foundationallm.hubs.agent import AgentHub
+from typing import List
+
+router = APIRouter(
+    prefix='/list',
+    tags=['list'],
+    dependencies=[Depends(validate_api_key_header)],
+    responses={404: {'description':'Not found'}},
+    redirect_slashes=False
+)
+
+@router.get('')
+async def list() -> List:    
+    return AgentHub().list()

--- a/src/python/PythonSDK/foundationallm/hubs/hub_base.py
+++ b/src/python/PythonSDK/foundationallm/hubs/hub_base.py
@@ -11,4 +11,7 @@ class HubBase(ABC):
         return self.resolver.resolve(request)
     
     def list(self):
+        """
+        Returns a lightweight list (containing of name and description) of all configured metadata items.
+        """
         return self.resolver.list()

--- a/src/python/PythonSDK/foundationallm/hubs/hub_base.py
+++ b/src/python/PythonSDK/foundationallm/hubs/hub_base.py
@@ -9,3 +9,6 @@ class HubBase(ABC):
 
     def resolve(self, request):        
         return self.resolver.resolve(request)
+    
+    def list(self):
+        return self.resolver.list()

--- a/src/python/PythonSDK/foundationallm/hubs/resolver.py
+++ b/src/python/PythonSDK/foundationallm/hubs/resolver.py
@@ -8,7 +8,13 @@ class Resolver(ABC):
     
     def __init__(self, repository: Repository):
         self.repository = repository
-
+        
+    def list(self) -> List:
+        all_values = self.repository.get_metadata_values()
+        light_weight_list = [{"name":x.name, "description": x.description} for x in all_values]
+        return light_weight_list
+    
     @abstractmethod
     def resolve(self, request) -> List[Metadata]:
         pass
+    

--- a/src/python/PythonSDK/foundationallm/hubs/resolver.py
+++ b/src/python/PythonSDK/foundationallm/hubs/resolver.py
@@ -10,6 +10,9 @@ class Resolver(ABC):
         self.repository = repository
         
     def list(self) -> List:
+        """
+        Returns a lightweight list (containing of name and description) of all configured metadata items.
+        """
         all_values = self.repository.get_metadata_values()
         light_weight_list = [{"name":x.name, "description": x.description} for x in all_values]
         return light_weight_list

--- a/tests/python/PythonSDK.Tests/PythonSDK.Tests.pyproj
+++ b/tests/python/PythonSDK.Tests/PythonSDK.Tests.pyproj
@@ -24,6 +24,8 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="hubs\agent\agent_hub_tests.py" />
+    <Compile Include="hubs\agent\agent_resolver_tests.py" />
     <Compile Include="langchain\message_history\message_history_tests.py" />
     <Compile Include="pytest.ini" />
   </ItemGroup>
@@ -38,6 +40,8 @@
     <Content Include="requirements.txt" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="hubs\" />
+    <Folder Include="hubs\agent\" />
     <Folder Include="langchain\" />
     <Folder Include="langchain\message_history\" />
   </ItemGroup>

--- a/tests/python/PythonSDK.Tests/hubs/agent/agent_hub_tests.py
+++ b/tests/python/PythonSDK.Tests/hubs/agent/agent_hub_tests.py
@@ -18,11 +18,18 @@ class AgentHubTests:
     def test_list_method_returns_at_least_one_lightweight_agent(self, agent_hub):
         """
         The lightweight agent consists of a dictionary containing the name and description of the agent ONLY.
+        
+        While this test is using the AgentHub as the system under test, it is in fact testing the
+        HubBase ABC class where the generic list method is implemented.
         """
         agents_list = agent_hub.list()
         assert len(agents_list) > 0
         
     def test_list_method_contains_default_agent_name(self, agent_hub):
+        """
+        While this test is using the AgentHub as the system under test, it is in fact testing the
+        HubBase ABC class where the generic list method is implemented.
+        """
         agent_name_list = [x["name"] for x in agent_hub.list()]
         assert "default" in agent_name_list
         

--- a/tests/python/PythonSDK.Tests/hubs/agent/agent_hub_tests.py
+++ b/tests/python/PythonSDK.Tests/hubs/agent/agent_hub_tests.py
@@ -1,0 +1,28 @@
+import pytest
+from foundationallm.hubs.agent import AgentHub
+
+@pytest.fixture
+def agent_hub():
+    return AgentHub()
+    
+class AgentHubTests:
+    """
+    AgentHubTests is responsible for testing the listing of agents or selection of the best-fit
+        agent to respond to a user prompt with the AgentHub acting as the system under test.
+        
+    This is an integration test class and expects the following environment variable to be set:
+        foundationallm-app-configuration-uri
+        
+    This test class also expects a valid Azure credential (DefaultAzureCredential) session.
+    """
+    def test_list_method_returns_at_least_one_lightweight_agent(self, agent_hub):
+        """
+        The lightweight agent consists of a dictionary containing the name and description of the agent ONLY.
+        """
+        agents_list = agent_hub.list()
+        assert len(agents_list) > 0
+        
+    def test_list_method_contains_default_agent_name(self, agent_hub):
+        agent_name_list = [x["name"] for x in agent_hub.list()]
+        assert "default" in agent_name_list
+        

--- a/tests/python/PythonSDK.Tests/hubs/agent/agent_resolver_tests.py
+++ b/tests/python/PythonSDK.Tests/hubs/agent/agent_resolver_tests.py
@@ -1,0 +1,39 @@
+from numpy import isin
+import pytest
+from typing import List
+from foundationallm.config import Configuration
+from foundationallm.hubs.agent import AgentRepository, AgentResolver
+
+@pytest.fixture
+def test_config():
+    return Configuration()
+
+@pytest.fixture
+def agent_repository(test_config):
+    return AgentRepository(config=test_config)
+
+@pytest.fixture
+def agent_resolver(agent_repository):
+    return AgentResolver(repository=agent_repository)
+    
+class AgentResolverTests:
+    """
+    AgentResolverTests is responsible for testing the listing of agents or selection of the best-fit
+        agent to respond to a user prompt.
+        
+    This is an integration test class and expects the following environment variable to be set:
+        foundationallm-app-configuration-uri
+        
+    This test class also expects a valid Azure credential (DefaultAzureCredential) session.
+    """
+    def test_list_method_returns_at_least_one_lightweight_agent(self, agent_resolver):
+        """
+        The lightweight agent consists of a dictionary containing the name and description of the agent ONLY.
+        """
+        agents_list = agent_resolver.list() 
+        assert len(agents_list) > 0
+        
+    def test_list_method_contains_default_agent_name(self, agent_resolver):
+        agent_name_list = [x["name"] for x in agent_resolver.list()]
+        assert "default" in agent_name_list
+        

--- a/tests/python/PythonSDK.Tests/hubs/agent/agent_resolver_tests.py
+++ b/tests/python/PythonSDK.Tests/hubs/agent/agent_resolver_tests.py
@@ -19,7 +19,7 @@ def agent_resolver(agent_repository):
 class AgentResolverTests:
     """
     AgentResolverTests is responsible for testing the listing of agents or selection of the best-fit
-        agent to respond to a user prompt.
+        agent to respond to a user prompt using the AgentResolver as the system under test.
         
     This is an integration test class and expects the following environment variable to be set:
         foundationallm-app-configuration-uri
@@ -29,11 +29,18 @@ class AgentResolverTests:
     def test_list_method_returns_at_least_one_lightweight_agent(self, agent_resolver):
         """
         The lightweight agent consists of a dictionary containing the name and description of the agent ONLY.
+        
+        While this test is using the AgentResolver as the system under test, it is in fact testing the
+        Resolver ABC class where the generic list method is implemented.
         """
         agents_list = agent_resolver.list() 
         assert len(agents_list) > 0
         
     def test_list_method_contains_default_agent_name(self, agent_resolver):
+        """
+        While this test is using the AgentResolver as the system under test, it is in fact testing the
+        Resolver ABC class where the generic list method is implemented.
+        """
         agent_name_list = [x["name"] for x in agent_resolver.list()]
         assert "default" in agent_name_list
         


### PR DESCRIPTION
# AgentHub - list implementation

## The issue or feature being addressed

The UI will require a list of available agents to select from. This PR introduces a /list GET request on the AgentHub API that returns a lightweight list of agents configured (the ones in the agents storage account). The lightweight object returns only the name and description properties of each agent.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build