### PR TITLE
Add a StatusController for all dotnet APIs

### DIFF
--- a/src/dotnet/AgentFactoryAPI/Controllers/StatusController.cs
+++ b/src/dotnet/AgentFactoryAPI/Controllers/StatusController.cs
@@ -12,7 +12,7 @@ namespace FoundationaLLM.AgentFactory.API.Controllers
     public class StatusController : ControllerBase
     {
         /// <summary>
-        /// Returns the status of the Core service.
+        /// Returns the status of the Agent Factory API service.
         /// </summary>
         [HttpGet(Name = "GetServiceStatus")]
         public IActionResult Get()
@@ -21,7 +21,7 @@ namespace FoundationaLLM.AgentFactory.API.Controllers
         }
 
         /// <summary>
-        /// Returns the allowed HTTP methods for the Core service.
+        /// Returns the allowed HTTP methods for the Agent Factory API service.
         /// </summary>
         [HttpOptions]
         public IActionResult Options()

--- a/src/dotnet/AgentFactoryAPI/Controllers/StatusController.cs
+++ b/src/dotnet/AgentFactoryAPI/Controllers/StatusController.cs
@@ -1,7 +1,7 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace FoundationaLLM.Core.API.Controllers
+namespace FoundationaLLM.AgentFactory.API.Controllers
 {
     /// <summary>
     /// Provides methods for checking the status of the service.
@@ -27,7 +27,7 @@ namespace FoundationaLLM.Core.API.Controllers
         public IActionResult Options()
         {
             HttpContext.Response.Headers.Add("Allow", new[] { "GET", "POST", "OPTIONS" });
-            
+
             return Ok();
         }
     }

--- a/src/dotnet/CoreAPI/Controllers/StatusController.cs
+++ b/src/dotnet/CoreAPI/Controllers/StatusController.cs
@@ -12,7 +12,7 @@ namespace FoundationaLLM.Core.API.Controllers
     public class StatusController : ControllerBase
     {
         /// <summary>
-        /// Returns the status of the Core service.
+        /// Returns the status of the Core API service.
         /// </summary>
         [HttpGet(Name = "GetServiceStatus")]
         public IActionResult Get()
@@ -21,7 +21,7 @@ namespace FoundationaLLM.Core.API.Controllers
         }
 
         /// <summary>
-        /// Returns the allowed HTTP methods for the Core service.
+        /// Returns the allowed HTTP methods for the Core API service.
         /// </summary>
         [HttpOptions]
         public IActionResult Options()

--- a/src/dotnet/GatekeeperAPI/Controllers/StatusController.cs
+++ b/src/dotnet/GatekeeperAPI/Controllers/StatusController.cs
@@ -1,7 +1,7 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace FoundationaLLM.Core.API.Controllers
+namespace FoundationaLLM.Gatekeeper.API.Controllers
 {
     /// <summary>
     /// Provides methods for checking the status of the service.
@@ -27,7 +27,7 @@ namespace FoundationaLLM.Core.API.Controllers
         public IActionResult Options()
         {
             HttpContext.Response.Headers.Add("Allow", new[] { "GET", "POST", "OPTIONS" });
-            
+
             return Ok();
         }
     }

--- a/src/dotnet/GatekeeperAPI/Controllers/StatusController.cs
+++ b/src/dotnet/GatekeeperAPI/Controllers/StatusController.cs
@@ -12,7 +12,7 @@ namespace FoundationaLLM.Gatekeeper.API.Controllers
     public class StatusController : ControllerBase
     {
         /// <summary>
-        /// Returns the status of the Core service.
+        /// Returns the status of the Gatekeeper API service.
         /// </summary>
         [HttpGet(Name = "GetServiceStatus")]
         public IActionResult Get()
@@ -21,7 +21,7 @@ namespace FoundationaLLM.Gatekeeper.API.Controllers
         }
 
         /// <summary>
-        /// Returns the allowed HTTP methods for the Core service.
+        /// Returns the allowed HTTP methods for the Gatekeeper API service.
         /// </summary>
         [HttpOptions]
         public IActionResult Options()

--- a/src/dotnet/SemanticKernelAPI/Controllers/StatusController.cs
+++ b/src/dotnet/SemanticKernelAPI/Controllers/StatusController.cs
@@ -1,7 +1,7 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace FoundationaLLM.Core.API.Controllers
+namespace FoundationaLLM.SemanticKernel.API.Controllers
 {
     /// <summary>
     /// Provides methods for checking the status of the service.
@@ -27,7 +27,7 @@ namespace FoundationaLLM.Core.API.Controllers
         public IActionResult Options()
         {
             HttpContext.Response.Headers.Add("Allow", new[] { "GET", "POST", "OPTIONS" });
-            
+
             return Ok();
         }
     }

--- a/src/dotnet/SemanticKernelAPI/Controllers/StatusController.cs
+++ b/src/dotnet/SemanticKernelAPI/Controllers/StatusController.cs
@@ -12,7 +12,7 @@ namespace FoundationaLLM.SemanticKernel.API.Controllers
     public class StatusController : ControllerBase
     {
         /// <summary>
-        /// Returns the status of the Core service.
+        /// Returns the status of the Semantic Kernel API service.
         /// </summary>
         [HttpGet(Name = "GetServiceStatus")]
         public IActionResult Get()
@@ -21,12 +21,12 @@ namespace FoundationaLLM.SemanticKernel.API.Controllers
         }
 
         /// <summary>
-        /// Returns the allowed HTTP methods for the Core service.
+        /// Returns the allowed HTTP methods for the Semantic Kernel API service.
         /// </summary>
         [HttpOptions]
         public IActionResult Options()
         {
-            HttpContext.Response.Headers.Add("Allow", new[] { "GET", "POST", "OPTIONS" });
+            HttpContext.Response.Headers.Add("Allow", new[] { "GET", "POST", "OPTIONS", "DELETE" });
 
             return Ok();
         }


### PR DESCRIPTION
# Add a StatusController for all dotnet APIs

## The issue or feature being addressed

Missing dedicated heal-check probe endpoints

## Details on the issue fix or feature implementation

Adds dedicated heal-check probe endpoints

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build