### PR TITLE
Setting helm chart version to 0.0.0 in langchain-api helm chart to support release automation

### DIFF
--- a/deploy/helm/langchain-api/Chart.yaml
+++ b/deploy/helm/langchain-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: langchain-api
-version: 0.1.0
+version: 0.0.0


### PR DESCRIPTION
# Setting helm chart version to 0.0.0 in langchain-api helm chart to support release automation

