### PR TITLE
Python API Status Endpoint - Eliminate loading of dependencies

### DIFF
--- a/src/python/AgentHubAPI/app/routers/status.py
+++ b/src/python/AgentHubAPI/app/routers/status.py
@@ -1,10 +1,8 @@
-from fastapi import APIRouter, Depends
-from app.dependencies import validate_api_key_header
+from fastapi import APIRouter
 
 router = APIRouter(
     prefix='/status',
     tags=['status'],
-    dependencies=[Depends(validate_api_key_header)],
     responses={404: {'description':'Not found'}}
 )
 

--- a/src/python/DataSourceHubAPI/app/routers/status.py
+++ b/src/python/DataSourceHubAPI/app/routers/status.py
@@ -1,10 +1,8 @@
-from fastapi import APIRouter, Depends
-from app.dependencies import validate_api_key_header
+from fastapi import APIRouter
 
 router = APIRouter(
     prefix='/status',
     tags=['status'],
-    dependencies=[Depends(validate_api_key_header)],
     responses={404: {'description':'Not found'}}
 )
 

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -6,7 +6,7 @@ router = APIRouter(
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('/')
+@router.get('')
 async def get_status() -> str:
     """
     Retrieves the status of the API.

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -1,12 +1,8 @@
-from fastapi import APIRouter, Depends
-from app.dependencies import validate_api_key_header
+from fastapi import APIRouter
 
 router = APIRouter(
     prefix='/status',
     tags=['status'],
-    dependencies=[
-        Depends(validate_api_key_header)
-    ],
     responses={404: {'description':'Not found'}}
 )
 

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -1,10 +1,8 @@
-from fastapi import APIRouter, Depends
-from app.dependencies import validate_api_key_header
+from fastapi import APIRouter
 
 router = APIRouter(
     prefix='/status',
     tags=['status'],
-    dependencies=[Depends(validate_api_key_header)],
     responses={404: {'description':'Not found'}}
 )
 

--- a/tests/python/PythonSDK.Tests/langchain/agents/blob_storage_agent_tests.py
+++ b/tests/python/PythonSDK.Tests/langchain/agents/blob_storage_agent_tests.py
@@ -18,7 +18,7 @@ def test_config():
 def test_completion_request():
      req = CompletionRequest(
                          user_prompt="Tell me about the Gorillas and what happened with them during the pandemic?",
-                         agent=Agent(name="sdzwa", type="blob-storage", description="Provides details about the San Diego Zoo Wildlife Alliance originating from the 2022 and 2023 issues of the journal.", prompt_template="You are the San Diego Zoo assistant named Sandy. You are responsible for answering questions related to the San Diego Zoo that is contained in the journal publications. Only answer questions that relate to the Zoo and journal content. Do not make anything up. Use only the data provided."),
+                         agent=Agent(name="sdzwa", type="blob-storage", description="Provides details about the San Diego Zoo Wildlife Alliance originating from the 2022 and 2023 issues of the journal.", prompt_prefix="You are the San Diego Zoo assistant named Sandy. You are responsible for answering questions related to the San Diego Zoo that is contained in the journal publications. Only answer questions that relate to the Zoo and journal content. Do not make anything up. Use only the data provided."),
                          data_source=DataSource(name="sdzwa", type="blob-storage", description="Information about the San Diego Zoo publications.", configuration=BlobStorageConfiguration(connection_string_secret="FoundationaLLM:BlobStorage:ConnectionString", container="zoo-source", files = ["SDZWA-Journal-July-2022.pdf","SDZWA-Journal-July-2023.pdf","SDZWA-Journal-March-2022.pdf", "SDZWA-Journal-March-2023.pdf", "SDZWA-Journal-May-2022.pdf","SDZWA-Journal-May-2023.pdf", "SDZWA-Journal-November-2022.pdf", "SDZWA-Journal-November-2023.pdf", "SDZWA-Journal-September-2022.pdf","SDZWA-Journal-September-2023.pdf"])),
                          language_model=LanguageModel(type=LanguageModelTypes.OPENAI, provider=LanguageModelProviders.MICROSOFT, temperature=0, use_chat=True),
                          message_history=[]
@@ -33,15 +33,16 @@ def test_llm(test_completion_request, test_config):
 
 class BlobStorageAgentTests:    
    
-    def test_agent_should_return_valid_response_gorilla_pandemic_pdf(self, test_completion_request, test_llm, test_config):        
-        agent = BlobStorageAgent(completion_request=test_completion_request,llm=test_llm, config=test_config)
-        completion_response = agent.run(prompt=test_completion_request.user_prompt)
-        print(completion_response.completion)
-        assert "gorillas" in completion_response.completion.lower()
-        
-    def test_agent_should_return_valid_response_journal_versions_pdf(self, test_completion_request, test_llm, test_config):        
-        test_completion_request.user_prompt = "How often is the Journal published?"        
-        agent = BlobStorageAgent(completion_request=test_completion_request,llm=test_llm, config=test_config)
-        completion_response = agent.run(prompt=test_completion_request.user_prompt)
-        print(completion_response.completion)
-        assert "bimonthly" in completion_response.completion.lower()
+# TESTS ARE COMMENTED OUT DUE TO THE LENGTH OF TIME IT TAKES TO VECTORIZE THE PDF FILES
+#    def test_agent_should_return_valid_response_gorilla_pandemic_pdf(self, test_completion_request, test_llm, test_config):        
+#        agent = BlobStorageAgent(completion_request=test_completion_request,llm=test_llm, config=test_config)
+#        completion_response = agent.run(prompt=test_completion_request.user_prompt)
+#        print(completion_response.completion)
+#        assert "gorillas" in completion_response.completion.lower()
+#        
+#    def test_agent_should_return_valid_response_journal_versions_pdf(self, test_completion_request, test_llm, test_config):        
+#        test_completion_request.user_prompt = "How often is the Journal published?"        
+#        agent = BlobStorageAgent(completion_request=test_completion_request,llm=test_llm, config=test_config)
+#        completion_response = agent.run(prompt=test_completion_request.user_prompt)
+#        print(completion_response.completion)
+#        assert "bimonthly" in completion_response.completion.lower()

--- a/tests/python/PythonSDK.Tests/langchain/agents/csv_agent_tests.py
+++ b/tests/python/PythonSDK.Tests/langchain/agents/csv_agent_tests.py
@@ -18,7 +18,7 @@ def test_config():
 def test_completion_request():
      req = CompletionRequest(
                          user_prompt="How many survey responses are there?",
-                         agent=Agent(name="survey-results", type="csv", description="Useful for answering analytical questions about survey responses.", prompt_template="You are an analytic agent named Khalil that helps people find information about the results of a survey.\nProvide consise answers that are polite and professional.\nDo not make anything up, only use the data provided from the survey responses.\nAnswer any questions step-by-step.\n"),
+                         agent=Agent(name="survey-results", type="csv", description="Useful for answering analytical questions about survey responses.", prompt_prefix="You are an analytic agent named Khalil that helps people find information about the results of a survey.\nProvide consise answers that are polite and professional.\nDo not make anything up, only use the data provided from the survey responses.\nAnswer any questions step-by-step.\n"),
                          data_source=DataSource(name="survey-results-csv", type="blob-storage", description="Information about the survey collected by Hargrove.", configuration=BlobStorageConfiguration(connection_string_secret="FoundationaLLM:BlobStorage:ConnectionString", container="hai-source", files = ["surveydata.csv"])),
                          language_model=LanguageModel(type=LanguageModelTypes.OPENAI, provider=LanguageModelProviders.MICROSOFT, temperature=0, use_chat=True),
                          message_history=[]

--- a/tests/python/PythonSDK.Tests/langchain/agents/generic_resolver_agent_tests.py
+++ b/tests/python/PythonSDK.Tests/langchain/agents/generic_resolver_agent_tests.py
@@ -17,7 +17,7 @@ def test_config():
 def test_completion_request():
      req = CompletionRequest(
                          user_prompt="What is FoundationaLLM?",
-                         agent=Agent(name="demo-resolver", type="generic-resolver", description="Useful for choosing one or more items from a list of FoundationaLLM demo options.", prompt_template="You are a demo option selector in the FoundationaLLM system. Your job is to select one or more options from a list of options that can best satisfy the incoming User Prompt. An option consists of a name and description. Evaluate each option by its description.\n\nYou are to select the number of options that are requested in the user prompt. Provide the answer in natural language.\n\nExample: The best option for your request is the default demo.\n\nDo not make anything up, do not create a fake conversation, use only the data provided here.\n\n{options}\n\nUser Prompt:{user_prompt}\n\nAnswer:\n"),
+                         agent=Agent(name="demo-resolver", type="generic-resolver", description="Useful for choosing one or more items from a list of FoundationaLLM demo options.", prompt_prefix="You are a demo option selector in the FoundationaLLM system. Your job is to select one or more options from a list of options that can best satisfy the incoming User Prompt. An option consists of a name and description. Evaluate each option by its description.\n\nYou are to select the number of options that are requested in the user prompt. Provide the answer in natural language.\n\nExample: The best option for your request is the default demo.\n\nDo not make anything up, do not create a fake conversation, use only the data provided here.\n\n{options}\n\nUser Prompt:{user_prompt}\n\nAnswer:\n"),
                          data_source=DataSource(name="foundationallm-demos", type="blob-storage", description="Information about FoundationaLLM demos.", configuration=BlobStorageConfiguration(connection_string_secret="FoundationaLLM:BlobStorage:ConnectionString", container="foundationallm-demo-source", files = ["demos.json"])),
                          language_model=LanguageModel(type=LanguageModelTypes.OPENAI, provider=LanguageModelProviders.MICROSOFT, temperature=0, use_chat=True),
                          message_history=[MessageHistoryItem(sender="User", text="What is FoundationaLLM?"),  
@@ -45,6 +45,7 @@ class GenericResolverAgentTests:
 
     def test_read_json_options_from_storage(self, test_completion_request, test_llm, test_config):
        agent = GenericResolverAgent(completion_request=test_completion_request,llm=test_llm, config=test_config)
+       print(agent)
        options_list = agent.load_options()       
        assert len(options_list) > 0
         


### PR DESCRIPTION
# Python API Status Endpoint - Eliminate loading of dependencies

## The issue or feature being addressed

The APIs status endpoints were loading configuration and the health probes were causing rate issues with the config service. 

This change removes the API key check (which was loading settings).

Also minor fixes to unit tests (and commenting out of blob storage PDF vectorization tests due to the length of time it takes to run)

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build