### PR TITLE
Adding .gitattributes to ensure that *.sh files are committed with correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/deploy/starter/azd-hooks/postprovision.sh
+++ b/deploy/starter/azd-hooks/postprovision.sh
@@ -39,7 +39,6 @@ jq -c '.[]' ./config/appconfig.json | while read i; do
 
     echo $cmd
     eval $cmd </dev/null
-    sleep 2
 done
 
 az storage azcopy blob upload -c agents --account-name $AZURE_STORAGE_ACCOUNT_NAME -s "../common/data/agents/*" --recursive --only-show-errors


### PR DESCRIPTION
# Adding .gitattributes to ensure that *.sh files are committed with correct line endings

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

