### PR TITLE
Update resource locator logic when deleting an agent

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -297,21 +297,25 @@ namespace FoundationaLLM.Agent.ResourceProviders
 
         private async Task DeleteAgent(List<ResourceTypeInstance> instances)
         {
-            if (_agentReferences.TryGetValue(instances.Last().ResourceId!, out var agentReference)
-                || agentReference!.Deleted)
+            if (_agentReferences.TryGetValue(instances.Last().ResourceId!, out var agentReference))
             {
-                agentReference.Deleted = true;
+                if (!agentReference.Deleted)
+                {
+                    agentReference.Deleted = true;
 
-                await _storageService.WriteFileAsync(
-                    _storageContainerName,
-                    AGENT_REFERENCES_FILE_PATH,
-                    JsonSerializer.Serialize(AgentReferenceStore.FromDictionary(_agentReferences.ToDictionary())),
-                    default,
-                    default);
+                    await _storageService.WriteFileAsync(
+                        _storageContainerName,
+                        AGENT_REFERENCES_FILE_PATH,
+                        JsonSerializer.Serialize(AgentReferenceStore.FromDictionary(_agentReferences.ToDictionary())),
+                        default,
+                        default);
+                }
             }
             else
+            {
                 throw new ResourceProviderException($"Could not locate the {instances.Last().ResourceId} agent resource.",
-                            StatusCodes.Status404NotFound);
+                    StatusCodes.Status404NotFound);
+            }
         }
 
         #endregion


### PR DESCRIPTION
# Update resource locator logic when deleting an agent

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

It was throwing a null reference exception and 500 status code if the agent reference was not found instead of a 404.

## Details on the issue fix or feature implementation

Updates the resource locator logic to first check for the agent reference existence, then check for the Deleted property value, rather than checking both at once. This lets the code throw the 404 resource not found exception if the agent reference does not exist.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
