### PR TITLE
Add Newtonsoft.Json support for SwaggerGen

### DIFF
--- a/src/dotnet/AgentFactoryAPI/AgentFactoryAPI.csproj
+++ b/src/dotnet/AgentFactoryAPI/AgentFactoryAPI.csproj
@@ -22,6 +22,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/AgentFactoryAPI/Program.cs
+++ b/src/dotnet/AgentFactoryAPI/Program.cs
@@ -127,7 +127,7 @@ namespace FoundationaLLM.AgentFactory.API
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-
+            builder.Services.AddSwaggerGenNewtonsoftSupport();
             builder.Services.AddSwaggerGen(
                 options =>
                 {

--- a/src/dotnet/CoreAPI/CoreAPI.csproj
+++ b/src/dotnet/CoreAPI/CoreAPI.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="2.15.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -112,7 +112,7 @@ namespace FoundationaLLM.Core.API
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            
+            builder.Services.AddSwaggerGenNewtonsoftSupport();
             builder.Services.AddSwaggerGen(
                 options =>
                 {

--- a/src/dotnet/GatekeeperAPI/GatekeeperAPI.csproj
+++ b/src/dotnet/GatekeeperAPI/GatekeeperAPI.csproj
@@ -31,6 +31,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -116,7 +116,7 @@ namespace FoundationaLLM.Gatekeeper.API
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-
+            builder.Services.AddSwaggerGenNewtonsoftSupport();
             builder.Services.AddSwaggerGen(
                 options =>
                 {

--- a/src/dotnet/SemanticKernelAPI/Program.cs
+++ b/src/dotnet/SemanticKernelAPI/Program.cs
@@ -57,7 +57,7 @@ namespace FoundationaLLM.SemanticKernel.API
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-
+            builder.Services.AddSwaggerGenNewtonsoftSupport();
             builder.Services.AddSwaggerGen(
                 options =>
                 {

--- a/src/dotnet/SemanticKernelAPI/SemanticKernelAPI.csproj
+++ b/src/dotnet/SemanticKernelAPI/SemanticKernelAPI.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/VectorizationAPI/Program.cs
+++ b/src/dotnet/VectorizationAPI/Program.cs
@@ -52,6 +52,7 @@ builder.Services
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGenNewtonsoftSupport();
 builder.Services.AddSwaggerGen(
     options =>
     {

--- a/src/dotnet/VectorizationAPI/VectorizationAPI.csproj
+++ b/src/dotnet/VectorizationAPI/VectorizationAPI.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/VectorizationWorker/Program.cs
+++ b/src/dotnet/VectorizationWorker/Program.cs
@@ -61,6 +61,7 @@ builder.Services
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGenNewtonsoftSupport();
 builder.Services.AddSwaggerGen(
     options =>
     {

--- a/src/dotnet/VectorizationWorker/VectorizationWorker.csproj
+++ b/src/dotnet/VectorizationWorker/VectorizationWorker.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Adds Newtonsoft.Json support for SwaggerGen

## The issue or feature being addressed

Request body schemas are incorrect when properties are decorated with Newtonsoft.Json attributes

## Details on the issue fix or feature implementation

Adds support via package `Swashbuckle.AspNetCore.Newtonsoft` in all dotnet APIs

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
