### PR TITLE
Removing an invalid parameter from a bicep call in app-rg.bicep

### DIFF
--- a/deploy/standard/bicep/app-rg.bicep
+++ b/deploy/standard/bicep/app-rg.bicep
@@ -136,7 +136,6 @@ module aksBackend 'modules/aks.bicep' = {
     logAnalyticWorkspaceId: logAnalyticsWorkspaceId
     logAnalyticWorkspaceResourceId: logAnalyticsWorkspaceResourceId
     networkingResourceGroupName: networkingResourceGroupName
-    opsResourceGroupName: opsResourceGroupName
     privateDnsZones: filter(dnsZones.outputs.ids, (zone) => contains([ 'aks' ], zone.key))
     resourceSuffix: '${resourceSuffix}-backend'
     subnetId: '${vnetId}/subnets/FLLMBackend'


### PR DESCRIPTION
# Removing an invalid parameter from a bicep call in app-rg.bicep

Removed an invalid call to a bicep module in the App specific top level bicep template for the standard deployment.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

