### PR TITLE
Reverse App Insights instrumentation on Python apps

### DIFF
--- a/src/python/AgentHubAPI/app/main.py
+++ b/src/python/AgentHubAPI/app/main.py
@@ -8,10 +8,10 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 
 config = get_config()
 
-configure_azure_monitor(
-    connection_string=config.get_value('FoundationaLLM:APIs:AgentHubAPI:AppInsightsConnectionString'),
-    disable_offline_storage=True
-)
+# configure_azure_monitor(
+#     connection_string=config.get_value('FoundationaLLM:APIs:AgentHubAPI:AppInsightsConnectionString'),
+#     disable_offline_storage=True
+# )
 
 app = FastAPI(
     title='FoundationaLLM AgentHubAPI',

--- a/src/python/DataSourceHubAPI/app/main.py
+++ b/src/python/DataSourceHubAPI/app/main.py
@@ -8,10 +8,10 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 
 config = get_config()
 
-configure_azure_monitor(
-    connection_string=config.get_value('FoundationaLLM:APIs:DataSourceHubAPI:AppInsightsConnectionString'),
-    disable_offline_storage=True
-)
+# configure_azure_monitor(
+#     connection_string=config.get_value('FoundationaLLM:APIs:DataSourceHubAPI:AppInsightsConnectionString'),
+#     disable_offline_storage=True
+# )
 
 app = FastAPI(
     title='FoundationaLLM DataSourceHubAPI',

--- a/src/python/LangChainAPI/app/main.py
+++ b/src/python/LangChainAPI/app/main.py
@@ -8,10 +8,10 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 
 config = get_config()
 
-configure_azure_monitor(
-    connection_string=config.get_value('FoundationaLLM:APIs:LangChainAPI:AppInsightsConnectionString'),
-    disable_offline_storage=True
-)
+# configure_azure_monitor(
+#     connection_string=config.get_value('FoundationaLLM:APIs:LangChainAPI:AppInsightsConnectionString'),
+#     disable_offline_storage=True
+# )
 
 app = FastAPI(
     title='FoundationaLLM LangChainAPI',

--- a/src/python/PromptHubAPI/app/main.py
+++ b/src/python/PromptHubAPI/app/main.py
@@ -8,10 +8,10 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 
 config = get_config()
 
-configure_azure_monitor(
-    connection_string=config.get_value('FoundationaLLM:APIs:PromptHubAPI:AppInsightsConnectionString'),
-    disable_offline_storage=True
-)
+# configure_azure_monitor(
+#     connection_string=config.get_value('FoundationaLLM:APIs:PromptHubAPI:AppInsightsConnectionString'),
+#     disable_offline_storage=True
+# )
 
 app = FastAPI(
     title='FoundationaLLM PromptHubAPI',


### PR DESCRIPTION
# Reverse App Insights instrumentation on Python apps

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes degraded container issues.

## Details on the issue fix or feature implementation

Temporary fix to disable App Insights while we resolve the recurring `Exception  in detector <opentelemetry.resource.detector.azure.vm.AzureVMResourceDetector object at 0x7f6007acd1d0>, ignoring` error in non-Windows environments.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build