### PR TITLE
Remove Cosmos DB service allocation from status controller

### DIFF
--- a/src/dotnet/CoreAPI/Controllers/StatusController.cs
+++ b/src/dotnet/CoreAPI/Controllers/StatusController.cs
@@ -16,29 +16,13 @@ namespace FoundationaLLM.Core.API.Controllers
     [Route("[controller]")]
     public class StatusController : ControllerBase
     {
-        private readonly ICoreService _coreService;
-        private readonly ILogger<StatusController> _logger;
-
-        /// <summary>
-        /// Constructor for the Status Controller.
-        /// </summary>
-        /// <param name="coreService">The Core service provides status methods.</param>
-        /// <param name="logger">The logging interface used to log under the
-        /// <see cref="StatusController"/> type name.</param>
-        public StatusController(ICoreService coreService,
-            ILogger<StatusController> logger)
-        {
-            _coreService = coreService;
-            _logger = logger;
-        }
-
         /// <summary>
         /// Returns the status of the Core service.
         /// </summary>
         [HttpGet(Name = "GetServiceStatus")]
-        public string Get()
+        public IActionResult Get()
         {
-            return _coreService.Status;
+            return Ok();
         }
 
         /// <summary>


### PR DESCRIPTION
# Remove Cosmos DB service allocation from status controller

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes excess allocations of the Cosmos DB service when upstream services execute the status check endpoint on the CoreAPI service.

## Details on the issue fix or feature implementation

Remove Cosmos DB service DI. Refactor the `Get` endpoint to return a simple 200 response, which is all the health check service requires.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build