### PR TITLE
Disabling CosmosDB data import step because the data is no longer used

### DIFF
--- a/deploy/scripts/Unified-Deploy.ps1
+++ b/deploy/scripts/Unified-Deploy.ps1
@@ -18,7 +18,7 @@ Param(
     [parameter(Mandatory = $false)][bool]$stepDeployTls = $true,
     [parameter(Mandatory = $false)][bool]$stepDeployImages = $true,
     [parameter(Mandatory = $false)][bool]$stepUploadSystemPrompts = $true,
-    [parameter(Mandatory = $false)][bool]$stepImportData = $true,
+    [parameter(Mandatory = $false)][bool]$stepImportData = $false,
     [parameter(Mandatory = $false)][bool]$stepLoginAzure = $true,
     [parameter(Mandatory = $false)][string]$resourcePrefix = $null
 )


### PR DESCRIPTION
# Disabling CosmosDB data import step because the data is no longer used

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build