### PR TITLE
Cleanup user context references in Agent Factory

### DIFF
--- a/src/dotnet/AgentFactory/Agents/AgentBase.cs
+++ b/src/dotnet/AgentFactory/Agents/AgentBase.cs
@@ -63,9 +63,8 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
         /// This will setup the agent based on its metadata
         /// </summary>
         /// <param name="userPrompt"></param>
-        /// <param name="userContext"></param>
         /// <returns></returns>
-        public virtual async Task Configure(string userPrompt, string userContext)
+        public virtual async Task Configure(string userPrompt)
         {
             await Task.CompletedTask;
         }

--- a/src/dotnet/AgentFactory/Agents/AgentBuilder.cs
+++ b/src/dotnet/AgentFactory/Agents/AgentBuilder.cs
@@ -13,7 +13,6 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
         /// Used to build an agenet given the inbound parameters.
         /// </summary>
         /// <param name="userPrompt"></param>
-        /// <param name="userContext"></param>
         /// <param name="agentHubAPIService"></param>
         /// <param name="orchestrationServices"></param>
         /// <param name="promptHubAPIService"></param>
@@ -22,13 +21,12 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
         /// <exception cref="ArgumentException"></exception>
         public static async Task<AgentBase> Build(
             string userPrompt,
-            string userContext,
             IAgentHubAPIService agentHubAPIService,
             IEnumerable<ILLMOrchestrationService> orchestrationServices,
             IPromptHubAPIService promptHubAPIService,
             IDataSourceHubAPIService dataSourceHubAPIService)
         {
-            var agentResponse = await agentHubAPIService.ResolveRequest(userPrompt, userContext);
+            var agentResponse = await agentHubAPIService.ResolveRequest(userPrompt);
             var agentInfo = agentResponse.Agent;
 
             // TODO: Extend the Agent Hub API service response to include the orchestrator
@@ -45,7 +43,7 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
             AgentBase? agent = null;
             agent = new DefaultAgent(agentInfo!, orchestrationService, promptHubAPIService, dataSourceHubAPIService);           
 
-            await agent.Configure(userPrompt, userContext);
+            await agent.Configure(userPrompt);
 
             return agent;
         }

--- a/src/dotnet/AgentFactory/Agents/DefaultAgent.cs
+++ b/src/dotnet/AgentFactory/Agents/DefaultAgent.cs
@@ -38,13 +38,13 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
         /// <param name="userContext"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public async override Task Configure(string userPrompt, string userContext)
+        public async override Task Configure(string userPrompt)
         {
             //get prompts for the agent from the prompt hub
-            var promptResponse = await _promptHubService.ResolveRequest(_agentMetadata.Name!, userContext);
+            var promptResponse = await _promptHubService.ResolveRequest(_agentMetadata.Name!);
 
             //get data sources listed for the agent           
-            var dataSourceResponse = await _dataSourceHubService.ResolveRequest(_agentMetadata.AllowedDataSourceNames!, userContext);
+            var dataSourceResponse = await _dataSourceHubService.ResolveRequest(_agentMetadata.AllowedDataSourceNames!);
 
             MetadataBase dataSourceMetadata = null!;
 

--- a/src/dotnet/AgentFactory/Interfaces/IAgentHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Interfaces/IAgentHubAPIService.cs
@@ -18,7 +18,6 @@ public interface IAgentHubAPIService
     /// Calls the target Agent Hub and resolves a user prompt with the user's context
     /// </summary>
     /// <param name="userPrompt"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    Task<AgentHubResponse> ResolveRequest(string userPrompt, string userContext);
+    Task<AgentHubResponse> ResolveRequest(string userPrompt);
 }

--- a/src/dotnet/AgentFactory/Interfaces/IDataSourceHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Interfaces/IDataSourceHubAPIService.cs
@@ -16,7 +16,6 @@ public interface IDataSourceHubAPIService
     /// Calls the target DataSource Hub to retrieve a list of data sources.  Input will typically come from the AgentHub response.
     /// </summary>
     /// <param name="sources"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    Task<DataSourceHubResponse> ResolveRequest(List<string> sources, string userContext);
+    Task<DataSourceHubResponse> ResolveRequest(List<string> sources);
 }

--- a/src/dotnet/AgentFactory/Interfaces/IPromptHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Interfaces/IPromptHubAPIService.cs
@@ -18,7 +18,6 @@ public interface IPromptHubAPIService
     /// Gets an agent based on its name.  Passes the userContext such that the prompt is built with any user based attributes.
     /// </summary>
     /// <param name="agentName"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    Task<PromptHubResponse> ResolveRequest(string agentName, string userContext);
+    Task<PromptHubResponse> ResolveRequest(string agentName);
 }

--- a/src/dotnet/AgentFactory/Services/AgentFactoryService.cs
+++ b/src/dotnet/AgentFactory/Services/AgentFactoryService.cs
@@ -23,12 +23,10 @@ public class AgentFactoryService : IAgentFactoryService
 {
     private readonly IEnumerable<ILLMOrchestrationService> _orchestrationServices;
     private readonly IAgentHubAPIService _agentHubAPIService;
-    private readonly AgentFactorySettings _agentFactorySettings;
     private readonly IPromptHubAPIService _promptHubAPIService;
     private readonly IDataSourceHubAPIService _dataSourceHubAPIService;
 
     private readonly ILogger<AgentFactoryService> _logger;
-    private readonly IUserIdentityContext _userIdentity;
 
 
     //private LLMOrchestrationService _llmOrchestrationService = LLMOrchestrationService.LangChain;
@@ -45,27 +43,17 @@ public class AgentFactoryService : IAgentFactoryService
     /// <param name="userIdentity"></param>
     public AgentFactoryService(
         IEnumerable<ILLMOrchestrationService> orchestrationServices,
-
-        IOptions<AgentFactorySettings> agentFactorySettings,
-
         IAgentHubAPIService agentHubService,
         IPromptHubAPIService promptHubService,
         IDataSourceHubAPIService dataSourceHubService,
-
-        ILogger<AgentFactoryService> logger,
-        IUserIdentityContext userIdentity)
+        ILogger<AgentFactoryService> logger)
     {
         _orchestrationServices = orchestrationServices;
-
-        _agentFactorySettings = agentFactorySettings.Value;
-
         _agentHubAPIService = agentHubService;
         _promptHubAPIService = promptHubService;
         _dataSourceHubAPIService = dataSourceHubService;
 
         _logger = logger;
-        _userIdentity = userIdentity;
-
     }
 
     /// <summary>
@@ -94,7 +82,6 @@ public class AgentFactoryService : IAgentFactoryService
         {
             var agent = await AgentBuilder.Build(
                 completionRequest.UserPrompt,
-                _userIdentity.CurrentUserIdentity.UPN,
                 _agentHubAPIService,
                 _orchestrationServices,
                 _promptHubAPIService,
@@ -125,7 +112,6 @@ public class AgentFactoryService : IAgentFactoryService
         {
             var agent = await AgentBuilder.Build(
                 summaryRequest.UserPrompt,
-                _userIdentity.CurrentUserIdentity.UPN,
                 _agentHubAPIService,
                 _orchestrationServices,
                 _promptHubAPIService,

--- a/src/dotnet/AgentFactory/Services/AgentHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Services/AgentHubAPIService.cs
@@ -77,9 +77,8 @@ public class AgentHubAPIService : IAgentHubAPIService
     /// Gets a set of agents from the Agent Hub based on the prompt and user context.
     /// </summary>
     /// <param name="userPrompt"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    public async Task<AgentHubResponse> ResolveRequest(string userPrompt, string userContext)
+    public async Task<AgentHubResponse> ResolveRequest(string userPrompt)
     {
         try
         {

--- a/src/dotnet/AgentFactory/Services/DataHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Services/DataHubAPIService.cs
@@ -69,9 +69,8 @@ public class DataSourceHubAPIService : IDataSourceHubAPIService
     /// Gets a list of DataSources from the DataSource Hub
     /// </summary>
     /// <param name="sources"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    public async Task<DataSourceHubResponse> ResolveRequest(List<string> sources, string userContext)
+    public async Task<DataSourceHubResponse> ResolveRequest(List<string> sources)
     {
         try
         {

--- a/src/dotnet/AgentFactory/Services/PromptHubAPIService.cs
+++ b/src/dotnet/AgentFactory/Services/PromptHubAPIService.cs
@@ -69,9 +69,8 @@ public class PromptHubAPIService : IPromptHubAPIService
     /// Used to get prompts for a target agent and user context.
     /// </summary>
     /// <param name="agentName"></param>
-    /// <param name="userContext"></param>
     /// <returns></returns>
-    public async Task<PromptHubResponse> ResolveRequest(string agentName, string userContext)
+    public async Task<PromptHubResponse> ResolveRequest(string agentName)
     {
         try
         {


### PR DESCRIPTION
# Cleanup user context references in Agent Factory

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

Removes unnecessary user context handling within the Agent Factory class and related API.

## Details on the issue fix or feature implementation

The user context needs to flow down the request chain via the `X-USER-CONTEXT` header to the downstream Hub APIs. Passing the context any other way is incorrect.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build