### PR TITLE
Fix typo in vectorization resource type name

### DIFF
--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceTypeNames.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceTypeNames.cs
@@ -19,7 +19,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
         /// <summary>
         /// Text partitioning profiles.
         /// </summary>
-        public const string TextPartitioningProfiles = "textpartitionprofiles";
+        public const string TextPartitioningProfiles = "textpartitioningprofiles";
 
         /// <summary>
         /// Text embedding profiles.


### PR DESCRIPTION
# Fix typo in vectorization resource type name

## The issue or feature being addressed

Incorrect resource type name in vectorization resource provider.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
