### PR TITLE
Populate chat Message display names

### DIFF
--- a/src/dotnet/Common/Models/Chat/Message.cs
+++ b/src/dotnet/Common/Models/Chat/Message.cs
@@ -33,6 +33,11 @@ public record Message
     [SimpleField]
     public string Sender { get; set; }
     /// <summary>
+    /// The display name of the message sender. This could be the name of the signed in user or the name of the agent.
+    /// </summary>
+    [SimpleField]
+    public string? SenderDisplayName { get; set; }
+    /// <summary>
     /// The number of tokens associated with the message, if any.
     /// </summary>
     [SimpleField]
@@ -60,12 +65,14 @@ public record Message
     /// <summary>
     /// Constructor for Message.
     /// </summary>
-    public Message(string sessionId, string sender, int? tokens, string text, float[]? vector, bool? rating)
+    public Message(string sessionId, string sender, int? tokens, string text,
+        float[]? vector, bool? rating, string? senderDisplayName = null)
     {
         Id = Guid.NewGuid().ToString();
         Type = nameof(Message);
         SessionId = sessionId;
         Sender = sender;
+        SenderDisplayName = senderDisplayName;
         Tokens = tokens ?? 0;
         TimeStamp = DateTime.UtcNow;
         Text = text;

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -1,4 +1,5 @@
 ﻿using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Common.Models.Chat;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,7 @@ public class CoreService : ICoreService
     private readonly ICosmosDbService _cosmosDbService;
     private readonly IGatekeeperAPIService _gatekeeperAPIService;
     private readonly ILogger<CoreService> _logger;
+    private readonly ICallContext _callContext;
     private readonly string _sessionType;
 
     /// <summary>
@@ -47,16 +49,19 @@ public class CoreService : ICoreService
     /// <see cref="CoreService"/> type name.</param>
     /// <param name="settings">The <see cref="ClientBrandingConfiguration"/>
     /// settings retrieved by the injected <see cref="IOptions{TOptions}"/>.</param>
+    /// <param name="callContext">Contains contextual data for the calling service.</param>
     public CoreService(
         ICosmosDbService cosmosDbService,
         IGatekeeperAPIService gatekeeperAPIService,
         ILogger<CoreService> logger,
-        IOptions<ClientBrandingConfiguration> settings)
+        IOptions<ClientBrandingConfiguration> settings,
+        ICallContext callContext)
     {
         _cosmosDbService = cosmosDbService;
         _gatekeeperAPIService = gatekeeperAPIService;
         _logger = logger;
         _sessionType = settings.Value.KioskMode ? SessionTypes.KioskSession : SessionTypes.Session;
+        _callContext = callContext;
     }
 
     /// <summary>
@@ -135,8 +140,8 @@ public class CoreService : ICoreService
             var result = await _gatekeeperAPIService.GetCompletion(completionRequest);
 
             // Add to prompt and completion to cache, then persist in Cosmos as transaction.
-            var promptMessage = new Message(sessionId, nameof(Participants.User), result.PromptTokens, userPrompt, result.UserPromptEmbedding, null);
-            var completionMessage = new Message(sessionId, nameof(Participants.Assistant), result.CompletionTokens, result.Completion, null, null);
+            var promptMessage = new Message(sessionId, nameof(Participants.User), result.PromptTokens, userPrompt, result.UserPromptEmbedding, null, _callContext.CurrentUserIdentity?.Name);
+            var completionMessage = new Message(sessionId, nameof(Participants.Assistant), result.CompletionTokens, result.Completion, null, null, result.AgentName);
             var completionPromptText =
                 $"User prompt: {result.UserPrompt}{Environment.NewLine}Agent: {result.AgentName}{Environment.NewLine}Prompt template: {result.PromptTemplate}";
             var completionPrompt = new CompletionPrompt(sessionId, completionMessage.Id, completionPromptText);

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -8,7 +8,7 @@
 				<!-- Sender -->
 				<span class="header__sender">
 					<img v-if="message.sender !== 'User'" class="avatar" src="~/assets/FLLM-Agent-Light.svg">
-					<span>{{ message.sender }}</span>
+					<span>{{ getDisplayName() }}</span>
 				</span>
 
 				<!-- Tokens & Timestamp -->
@@ -142,6 +142,14 @@ export default {
 			};
 
 			displayNextWord();
+		},
+
+		getDisplayName() {
+			if (this.message.senderDisplayName) {
+				return this.message.sender === 'User' ? this.message.senderDisplayName : `${this.message.sender} - ${this.message.senderDisplayName}`;
+			}
+			
+			return this.message.sender;
 		},
 
 		handleRate(message: Message, isLiked: boolean) {

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -4,6 +4,7 @@ export interface Message {
 	sessionId: string;
 	timeStamp: string;
 	sender: 'User' | 'Assistant';
+	senderDisplayName: string | null;
 	tokens: number;
 	text: string;
 	rating: boolean | null;


### PR DESCRIPTION
# Populate chat Message display names

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Stores and displays the authenticated user's name for user messages and appends the resolved agent name for assistant messages.

![image](https://github.com/solliancenet/foundationallm/assets/5950304/baff9e93-b125-418f-973b-0422191c92d3)


## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build