### PR TITLE
Removing OpenTelemetry from GatekeeperIntegrationAPI

### DIFF
--- a/src/python/GatekeeperIntegrationAPI/app/routers/analyze.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/analyze.py
@@ -5,11 +5,11 @@ PII (personally identifiable information) entities.
 from fastapi import APIRouter, Depends
 from foundationallm.integration.models import AnalyzeRequest, AnalyzeResponse
 from foundationallm.integration.mspresidio import Analyzer
-from foundationallm.telemetry import Telemetry
+#from foundationallm.telemetry import Telemetry
 from app.dependencies import validate_api_key_header, handle_exception
 
-logger = Telemetry.get_logger(__name__)
-tracer = Telemetry.get_tracer(__name__)
+#logger = Telemetry.get_logger(__name__)
+#tracer = Telemetry.get_tracer(__name__)
 
 router = APIRouter(
     prefix='/analyze',
@@ -34,10 +34,10 @@ async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
         If the request includes anonymize=True, the original content
         will be returned anonymized.
     """
-    with tracer.start_as_current_span('analyze') as span:
-        try:
-            analyzer = Analyzer(request)
-            return analyzer.analyze()
-        except Exception as e:
-            Telemetry.record_exception(span, e)
-            handle_exception(e)
+    #with tracer.start_as_current_span('analyze') as span:
+    try:
+        analyzer = Analyzer(request)
+        return analyzer.analyze()
+    except Exception as e:
+        #Telemetry.record_exception(span, e)
+        handle_exception(e)

--- a/src/python/GatekeeperIntegrationAPI/app/routers/manage.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/manage.py
@@ -3,7 +3,7 @@ The endpoint for managing the LangChainAPI.
 """
 import time
 from fastapi import APIRouter, Depends, HTTPException
-from foundationallm.telemetry import Telemetry
+#from foundationallm.telemetry import Telemetry
 from app.dependencies import (
     API_NAME,
     get_config,
@@ -11,8 +11,8 @@ from app.dependencies import (
     validate_api_key_header
 )
 
-logger = Telemetry.get_logger(__name__)
-tracer = Telemetry.get_tracer(__name__)
+#logger = Telemetry.get_logger(__name__)
+#tracer = Telemetry.get_tracer(__name__)
 
 # Initialize API routing
 router = APIRouter(
@@ -33,23 +33,24 @@ async def refresh_cache(name: str):
         The name of the cache object to refresh.
         "config", for example.
     """
-    with tracer.start_as_current_span('refresh_cache') as span:
-        span.set_attribute('cache_name', name)
-        span.add_event(f'{API_NAME} {name} cache refresh requested.')
+    #with tracer.start_as_current_span('refresh_cache') as span:
+    #    span.set_attribute('cache_name', name)
+    #    span.add_event(f'{API_NAME} {name} cache refresh requested.')
 
-        start = time.time()
+    start = time.time()
 
-        if name=='config' or name=='configuration':
-            try:
-                get_config('refresh')
-            except Exception as e:
-                Telemetry.record_exception(span, e)
-                handle_exception(e)
-        else:
-            raise HTTPException(status_code=404, detail=f'Cache named {name} not found.')
+    if name=='config' or name=='configuration':
+        try:
+            get_config('refresh')
+        except Exception as e:
+            #Telemetry.record_exception(span, e)
+            handle_exception(e)
+    else:
+        raise HTTPException(status_code=404, detail=f'Cache named {name} not found.')
 
-        end = time.time()
+    end = time.time()
 
-        detail = f'The {API_NAME} {name} cache was refreshed in {round(end-start, 3)} seconds.'
-        span.add_event(detail)
-        return {'detail':detail}
+    detail = f'The {API_NAME} {name} cache was refreshed in {round(end-start, 3)} seconds.'
+    #span.add_event(detail)
+
+    return {'detail':detail}


### PR DESCRIPTION
# Removing OpenTelemetry from GatekeeperIntegrationAPI

## The issue or feature being addressed

GatekeeperIntegrationAPI does not reference the PythonSDK, so cannot get to the Telemetry class.

## Details on the issue fix or feature implementation

Temporarily removing OpenTelemetry from GatekeeperIntegrationAPI.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
