### PR TITLE
Ensuring output by AZCLI is in JSON when generating config settings

### DIFF
--- a/deploy/standard/scripts/Generate-Config.ps1
+++ b/deploy/standard/scripts/Generate-Config.ps1
@@ -348,20 +348,23 @@ Write-Host "Getting AKS Instances, Private Endpoints and NICs"
 $aksInstances = $(
     az aks list `
         --resource-group $resourceGroups.app `
-        --query "[].{aksName:name,privateFqdn:privateFqdn,aksId:id}" | `
+        --query "[].{aksName:name,privateFqdn:privateFqdn,aksId:id}" `
+        --output json | `
         ConvertFrom-Json
 )
 $peInstances = $(
     az network private-endpoint list `
         --resource-group $resourceGroups.app `
-        --query "[].{groupId:privateLinkServiceConnections[0].groupIds[0],peName:name,aksId:privateLinkServiceConnections[0].privateLinkServiceId,nicId:networkInterfaces[0].id,peId:id}" | `
+        --query "[].{groupId:privateLinkServiceConnections[0].groupIds[0],peName:name,aksId:privateLinkServiceConnections[0].privateLinkServiceId,nicId:networkInterfaces[0].id,peId:id}" `
+        --output json | `
         ConvertFrom-Json
 )
 
 $nicInstances = $(
     az network nic list `
         --resource-group $resourceGroups.app `
-        --query "[].{nicId:id, nicName:name, privateIpAddress:ipConfigurations[0].privateIPAddress,peId:privateEndpoint.id}" | `
+        --query "[].{nicId:id, nicName:name, privateIpAddress:ipConfigurations[0].privateIPAddress,peId:privateEndpoint.id}" `
+        --output json | `
         ConvertFrom-Json
 )
 


### PR DESCRIPTION
# Ensuring output by AZCLI is in JSON when generating config settings

Adding changes to standard config generation script to ensure that output from AZCLI is always in JSON format in the case where a user has a default output type other than JSON configured.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
