### PR TITLE
Fix broken logo in mobile view in the User Portal when using an absolute URI

### DIFF
--- a/src/ui/UserPortal/plugins/filters.ts
+++ b/src/ui/UserPortal/plugins/filters.ts
@@ -9,7 +9,7 @@ const filters = {
 	},
 
 	enforceLeadingSlash(path: string) {
-		if (!path.startsWith('/')) {
+		if (!path.startsWith('/') && !path.startsWith('http')) {
 			return '/' + path;
 		} else {
 			return path;


### PR DESCRIPTION
# Fix broken logo in mobile view in the User Portal when using an absolute URI

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes broken image in mobile view when using an absolute vs. relative path.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
