### PR TITLE
Worker Cosmos DB change feed resilience

### DIFF
--- a/src/dotnet/AgentFactoryAPI/Program.cs
+++ b/src/dotnet/AgentFactoryAPI/Program.cs
@@ -57,7 +57,7 @@ namespace FoundationaLLM.AgentFactory.API
                 ConnectionString = builder.Configuration["FoundationaLLM:APIs:AgentFactoryAPI:AppInsightsConnectionString"],
                 DeveloperMode = builder.Environment.IsDevelopment()
             });
-            builder.Services.AddServiceProfiler();
+            //builder.Services.AddServiceProfiler();
             builder.Services.AddControllers().AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ContractResolver = Common.Settings.CommonJsonSerializerSettings.GetJsonSerializerSettings().ContractResolver;

--- a/src/dotnet/Core/Core.csproj
+++ b/src/dotnet/Core/Core.csproj
@@ -13,9 +13,10 @@
 		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.6" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.5.0-alpha.20230531.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Polly.Core" Version="8.2.0" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/Core/Interfaces/ICosmosDbService.cs
+++ b/src/dotnet/Core/Interfaces/ICosmosDbService.cs
@@ -14,8 +14,9 @@ public interface ICosmosDbService
     /// <param name="type">The session type to return.</param>
     /// <param name="upn">The user principal name used for retrieving
     /// sessions for the signed in user.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>List of distinct chat session items.</returns>
-    Task<List<Session>> GetSessionsAsync(string type, string upn);
+    Task<List<Session>> GetSessionsAsync(string type, string upn, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a list of all current chat messages for a specified session identifier.
@@ -23,35 +24,39 @@ public interface ICosmosDbService
     /// <param name="sessionId">Chat session identifier used to filter messages.</param>
     /// <param name="upn">The user principal name used for retrieving the messages for
     /// the signed in user.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>List of chat message items for the specified session.</returns>
-    Task<List<Message>> GetSessionMessagesAsync(string sessionId, string upn);
+    Task<List<Message>> GetSessionMessagesAsync(string sessionId, string upn, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs a point read to retrieve a single chat session item.
     /// </summary>
     /// <returns>The chat session item.</returns>
-    Task<Session> GetSessionAsync(string id);
+    Task<Session> GetSessionAsync(string id, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new chat session.
     /// </summary>
     /// <param name="session">Chat session item to create.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Newly created chat session item.</returns>
-    Task<Session> InsertSessionAsync(Session session);
+    Task<Session> InsertSessionAsync(Session session, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new chat message.
     /// </summary>
     /// <param name="message">Chat message item to create.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Newly created chat message item.</returns>
-    Task<Message> InsertMessageAsync(Message message);
+    Task<Message> InsertMessageAsync(Message message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates an existing chat message.
     /// </summary>
     /// <param name="message">Chat message item to update.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Revised chat message item.</returns>
-    Task<Message> UpdateMessageAsync(Message message);
+    Task<Message> UpdateMessageAsync(Message message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates a message's rating through a patch operation.
@@ -59,23 +64,26 @@ public interface ICosmosDbService
     /// <param name="id">The message id.</param>
     /// <param name="sessionId">The message's partition key (session id).</param>
     /// <param name="rating">The rating to replace.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Revised chat message item.</returns>
-    Task<Message> UpdateMessageRatingAsync(string id, string sessionId, bool? rating);
+    Task<Message> UpdateMessageRatingAsync(string id, string sessionId, bool? rating, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates an existing chat session.
     /// </summary>
     /// <param name="session">Chat session item to update.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Revised created chat session item.</returns>
-    Task<Session> UpdateSessionAsync(Session session);
+    Task<Session> UpdateSessionAsync(Session session, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates a session's name through a patch operation.
     /// </summary>
     /// <param name="id">The session id.</param>
     /// <param name="name">The session's new name.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>Revised chat session item.</returns>
-    Task<Session> UpdateSessionNameAsync(string id, string name);
+    Task<Session> UpdateSessionNameAsync(string id, string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Batch create or update chat messages and session.
@@ -87,20 +95,23 @@ public interface ICosmosDbService
     /// Create or update a user session from the passed in Session object.
     /// </summary>
     /// <param name="session">The chat session item to create or replace.</param>
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns></returns>
-    Task UpsertUserSessionAsync(Session session);
+    Task UpsertUserSessionAsync(Session session, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Batch deletes an existing chat session and all related messages.
     /// </summary>
     /// <param name="sessionId">Chat session identifier used to flag messages and sessions for deletion.</param>
-    Task DeleteSessionAndMessagesAsync(string sessionId);
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
+    Task DeleteSessionAndMessagesAsync(string sessionId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Reads all documents retrieved by Vector Search.
     /// </summary>
     /// <param name="vectorDocuments">List string of JSON documents from vector search results</param>
-    Task<string> GetVectorSearchDocumentsAsync(List<DocumentVector> vectorDocuments);
+    /// <param name="cancellationToken">Cancellation token for async calls.</param>
+    Task<string> GetVectorSearchDocumentsAsync(List<DocumentVector> vectorDocuments, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the completion prompt for a given session and completion prompt id.

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -87,7 +87,7 @@ namespace FoundationaLLM.Core.API
                 ConnectionString = builder.Configuration["FoundationaLLM:APIs:CoreAPI:AppInsightsConnectionString"],
                 DeveloperMode = builder.Environment.IsDevelopment()
             });
-            builder.Services.AddServiceProfiler();
+            //builder.Services.AddServiceProfiler();
             builder.Services.AddControllers().AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ContractResolver = Common.Settings.CommonJsonSerializerSettings.GetJsonSerializerSettings().ContractResolver;

--- a/src/dotnet/CoreWorker/CoreWorker.csproj
+++ b/src/dotnet/CoreWorker/CoreWorker.csproj
@@ -7,6 +7,7 @@
     <UserSecretsId>dotnet-CoreWorker-66b793a2-9018-4ae5-9ed4-b893e8a3e240</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	<DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CoreWorker/Program.cs
+++ b/src/dotnet/CoreWorker/Program.cs
@@ -8,8 +8,6 @@ var builder = Host.CreateApplicationBuilder(args);
 
 builder.Configuration.Sources.Clear();
 builder.Configuration.AddJsonFile("appsettings.json", false, true);
-if (builder.Environment.IsDevelopment())
-    builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
 builder.Configuration.AddEnvironmentVariables();
 builder.Configuration.AddAzureAppConfiguration(options =>
 {
@@ -22,6 +20,8 @@ builder.Configuration.AddAzureAppConfiguration(options =>
     options.Select("FoundationaLLM:CoreWorker:*");
     options.Select("FoundationaLLM:CosmosDB:*");
 });
+if (builder.Environment.IsDevelopment())
+    builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
 
 builder.Services.AddOptions<CosmosDbSettings>()
     .Bind(builder.Configuration.GetSection("FoundationaLLM:CosmosDB"));

--- a/src/dotnet/CoreWorker/Properties/launchSettings.json
+++ b/src/dotnet/CoreWorker/Properties/launchSettings.json
@@ -6,9 +6,6 @@
         "DOTNET_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true
-    },
-    "Docker": {
-      "commandName": "Docker"
     }
   }
 }

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -55,7 +55,7 @@ namespace FoundationaLLM.Gatekeeper.API
                 ConnectionString = builder.Configuration["FoundationaLLM:APIs:GatekeeperAPI:AppInsightsConnectionString"],
                 DeveloperMode = builder.Environment.IsDevelopment()
             });
-            builder.Services.AddServiceProfiler();
+            //builder.Services.AddServiceProfiler();
             builder.Services.AddControllers().AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ContractResolver = Common.Settings.CommonJsonSerializerSettings.GetJsonSerializerSettings().ContractResolver;

--- a/src/dotnet/SemanticKernelAPI/Program.cs
+++ b/src/dotnet/SemanticKernelAPI/Program.cs
@@ -85,7 +85,7 @@ namespace FoundationaLLM.SemanticKernel.API
                 ConnectionString = builder.Configuration["FoundationaLLM:APIs:SemanticKernelAPI:AppInsightsConnectionString"],
                 DeveloperMode = builder.Environment.IsDevelopment()
             });
-            builder.Services.AddServiceProfiler();
+            //builder.Services.AddServiceProfiler();
 
             // System prompt service backed by an Azure blob storage account
             builder.Services.AddOptions<DurableSystemPromptServiceSettings>()


### PR DESCRIPTION
# Worker Cosmos DB change feed resilience

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## Details on the issue fix or feature implementation

Improves change feed transient error handling by implementing a Polly resilience strategy within the change feed processor service. Also disabled the App Insights profiler for now due to occasional null reference exceptions on the App Insights logger during heartbeat operations.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
