### PR TITLE
Remove punctuation from generated session names

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -1,4 +1,5 @@
-﻿using FoundationaLLM.Common.Constants;
+﻿using System.Text.RegularExpressions;
+using FoundationaLLM.Common.Constants;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Common.Models.Chat;
@@ -48,11 +49,9 @@ public class CoreService : ICoreService
     /// <summary>
     /// Returns list of chat session ids and names.
     /// </summary>
-    public async Task<List<Session>> GetAllChatSessionsAsync()
-    {
-        return await _cosmosDbService.GetSessionsAsync(_sessionType, _callContext.CurrentUserIdentity?.UPN ?? 
-            throw new InvalidOperationException("Failed to retrieve the identity of the signed in user when retrieving chat sessions."));
-    }
+    public async Task<List<Session>> GetAllChatSessionsAsync() =>
+        await _cosmosDbService.GetSessionsAsync(_sessionType, _callContext.CurrentUserIdentity?.UPN ?? 
+                                                              throw new InvalidOperationException("Failed to retrieve the identity of the signed in user when retrieving chat sessions."));
 
     /// <summary>
     /// Returns the chat messages related to an existing session.
@@ -166,6 +165,9 @@ public class CoreService : ICoreService
             };
 
             var summary = await _gatekeeperAPIService.GetSummary(summaryRequest);
+
+            // Remove any punctuation from the summary.
+            summary = Regex.Replace(summary, @"[^\w\s]", string.Empty);
 
             await RenameChatSessionAsync(sessionId, summary);
 


### PR DESCRIPTION
# Remove punctuation from generated session names

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes an issue where generated session names (summarized) often include punctuation.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
