### PR TITLE
Fixing error in Python SDK error handling methods

### DIFF
--- a/src/python/AgentHubAPI/app/routers/list.py
+++ b/src/python/AgentHubAPI/app/routers/list.py
@@ -28,5 +28,5 @@ async def list() -> List:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/AgentHubAPI/app/routers/resolve.py
+++ b/src/python/AgentHubAPI/app/routers/resolve.py
@@ -39,5 +39,5 @@ async def resolve(request: AgentHubRequest, x_user_identity: Optional[str] = Hea
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/DataSourceHubAPI/app/routers/resolve.py
+++ b/src/python/DataSourceHubAPI/app/routers/resolve.py
@@ -31,5 +31,5 @@ async def resolve(request:DataSourceHubRequest) -> DataSourceHubResponse:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/GatekeeperIntegrationAPI/app/routers/analyze.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/analyze.py
@@ -27,5 +27,5 @@ async def analyze(text: str | None = None) -> List:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/GatekeeperIntegrationAPI/app/routers/anonymize.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/anonymize.py
@@ -26,5 +26,5 @@ async def anonymize(text: str | None = None) -> str:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/LangChainAPI/app/routers/orchestration.py
+++ b/src/python/LangChainAPI/app/routers/orchestration.py
@@ -38,5 +38,5 @@ async def get_completion(completion_request: CompletionRequest, x_user_identity:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )

--- a/src/python/PromptHubAPI/app/routers/resolve.py
+++ b/src/python/PromptHubAPI/app/routers/resolve.py
@@ -31,5 +31,5 @@ async def resolve(request: PromptHubRequest) -> PromptHubResponse:
         logging.error(e, stack_info=True, exc_info=True)
         raise HTTPException(
             status_code = 500,
-            detail = e.message
+            detail = str(e)
         )


### PR DESCRIPTION
# Fixing error in Python SDK error handling methods

## Details on the issue fix or feature implementation

Fixes a possible error in Python SDK error handling methods by no longer referencing `e.message`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable
