### PR TITLE
(Python) Property casing fix for vectorization resource provider

### DIFF
--- a/src/python/PythonSDK/foundationallm/resources/resource_provider.py
+++ b/src/python/PythonSDK/foundationallm/resources/resource_provider.py
@@ -112,7 +112,7 @@ class ResourceProvider:
                     if file_content is not None:
                         decoded_content = file_content.decode("utf-8")
                         profiles = json.loads(decoded_content).get("Profiles", [])
-                        filtered = next(filter(lambda profile: profile.get("Name","") == resource, profiles), None)
+                        filtered = next(filter(lambda profile: profile.get("name","") == resource, profiles), None)
                         if filtered is not None:
                             filtered = self.__translate_keys(filtered)
                             return filtered


### PR DESCRIPTION
# (Python) Property casing fix for vectorization resource provider

## The issue or feature being addressed

The Name property is now name on indexing and embedding profiles.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
