### PR TITLE
Renaming the subnet in the ACA case to not imply it is an AKS resource

### DIFF
--- a/deploy/arm/azureAcaDeploy.json
+++ b/deploy/arm/azureAcaDeploy.json
@@ -783,7 +783,7 @@
       "name": "[format('{0}-vnet', parameters('name'))]",
       "addressPrefix": "10.244.0.0/16",
       "subnets": {
-        "aks-subnet": {
+        "aca-subnet": {
           "addressPrefix": "10.244.0.0/16"
         }
       }
@@ -1457,14 +1457,14 @@
         },
         "subnets": [
           {
-            "name": "aks-subnet",
-            "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aks-subnet')]",
+            "name": "aca-subnet",
+            "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aca-subnet')]",
             "properties": {
-              "addressPrefix": "[variables('vnetSettings').subnets['aks-subnet'].addressPrefix]",
+              "addressPrefix": "[variables('vnetSettings').subnets['aca-subnet'].addressPrefix]",
               "delegations": [
                 {
                   "name": "Microsoft.App.environments",
-                  "id": "[concat(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aks-subnet'), '/delegations/Microsoft.App.environments')]",
+                  "id": "[concat(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aca-subnet'), '/delegations/Microsoft.App.environments')]",
                   "properties": {
                     "serviceName": "Microsoft.App/environments"
                   },
@@ -1484,17 +1484,17 @@
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2022-09-01",
-      "name": "[concat(variables('vnetSettings').name, '/aks-subnet')]",
+      "name": "[concat(variables('vnetSettings').name, '/aca-subnet')]",
       "dependsOn": [
         "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetSettings').name)]",
-        "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('vnetSettings').name, '-aks-subnet-nsg'))]"
+        "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('vnetSettings').name, '-aca-subnet-nsg'))]"
       ],
       "properties": {
-        "addressPrefix": "[variables('vnetSettings').subnets['aks-subnet'].addressPrefix]",
+        "addressPrefix": "[variables('vnetSettings').subnets['aca-subnet'].addressPrefix]",
         "delegations": [
           {
             "name": "Microsoft.App.environments",
-            "id": "[concat(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aks-subnet'), '/delegations/Microsoft.App.environments')]",
+            "id": "[concat(resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aca-subnet'), '/delegations/Microsoft.App.environments')]",
             "properties": {
               "serviceName": "Microsoft.App/environments"
             },
@@ -1504,8 +1504,8 @@
         "privateEndpointNetworkPolicies": "Disabled",
         "privateLinkServiceNetworkPolicies": "Enabled",
         "networkSecurityGroup": {
-          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('vnetSettings').name, '-aks-subnet-nsg'))]",
-          "name": "[concat(variables('vnetSettings').name, '-aks-subnet-nsg')]",
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('vnetSettings').name, '-aca-subnet-nsg'))]",
+          "name": "[concat(variables('vnetSettings').name, '-aca-subnet-nsg')]",
           "properties": {
             "flushConnection": false,
             "securityRules": [
@@ -1545,7 +1545,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2023-04-01",
-      "name": "[concat(variables('vnetSettings').name, '-aks-subnet-nsg')]",
+      "name": "[concat(variables('vnetSettings').name, '-aca-subnet-nsg')]",
       "location": "[parameters('location')]",
       "properties": {
         "flushConnection": false,
@@ -1589,7 +1589,7 @@
       "properties": {
         "vnetConfiguration": {
           "internal": false,
-          "infrastructureSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aks-subnet')]"
+          "infrastructureSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetSettings').name, 'aca-subnet')]"
         },
         "appLogsConfiguration": {
           "destination": "log-analytics",


### PR DESCRIPTION
# Renaming the subnet in the ACA case to not imply it is an AKS resource

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build