### PR TITLE
Setting default client and tenant IDs to empty strings in ARM templates

### DIFF
--- a/deploy/arm/azureAcaDeploy.json
+++ b/deploy/arm/azureAcaDeploy.json
@@ -377,7 +377,7 @@
         },
         {
           "key": "FoundationaLLM:Chat:Entra:ClientId",
-          "value": "0b08d115-b517-4d7f-b883-a1665191d14d",
+          "value": "",
           "contentType": null
         },
         {
@@ -397,7 +397,7 @@
         },
         {
           "key": "FoundationaLLM:Chat:Entra:TenantId",
-          "value": "d280491c-b27a-41bf-9623-21b60cf430b3",
+          "value": "",
           "contentType": null
         },
         {
@@ -457,7 +457,7 @@
         },
         {
           "key": "FoundationaLLM:CoreAPI:Entra:ClientId",
-          "value": "b7bfdfd8-fd88-4bec-a6db-7fd1ecac40db",
+          "value": "",
           "contentType": null
         },
         {
@@ -477,7 +477,7 @@
         },
         {
           "key": "FoundationaLLM:CoreAPI:Entra:TenantId",
-          "value": "d280491c-b27a-41bf-9623-21b60cf430b3",
+          "value": "",
           "contentType": null
         },
         {

--- a/deploy/arm/azureAksDeploy.json
+++ b/deploy/arm/azureAksDeploy.json
@@ -362,7 +362,7 @@
         },
         {
           "key": "FoundationaLLM:Chat:Entra:ClientId",
-          "value": "0b08d115-b517-4d7f-b883-a1665191d14d",
+          "value": "",
           "contentType": null
         },
         {
@@ -382,7 +382,7 @@
         },
         {
           "key": "FoundationaLLM:Chat:Entra:TenantId",
-          "value": "d280491c-b27a-41bf-9623-21b60cf430b3",
+          "value": "",
           "contentType": null
         },
         {
@@ -442,7 +442,7 @@
         },
         {
           "key": "FoundationaLLM:CoreAPI:Entra:ClientId",
-          "value": "b7bfdfd8-fd88-4bec-a6db-7fd1ecac40db",
+          "value": "",
           "contentType": null
         },
         {
@@ -462,7 +462,7 @@
         },
         {
           "key": "FoundationaLLM:CoreAPI:Entra:TenantId",
-          "value": "d280491c-b27a-41bf-9623-21b60cf430b3",
+          "value": "",
           "contentType": null
         },
         {


### PR DESCRIPTION
# Setting default client and tenant IDs to empty strings in ARM templates

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build