### PR TITLE
Make the agent selection sticky across chat sessions (experimental-02 branch)

### DIFF
--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -12,6 +12,7 @@ export const useAppStore = defineStore('app', {
 		isSidebarClosed: false as boolean,
 		agents: [] as Agent[],
 		selectedAgents: new Map(),
+		lastSelectedAgent: null as Agent | null,
 	}),
 
 	getters: {},
@@ -112,10 +113,21 @@ export const useAppStore = defineStore('app', {
 		},
 
 		getSessionAgent(session: Session) {
-			return this.selectedAgents.get(session.id);
+			var selectedAgent = this.selectedAgents.get(session.id);
+			if (!selectedAgent) {
+				if (this.lastSelectedAgent) {
+					// Default to the last selected agent to make the selection "sticky" across sessions.
+					selectedAgent = this.lastSelectedAgent;
+				} else {
+					// Default to the first agent in the list.
+					selectedAgent = this.agents[0];
+				}
+			}
+			return selectedAgent;
 		},
 
 		setSessionAgent(session: Session, agent: Agent) {
+			this.lastSelectedAgent = agent;
 			return this.selectedAgents.set(session.id, agent);
 		},
 


### PR DESCRIPTION
# Make the agent selection sticky across chat sessions (experimental-02 branch)

## Details on the issue fix or feature implementation

Make the agent selection sticky across chat sessions. Default to the first agent in the list if none previously selected.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
