### PR TITLE
Bugfix for the summary agent not to send over null initialized params

### DIFF
--- a/src/dotnet/AgentFactory/Services/LangChainService.cs
+++ b/src/dotnet/AgentFactory/Services/LangChainService.cs
@@ -1,10 +1,7 @@
 ﻿using FoundationaLLM.AgentFactory.Core.Models.Orchestration;
-using FoundationaLLM.AgentFactory.Core.Models.Orchestration.DataSourceConfigurations;
 using FoundationaLLM.AgentFactory.Core.Models.Orchestration.Metadata;
 using FoundationaLLM.AgentFactory.Interfaces;
 using FoundationaLLM.AgentFactory.Models.ConfigurationOptions;
-using FoundationaLLM.Common.Models.Chat;
-using FoundationaLLM.Common.Models.Orchestration;
 using FoundationaLLM.Common.Settings;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -36,6 +33,7 @@ namespace FoundationaLLM.AgentFactory.Services
             _logger = logger;
             _httpClientFactoryService = httpClientFactoryService;
             _jsonSerializerSettings = CommonJsonSerializerSettings.GetJsonSerializerSettings();
+            _jsonSerializerSettings.NullValueHandling = NullValueHandling.Ignore;
         }
 
         /// <summary>

--- a/tests/python/PythonSDK.Tests/PythonSDK.Tests.pyproj
+++ b/tests/python/PythonSDK.Tests/PythonSDK.Tests.pyproj
@@ -33,6 +33,7 @@
     <Compile Include="langchain\agents\search_service_agent_tests.py" />
     <Compile Include="langchain\agents\blob_storage_agent_tests.py" />
     <Compile Include="langchain\agents\csv_agent_tests.py" />
+    <Compile Include="langchain\agents\summary_agent_tests.py" />
     <Compile Include="langchain\message_history\message_history_tests.py" />
     <Compile Include="pytest.ini" />
     <Compile Include="langchain\agents\generic_resolver_agent_tests.py" />

--- a/tests/python/PythonSDK.Tests/langchain/agents/summary_agent_tests.py
+++ b/tests/python/PythonSDK.Tests/langchain/agents/summary_agent_tests.py
@@ -1,0 +1,43 @@
+from typing import Any
+import pytest
+from foundationallm.config import Configuration
+from foundationallm.models.orchestration import CompletionRequest
+from foundationallm.models.metadata import Agent
+from foundationallm.models.language_models import LanguageModelType, LanguageModelProvider, LanguageModel
+from foundationallm.langchain.language_models import LanguageModelFactory
+from foundationallm.langchain.agents import SummaryAgent
+
+@pytest.fixture
+def test_config():
+    return Configuration()                         
+
+@pytest.fixture
+def test_fllm_completion_request():
+    req = CompletionRequest(
+        user_prompt="FoundationaLLM is a groundbreaking platform to revolutionize how to build and manage, secure, trustworthy, enterprise-grade Copilots.",
+        agent=Agent(
+            name="summarizer",
+            type="summary",
+            description="Useful for summarizing input text based on a set of rules.",
+            prompt_prefix="Write a concise two-word summary of the following:\n\"{text}\"\nCONCISE SUMMARY IN TWO WORDS:"
+        ),
+        language_model=LanguageModel(
+            type=LanguageModelType.OPENAI,
+            provider=LanguageModelProvider.MICROSOFT,
+            temperature=0,
+            use_chat=True            
+        )
+    )
+    return req
+
+@pytest.fixture
+def test_fllm_llm(test_fllm_completion_request, test_config):
+    model_factory = LanguageModelFactory(language_model=test_fllm_completion_request.language_model, config = test_config)
+    return model_factory.get_llm()
+
+class SummaryAgentTests:    
+   def test_agent_should_return_summary(self, test_fllm_completion_request, test_fllm_llm, test_config):        
+        agent = SummaryAgent(completion_request=test_fllm_completion_request,llm=test_fllm_llm, config=test_config)
+        completion_response = agent.run(prompt=test_fllm_completion_request.user_prompt)
+        print(completion_response.completion)
+        assert "copilot" in completion_response.completion.lower()


### PR DESCRIPTION
# Bugfix for the summary agent not to send over null initialized params

Pydantic treats parameters specifically set to null as having a value thus doesn't use the default values.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
