### PR TITLE
RELEASE 0.4.0 - (Python) Read-only resource provider:  make prompt.type optional

### DIFF
--- a/src/python/PythonSDK/foundationallm/models/resource_providers/prompts/prompt.py
+++ b/src/python/PythonSDK/foundationallm/models/resource_providers/prompts/prompt.py
@@ -10,7 +10,7 @@ class Prompt(BaseModel):
     Encapsulates the prompt model from resource provider.
     """
     name: str
-    type: str
+    type: Optional[str] = "multipart"
     object_id: Optional[str] = None
     description: str
     prefix: str

--- a/src/python/PythonSDK/foundationallm/models/resource_providers/prompts/prompt.py
+++ b/src/python/PythonSDK/foundationallm/models/resource_providers/prompts/prompt.py
@@ -10,7 +10,7 @@ class Prompt(BaseModel):
     Encapsulates the prompt model from resource provider.
     """
     name: str
-    type: Optional[str] = "multipart"
+    type: Optional[str] = None
     object_id: Optional[str] = None
     description: str
     prefix: str


### PR DESCRIPTION
# RELEASE 0.4.0 - (Python) Read-only resource provider:  make prompt.type optional

## The issue or feature being addressed

Python read-only resource provider - make prompt.type optional, set default value to None

Fixes #{bug number} (in this specific format)

# Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

