### PR TITLE
Update Core API CORS settings to allow X-AGENT-HINT header

### DIFF
--- a/deploy/helm/core-api/values.yaml
+++ b/deploy/helm/core-api/values.yaml
@@ -33,9 +33,9 @@ ingress:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/enable-cors:            "true"
     nginx.ingress.kubernetes.io/secure-backends:        "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin:     "*"
+    nginx.ingress.kubernetes.io/cors-allow-origin:      "*"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers:     "*"
+    nginx.ingress.kubernetes.io/cors-allow-headers:     "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-AGENT-HINT"
     nginx.ingress.kubernetes.io/cors-allow-methods:     "*"
   tls:
   - secretName: tls-prod

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -63,7 +63,7 @@ namespace FoundationaLLM.Core.API
                     policy =>
                     {
                         policy.AllowAnyOrigin();
-                        policy.AllowAnyHeader();
+                        policy.WithHeaders("DNT", "Keep-Alive", "User-Agent", "X-Requested-With", "If-Modified-Since", "Cache-Control", "Content-Type", "Range", "Authorization", "X-AGENT-HINT");
                         policy.AllowAnyMethod();
                     });
             });
@@ -133,6 +133,9 @@ namespace FoundationaLLM.Core.API
 
             var app = builder.Build();
 
+            // Set the CORS policy before other middleware.
+            app.UseCors(allowAllCorsOrigins);
+
             // For the CoreAPI, we need to make sure that UseAuthentication is called before the UserIdentityMiddleware.
             app.UseAuthentication();
             app.UseAuthorization();
@@ -162,8 +165,6 @@ namespace FoundationaLLM.Core.API
 
             app.UseHttpsRedirection();
             app.MapControllers();
-
-            app.UseCors(allowAllCorsOrigins);
 
             app.Run();
         }


### PR DESCRIPTION
# Update Core API CORS settings to allow X-AGENT-HINT header

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

The overly permissive wildcard setting for the CORS `Access-Control-Allow-Headers` still blocked sending our custom `X-AGENT-HINT` header from the Nuxt SPA User Portal app.

## Details on the issue fix or feature implementation

Explicitly set the CORS `Access-Control-Allow-Headers` to add `X-AGENT-HINT` and other required headers for the ingress controller. Also set the same headers settings in the Core API CORS settings within the application and properly reorder the CORS middleware order to the head of the call stack. This ensures local testing works as expected.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build