### PR TITLE
Update Default Deployment Sizes

### DIFF
--- a/deploy/standard/bicep/modules/openai.bicep
+++ b/deploy/standard/bicep/modules/openai.bicep
@@ -4,8 +4,8 @@ param actionGroupId string
 
 @description('Model deployment capacity')
 param capacity object = {
-  completions: 1
-  embeddings: 1
+  completions: 60
+  embeddings: 60
 }
 
 @description('Key Vault Name for secrets')
@@ -74,7 +74,7 @@ var deploymentConfig = [
     model: {
       format: 'OpenAI'
       name: 'gpt-35-turbo'
-      version: '0613'  
+      version: '0613'
     }
   }
   {

--- a/deploy/standard/bicep/openai-rg.bicep
+++ b/deploy/standard/bicep/openai-rg.bicep
@@ -33,8 +33,8 @@ param timestamp string = utcNow()
 param vnetId string
 
 param capacity object = {
-  completions: 10
-  embeddings: 10
+  completions: 60
+  embeddings: 60
 }
 
 /** Locals **/


### PR DESCRIPTION
# Increase Default Deployment Sizes

## The issue or feature being addressed

The default deployment sizes are very small, this requires post-deployment update to get a reasonable deployment size.

## Details on the issue fix or feature implementation

This PR updates the default deployment sizes to 60k each.  The exact value can still be overriden using bicep parameters if desired.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable
