### PR TITLE
Add legacy agent selection support

### DIFF
--- a/src/dotnet/Common/Constants/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Constants/AppConfigurationKeys.cs
@@ -345,6 +345,10 @@ namespace FoundationaLLM.Common.Constants
         /// </summary>
         public const string FoundationaLLM_Branding_SecondaryTextColor = "FoundationaLLM:Branding:SecondaryTextColor";
         /// <summary>
+        /// The key for the FoundationaLLM:Branding:AllowAgentSelection app configuration setting.
+        /// </summary>
+        public const string FoundationaLLM_Branding_AllowAgentSelection = "FoundationaLLM:Branding:AllowAgentSelection";
+        /// <summary>
         /// The key for the FoundationaLLM:Chat:Entra:CallbackPath app configuration setting.
         /// </summary>
         public const string FoundationaLLM_Chat_Entra_CallbackPath = "FoundationaLLM:Chat:Entra:CallbackPath";

--- a/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
+++ b/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
@@ -79,5 +79,10 @@ namespace FoundationaLLM.Common.Models.Configuration.Branding
         /// The text color that overlays the <see cref="SecondaryColor"/> of the client in hex format.
         /// </summary>
         public string? SecondaryTextColor { get; set; }
+        /// <summary>
+        /// Comma-separated list of global agents. This is used for legacy support. New agents should
+        /// use the agent resource provider.
+        /// </summary>
+        public string? AllowAgentSelection { get; set; }
     }
 }


### PR DESCRIPTION
# Add legacy agent selection support

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## Details on the issue fix or feature implementation

Currently, the only agents available in the dropdown list of the User Portal are those that reside within the agent resource provider. This PR adds support for appending legacy agent names through the `FoundationaLLM:Branding:AllowAgentSelection` App Config setting.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
