### PR TITLE
Fix broken link in docs TOC

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -40,7 +40,7 @@ items:
     - name: Calling the Management API
       href: development/calling-apis/directly-calling-management-api.md
     - name: Calling the Vectorization APIs
-      href: development/calling-apis/directory-calling-vectorization-api.md
+      href: development/calling-apis/directly-calling-vectorization-api.md
   - name: Contributing
     href: development/contributing/index.md
     items:


### PR DESCRIPTION
# Fix broken link in docs TOC

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes broken link to the Vectorization API direct call doc from the TOC due to a typo.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
