### PR TITLE
Fixing code that was accidentally overwritten by a merge.

### DIFF
--- a/src/dotnet/AgentFactory/Agents/DefaultAgent.cs
+++ b/src/dotnet/AgentFactory/Agents/DefaultAgent.cs
@@ -56,10 +56,18 @@ namespace FoundationaLLM.AgentFactory.Core.Agents
             var promptResponse = _callContext.AgentHint != null
                 ? await _cacheService.Get<PromptHubResponse>(
                     new CacheKey(_callContext.AgentHint.Name!, "prompt"),
-                    async () => { return await _promptHubService.ResolveRequest(_agentMetadata.Name!, sessionId); },
+                    async () => {
+                        return await _promptHubService.ResolveRequest(
+                            _agentMetadata.PromptContainer ?? _agentMetadata.Name!,
+                            sessionId
+                        );
+                    },
                     false,
                     TimeSpan.FromHours(1))
-                : await _promptHubService.ResolveRequest(_agentMetadata.Name!, sessionId);
+                : await _promptHubService.ResolveRequest(
+                    _agentMetadata.PromptContainer ?? _agentMetadata.Name!,
+                    sessionId
+                  );
 
             // Get data sources listed for the agent.
             var dataSourceResponse = _callContext.AgentHint != null

--- a/src/dotnet/AgentFactory/Models/Orchestration/Metadata/CXODataSource.cs
+++ b/src/dotnet/AgentFactory/Models/Orchestration/Metadata/CXODataSource.cs
@@ -1,17 +1,12 @@
 ﻿using FoundationaLLM.AgentFactory.Core.Models.Orchestration.DataSourceConfigurations;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FoundationaLLM.AgentFactory.Core.Models.Orchestration.Metadata
 {
     /// <summary>
     /// CXO data source metadata model.
     /// </summary>
-    public class CXODataSource : SearchServiceDataSource
+    public class CXODataSource : DataSourceBase
     {
         /// <summary>
         /// Search Service configuration settings.


### PR DESCRIPTION
## Fixing payload for PromptHub to use new `prompt_container` property

This PR is to correct an overwrite from a previous PR. It reinstates code to first check for the `prompt_container` property on an agent, before falling back to the `agent_name` property when determining what folder in blob storage to use for assigning a prompt to an agent.

{Detail}

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
