### PR TITLE
Force HTTPS Redirect override on AgentFactoryAPI and GatekeeperAPI

### DIFF
--- a/docs/deployment/app-configuration-values.md
+++ b/docs/deployment/app-configuration-values.md
@@ -11,6 +11,7 @@ FoundationaLLM uses Azure App Configuration to store configuration values, Key V
 | `FoundationaLLM:APIs:AgentFactoryAPI:APIKey` | Key Vault secret name: `foundationallm-apis-agentfactoryapi-apikey` | This is a Key Vault reference. |
 | `FoundationaLLM:APIs:AgentFactoryAPI:APIUrl` | Enter the URL to the service. |   |
 | `FoundationaLLM:APIs:AgentFactoryAPI:AppInsightsConnectionString` | Key Vault secret name: `foundationallm-app-insights-connection-string` | This is a Key Vault reference. |
+| `FoundationaLLM:APIs:AgentFactoryAPI:ForceHttpsRedirection` | true | By default, the Agent Factory API forces HTTPS redirection. To override this behavior and allow it to handle HTTP requests, set this value to false. |
 | `FoundationaLLM:APIs:AgentHubAPI:APIKey` | Key Vault secret name: `foundationallm-apis-agenthubapi-apikey` | This is a Key Vault reference. |
 | `FoundationaLLM:APIs:AgentHubAPI:APIUrl` | Enter the URL to the service. |   |
 | `FoundationaLLM:APIs:CoreAPI:APIUrl` | Enter the URL to the service. |   |
@@ -20,6 +21,7 @@ FoundationaLLM uses Azure App Configuration to store configuration values, Key V
 | `FoundationaLLM:APIs:GatekeeperAPI:APIKey` | Key Vault secret name: `foundationallm-apis-gatekeeperapi-apikey` | This is a Key Vault reference. |
 | `FoundationaLLM:APIs:GatekeeperAPI:APIUrl` | Enter the URL to the service. |   |
 | `FoundationaLLM:APIs:GatekeeperAPI:AppInsightsConnectionString` | Key Vault secret name: `foundationallm-app-insights-connection-string` | This is a Key Vault reference. |
+| `FoundationaLLM:APIs:GatekeeperAPI:ForceHttpsRedirection` | true | By default, the Gatekeeper API forces HTTPS redirection. To override this behavior and allow it to handle HTTP requests, set this value to false. |
 | `FoundationaLLM:APIs:LangChainAPI:APIKey` | Key Vault secret name: `foundationallm-apis-langchainapi-apikey` | This is a Key Vault reference. |
 | `FoundationaLLM:APIs:LangChainAPI:APIUrl` | Enter the URL to the service. |   |
 | `FoundationaLLM:APIs:PromptHubAPI:APIKey` | Key Vault secret name: `foundationallm-apis-prompthubapi-apikey` | This is a Key Vault reference. |

--- a/src/dotnet/AgentFactoryAPI/Program.cs
+++ b/src/dotnet/AgentFactoryAPI/Program.cs
@@ -166,7 +166,11 @@ namespace FoundationaLLM.AgentFactory.API
                     }
                 });
 
-            app.UseHttpsRedirection();
+            bool.TryParse(builder.Configuration[$"FoundationaLLM:APIs:{HttpClients.AgentFactoryAPI}:ForceHttpsRedirection"], out var forceHttpsRedirection);
+            if (forceHttpsRedirection)
+            {
+                app.UseHttpsRedirection();
+            }
             app.UseAuthorization();
             app.MapControllers();
 

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -151,7 +151,11 @@ namespace FoundationaLLM.Gatekeeper.API
                     }
                 });
 
-            app.UseHttpsRedirection();
+            bool.TryParse(builder.Configuration[$"FoundationaLLM:APIs:{HttpClients.GatekeeperAPI}:ForceHttpsRedirection"], out var forceHttpsRedirection);
+            if (forceHttpsRedirection)
+            {
+                app.UseHttpsRedirection();
+            }
             app.UseAuthorization();
 
             app.MapControllers();


### PR DESCRIPTION
# Force HTTPS Redirect override on AgentFactoryAPI and GatekeeperAPI

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

The `AgentFactoryAPI` and `GatekeeperAPI` force an HTTPS redirect by default. This PR allows us to override this redirect by configuration.

## Details on the issue fix or feature implementation

Added two new App Configuration settings to enable overriding an HTTPS redirect on these two APIs. Updated the App Configuration documentation with the two new configuration settings.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build