### PR TITLE
Avoid race condition in initialization of encoder.

### DIFF
--- a/src/dotnet/Common/Services/Tokenizers/MicrosoftBPETokenizerService.cs
+++ b/src/dotnet/Common/Services/Tokenizers/MicrosoftBPETokenizerService.cs
@@ -153,6 +153,8 @@ namespace FoundationaLLM.Common.Services.Tokenizers
 
         private void ValidateEncoder(string encoderName)
         {
+            do { } while (!_initializationComplete.IsSet);
+
             if (string.IsNullOrWhiteSpace(encoderName)
                 || (!_encoderConfigurations.TryGetValue(encoderName, out TikTokenizerConfig? value))
                 || (value.MergeableRanksFileContent is null))


### PR DESCRIPTION
# Vectorization Service: Race Condition Fix

## The issue or feature being addressed

When initializing the `MicrosoftBPETokenizerService` outside of a DI container, a race condition may emerge if the user requests the service to encode/decode before the in-memory tokenization configuration is loaded. This fix modifies `ValidateEncoder()`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable