### PR TITLE
Fix bug with text splitting based on tokens

### DIFF
--- a/src/dotnet/Common/Services/TextSplitters/TokenTextSplitterService.cs
+++ b/src/dotnet/Common/Services/TextSplitters/TokenTextSplitterService.cs
@@ -41,14 +41,14 @@ namespace FoundationaLLM.Common.Services.TextSplitters
                     .Select(t => _tokenizerService.Decode(t, _settings.TokenizerEncoder))
                     .ToList();
 
-                var lastChunkStart = (chunksCount - 1) * _settings.ChunkSizeTokens;
+                var lastChunkStart = (chunksCount - 1) * (_settings.ChunkSizeTokens - _settings.OverlapSizeTokens);
                 var lastChunkSize = tokens.Count - lastChunkStart + 1;
                 var resultMessage = string.Empty;
 
                 if (lastChunkSize < 2 * _settings.OverlapSizeTokens)
                 {
                     // The last chunk is to small, will just incorporate it into the second to last.
-                    var secondToLastChunkStart = (chunksCount - 2) * _settings.ChunkSizeTokens;
+                    var secondToLastChunkStart = (chunksCount - 2) * (_settings.ChunkSizeTokens - _settings.OverlapSizeTokens);
                     var newLastChunkSize = tokens.Count - secondToLastChunkStart + 1;
                     var newLastChunk = _tokenizerService.Decode(
                         tokens


### PR DESCRIPTION
# Fix bug with text splitting based on tokens

## The issue or feature being addressed

The size of the last text chunk is incorrectly calculated.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
