### PR TITLE
MAIN: Fix for null reference when legacy agents are used.

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -139,18 +139,27 @@ namespace FoundationaLLM.Agent.ResourceProviders
 
         private async Task<AgentBase> LoadAgent(AgentReference agentReference)
         {
-            if (await _storageService.FileExistsAsync(_storageContainerName, agentReference.Filename, default))
+            // agentReference is null for legacy agents
+            if (agentReference != null)
             {
-                var fileContent = await _storageService.ReadFileAsync(_storageContainerName, agentReference.Filename, default);
-                return JsonSerializer.Deserialize(
-                    Encoding.UTF8.GetString(fileContent.ToArray()),
-                    agentReference.AgentType,
-                    _serializerSettings) as AgentBase
-                    ?? throw new ResourceProviderException($"Failed to load the agent {agentReference.Name}.",
-                        StatusCodes.Status400BadRequest);
+                if (await _storageService.FileExistsAsync(_storageContainerName, agentReference.Filename, default))
+                {
+                    var fileContent = await _storageService.ReadFileAsync(_storageContainerName, agentReference.Filename, default);
+                    return JsonSerializer.Deserialize(
+                        Encoding.UTF8.GetString(fileContent.ToArray()),
+                        agentReference.AgentType,
+                        _serializerSettings) as AgentBase
+                        ?? throw new ResourceProviderException($"Failed to load the agent {agentReference.Name}.",
+                            StatusCodes.Status400BadRequest);
+                }
             }
 
-            throw new ResourceProviderException($"Could not locate the {agentReference.Name} agent resource.",
+            var agentName = "legacy";
+            if (agentReference!= null)
+            {
+                agentName = agentReference.Name;
+            }
+            throw new ResourceProviderException($"Could not locate the {agentName} agent resource.",
                 StatusCodes.Status404NotFound);
         }
 


### PR DESCRIPTION
# Fix for null reference when legacy agents are used.

## The issue or feature being addressed

Fix for null reference when legacy agents are used in Agent Resource Provider

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable


