### PR TITLE
Add FOUNDATIONALLM_VERSION to Dockerfiles

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -59,6 +59,8 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         push: true
+        build-args: |
+          FOUNDATIONALLM_VERSION=${{ steps.releaseVersion.outputs.release_tag }}
 
   helm_chart_package_and_push:
     runs-on: ubuntu-latest

--- a/src/dotnet/AgentFactoryAPI/Dockerfile
+++ b/src/dotnet/AgentFactoryAPI/Dockerfile
@@ -1,10 +1,12 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -29,3 +31,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.AgentFactory.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/CoreAPI/Dockerfile
+++ b/src/dotnet/CoreAPI/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Core.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/CoreWorker/Dockerfile
+++ b/src/dotnet/CoreWorker/Dockerfile
@@ -1,7 +1,8 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
+
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -26,3 +27,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Core.Worker.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/GatekeeperAPI/Dockerfile
+++ b/src/dotnet/GatekeeperAPI/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,5 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Gatekeeper.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL foundationallm.version=$FOUNDATIONALLM_VERSION
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/ManagementAPI/Dockerfile
+++ b/src/dotnet/ManagementAPI/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Management.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/SemanticKernelAPI/Dockerfile
+++ b/src/dotnet/SemanticKernelAPI/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.SemanticKernel.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/VectorizationAPI/Dockerfile
+++ b/src/dotnet/VectorizationAPI/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Release
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Vectorization.API.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/dotnet/VectorizationWorker/Dockerfile
+++ b/src/dotnet/VectorizationWorker/Dockerfile
@@ -1,11 +1,11 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG FOUNDATIONALLM_VERSION
 WORKDIR /app
 EXPOSE 80
 
 ENV ASPNETCORE_URLS=http://+:80
 ENV ASPNETCORE_ENVIRONMENT=Release
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
@@ -30,3 +30,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FoundationaLLM.Vectorization.Worker.dll"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/python/AgentHubAPI/Dockerfile
+++ b/src/python/AgentHubAPI/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11
+ARG FOUNDATIONALLM_VERSION
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 WORKDIR /code
 COPY ./AgentHubAPI/requirements.txt /code/requirements.txt
@@ -11,3 +13,4 @@ ENV FORWARDED_ALLOW_IPS *
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80", "--forwarded-allow-ips", "*", "--proxy-headers"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/python/DataSourceHubAPI/Dockerfile
+++ b/src/python/DataSourceHubAPI/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11
+ARG FOUNDATIONALLM_VERSION
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 WORKDIR /code
 COPY ./DataSourceHubAPI/requirements.txt /code/requirements.txt
@@ -10,3 +12,4 @@ EXPOSE 80
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80", "--forwarded-allow-ips", "*", "--proxy-headers"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/python/GatekeeperIntegrationAPI/Dockerfile
+++ b/src/python/GatekeeperIntegrationAPI/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-bookworm
+ARG FOUNDATIONALLM_VERSION
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 RUN apt-get update \
         && apt-get install -y curl apt-transport-https gnupg2 \
@@ -17,3 +19,4 @@ EXPOSE 80
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/python/LangChainAPI/Dockerfile
+++ b/src/python/LangChainAPI/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-bookworm
+ARG FOUNDATIONALLM_VERSION
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 RUN apt-get update \
         && apt-get install -y curl apt-transport-https gnupg2 \
@@ -17,3 +19,4 @@ EXPOSE 80
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/python/PromptHubAPI/Dockerfile
+++ b/src/python/PromptHubAPI/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11
+ARG FOUNDATIONALLM_VERSION
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 WORKDIR /code
 COPY ./PromptHubAPI/requirements.txt /code/requirements.txt
@@ -10,3 +12,4 @@ EXPOSE 80
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80", "--forwarded-allow-ips", "*", "--proxy-headers"]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/ui/ManagementPortal/Dockerfile
+++ b/src/ui/ManagementPortal/Dockerfile
@@ -1,12 +1,14 @@
 # syntax = docker/dockerfile:1
 
 ARG NODE_VERSION=18.18.2
+ARG FOUNDATIONALLM_VERSION
 
 FROM node:${NODE_VERSION}-slim as base
 
 ARG PORT=3000
 
 ENV NODE_ENV=production
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 WORKDIR /src
 
@@ -30,3 +32,4 @@ COPY --from=build /src/.output /src/.output
 
 CMD [ "node", ".output/server/index.mjs" ]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/ui/UserPortal/Dockerfile
+++ b/src/ui/UserPortal/Dockerfile
@@ -1,12 +1,14 @@
 # syntax = docker/dockerfile:1
 
 ARG NODE_VERSION=18.18.2
+ARG FOUNDATIONALLM_VERSION
 
 FROM node:${NODE_VERSION}-slim as base
 
 ARG PORT=3000
 
 ENV NODE_ENV=production
+ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 
 WORKDIR /src
 
@@ -30,3 +32,4 @@ COPY --from=build /src/.output /src/.output
 
 CMD [ "node", ".output/server/index.mjs" ]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
+LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}


### PR DESCRIPTION
# Add FOUNDATIONALLM_VERSION to Dockerfiles

## The issue or feature being addressed

We want to be able to include the version as part of the `/status` endpoint.

## Details on the issue fix or feature implementation

This adds the version tag of the docker image to an environment variable named `FOUNDATIONALLM_VERSION` so that applications can find this by inspecting the environment.

Additionally, this adds the label `ai.foundationallm.version` to the image metadata so that other tools can inspect this without running a container or opening a shell on the container to dump the environment.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable


