### PR TITLE
Prompt Container fix

### DIFF
--- a/src/python/PythonSDK/foundationallm/hubs/prompt/prompt_resolver.py
+++ b/src/python/PythonSDK/foundationallm/hubs/prompt/prompt_resolver.py
@@ -18,6 +18,13 @@ class PromptResolver(Resolver):
                 path_prefix = f"user-profiles/{user_upn}/"
                 # override the container prefix for private agent lookup
                 self.repository.container_prefix = path_prefix
+
+        if request.prompt_container is None:
+            if hint is None:                        
+                request.prompt_container = "default"
+            else:
+                request.prompt_container = hint.name
+
         response = PromptHubResponse(prompt=
                                  self.repository.get_metadata_by_name(
                                      request.prompt_container + '.' + request.prompt_name)


### PR DESCRIPTION
# Prompt Container fix

## Details on the issue fix or feature implementation

Prompt container value is coming in as None (has a value) therefore default is not used in Pydantic. Added logic to default the container name.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

