### PR TITLE
Sort chat sessions by date in descending order

### DIFF
--- a/src/dotnet/Core/Services/CosmosDbService.cs
+++ b/src/dotnet/Core/Services/CosmosDbService.cs
@@ -222,7 +222,7 @@ namespace FoundationaLLM.Core.Services
         /// <returns>List of distinct chat session items.</returns>
         public async Task<List<Session>> GetSessionsAsync(string type)
         {
-            var query = new QueryDefinition("SELECT DISTINCT * FROM c WHERE c.type = @type")
+            var query = new QueryDefinition("SELECT DISTINCT * FROM c WHERE c.type = @type ORDER BY c._ts DESC")
                 .WithParameter("@type", type);
 
             var response = _completions.GetItemQueryIterator<Session>(query);


### PR DESCRIPTION
# Sort chat sessions by date in descending order

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes chat sessions are always sorted by date in ascending order.

## Details on the issue fix or feature implementation

Future change will provide sort options on the left-hand chat menu.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build