### PR TITLE
Explicitly checking for the resource group in a list

### DIFF
--- a/deploy/scripts/Unified-Deploy.ps1
+++ b/deploy/scripts/Unified-Deploy.ps1
@@ -51,10 +51,10 @@ if ($stepLoginAzure) {
 # Write-Host "Choosing your subscription" -ForegroundColor Yellow
 az account set --subscription $subscription
 
-if (-Not (az group list --query '[].name' -o json | ConvertFrom-Json) -Contains $resourceGroup) {
+if (-Not (az group list --query "[?name=='$resourceGroup'].name" -o json | ConvertFrom-Json) -Contains $resourceGroup) {
     Write-Host("The resource group $resourceGroup was not found, creating it...")
     $rg = $(az group create -g $resourceGroup -l $location --subscription $subscription)
-    if (-Not (az group list --query '[].name' -o json | ConvertFrom-Json) -Contains $resourceGroup) {
+    if (-Not (az group list --query "[?name=='$resourceGroup'].name" -o json | ConvertFrom-Json) -Contains $resourceGroup) {
         Write-Error("The resource group $resourceGroup was not found, and could not be created.")
         exit 1
     }


### PR DESCRIPTION
# Explicitly checking for the resource group in a list to account for the case where a subscription is not empty

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build