### PR TITLE
Resolve the username for Entra free licenses and P2 licenses

### DIFF
--- a/src/dotnet/Common/Services/EntraUserClaimsProviderService.cs
+++ b/src/dotnet/Common/Services/EntraUserClaimsProviderService.cs
@@ -25,9 +25,20 @@ namespace FoundationaLLM.Common.Services
             return new UnifiedUserIdentity
             {
                 Name = userPrincipal.FindFirstValue("name"),
-                Username = userPrincipal.FindFirstValue("preferred_username"),
-                UPN = userPrincipal.FindFirstValue("preferred_username")
+                Username = ResolveUsername(userPrincipal),
+                UPN = ResolveUsername(userPrincipal)
             };
+        }
+
+        /// <summary>
+        /// Resolves the username from the provided <see cref="ClaimsPrincipal"/> object.
+        /// </summary>
+        /// <param name="userPrincipal">The claims principal object that contains the authenticated identity.</param>
+        /// <returns></returns>
+        private string ResolveUsername(ClaimsPrincipal? userPrincipal)
+        {
+            // Depending on which Microsoft Entra ID license the user has, the username may be extracted from the Identity.Name value or the preferred_username claim.
+            return (!string.IsNullOrWhiteSpace(userPrincipal?.Identity?.Name) ? userPrincipal.Identity.Name : userPrincipal?.FindFirstValue("preferred_username")) ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
# Resolve the username for Entra free licenses and P2 licenses

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes issue with retrieving the `preferred_username` claim when using a free Microsoft Entra ID license.

## Details on the issue fix or feature implementation

Resolves the authenticated username depending on which Entra license the current tenant is assigned to.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build