### PR TITLE
Add auth token passthrough

### DIFF
--- a/src/dotnet/Common/Interfaces/ICallContext.cs
+++ b/src/dotnet/Common/Interfaces/ICallContext.cs
@@ -27,9 +27,14 @@ namespace FoundationaLLM.Common.Interfaces
         Agent? AgentHint { get; set; }
 
         /// <summary>
-        /// The current <see cref="UnifiedUserIdentity"/> object resolved
-        /// from one or more services.
+        /// The current <see cref="UnifiedUserIdentity"/> object resolved from one
+        /// or more services.
         /// </summary>
         UnifiedUserIdentity? CurrentUserIdentity { get; set; }
+
+        /// <summary>
+        /// Contains the current access token for the authenticated user, if any.
+        /// </summary>
+        string? Token { get; set; }
     }
 }

--- a/src/dotnet/Common/Middleware/CallContextMiddleware.cs
+++ b/src/dotnet/Common/Middleware/CallContextMiddleware.cs
@@ -3,6 +3,7 @@ using FoundationaLLM.Common.Models.Authentication;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using FoundationaLLM.Common.Models.Metadata;
+using Microsoft.AspNetCore.Authentication;
 
 namespace FoundationaLLM.Common.Middleware
 {
@@ -21,7 +22,7 @@ namespace FoundationaLLM.Common.Middleware
         public CallContextMiddleware(RequestDelegate next) =>
             _next = next;
 
-        /// <summary>
+        //// <summary>
         /// Executes the middleware.
         /// </summary>
         /// <param name="context">The current HTTP request context.</param>
@@ -35,6 +36,7 @@ namespace FoundationaLLM.Common.Middleware
             {
                 // Extract from ClaimsPrincipal if available:
                 callContext.CurrentUserIdentity = claimsProviderService.GetUserIdentity(context.User);
+                callContext.Token = await context.GetTokenAsync("access_token");
             }
             else
             {

--- a/src/dotnet/Common/Middleware/CallContextMiddleware.cs
+++ b/src/dotnet/Common/Middleware/CallContextMiddleware.cs
@@ -22,7 +22,7 @@ namespace FoundationaLLM.Common.Middleware
         public CallContextMiddleware(RequestDelegate next) =>
             _next = next;
 
-        //// <summary>
+        /// <summary>
         /// Executes the middleware.
         /// </summary>
         /// <param name="context">The current HTTP request context.</param>

--- a/src/dotnet/Common/Models/Context/CallContext.cs
+++ b/src/dotnet/Common/Models/Context/CallContext.cs
@@ -16,5 +16,7 @@ namespace FoundationaLLM.Common.Models.Context
         public Agent? AgentHint { get; set; }
         /// <inheritdoc/>
         public UnifiedUserIdentity? CurrentUserIdentity { get; set; }
+        /// <inheritdoc/>
+        public string? Token { get; set; }
     }
 }

--- a/src/dotnet/Common/Services/HttpClientFactoryService.cs
+++ b/src/dotnet/Common/Services/HttpClientFactoryService.cs
@@ -56,6 +56,12 @@ namespace FoundationaLLM.Common.Services
             {
                 var serializedIdentity = JsonConvert.SerializeObject(_callContext.CurrentUserIdentity);
                 httpClient.DefaultRequestHeaders.Add(Constants.HttpHeaders.UserIdentity, serializedIdentity);
+
+                // Add the bearer token header if present.
+                if (_callContext.Token != null)
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _callContext.Token);
+                }
             }
 
             // Add the agent hint header if present.


### PR DESCRIPTION
# Add auth token passthrough

Enables passing an existing auth token (eg. Bearer) from an upstream service to downstream service calls. This supports layering APIs in front of the Core API.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
