### PR TITLE
Fix Dockerfile for ACA builds

### DIFF
--- a/src/ui/UserPortal/Dockerfile
+++ b/src/ui/UserPortal/Dockerfile
@@ -13,10 +13,10 @@ WORKDIR /src
 # Build
 FROM base as build
 
-COPY --link package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm install --production=false
 
-COPY --link . .
+COPY . .
 
 RUN npm run build
 RUN npm prune


### PR DESCRIPTION
# Fix Dockerfile for ACA builds

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes `Error response from daemon: dockerfile parse error line 16: Unknown flag: link` that occurs during an ACR build.

## Details on the issue fix or feature implementation

Remove the `--link` flag since ACA apparently does not have BuildKit enabled. The `--link` flag is used for enabling symlink support during the copy operation, but we don't require it for a successful build.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build