### PR TITLE
Sample for vectorizing all files in an Azure Data Lake storage account folder

### DIFF
--- a/samples/vectorization/vectorize-data-lake-folder.ps1
+++ b/samples/vectorization/vectorize-data-lake-folder.ps1
@@ -1,0 +1,88 @@
+
+$developmentEnvironment = $true
+$subscriptioName = "FoundationaLLM Sandbox"
+$keyVaultName = "fllmaks14-kv"
+$appConfigName = "fllmaks14-appconfig"
+
+$vectorizationAPIUrlConfigName = "FoundationaLLM:APIs:VectorizationAPI:APIUrl"
+$vectorizationAPIKeySecretName = "foundationallm-apis-vectorizationapi-apikey"
+# $vectorizationApplicationIdUri = "api://FoundationaLLM-Vectorization"
+
+$vectorizationInputStorageAccountName = "fllmaks14sa"
+$vectorizaitonInputContainerName = "vectorization-input"
+$vectorizationInputFolderPath = "wtw"
+$vectorizationCanonicalRootPath = "wtw"
+
+$contentSourceProfile = "SDZWAJournals3"
+$textPartitionProfile = "DefaultTokenTextPartition_Small_v3"
+$textEmbeddingProfile = "AzureOpenAI_Embedding_v2"
+$indexingProfile = "AzureAISearch_Default_003"
+
+az login
+az account set --subscription $subscriptioName
+
+# $accessToken = (az account get-access-token --resource $vectorizationApplicationIdUri --query accessToken -o tsv)
+
+if ($developmentEnvironment) {
+    $vectorizationAPIUrl = "https://localhost:7047"
+} else {
+    $vectorizationAPIUrl = (az appconfig kv show --name $appConfigName --key $vectorizationAPIUrlConfigName --query value -o tsv)
+}
+$vectorizationAPIKey = (az keyvault secret show --name $vectorizationAPIKeySecretName --vault-name $keyVaultName --query value -o tsv)
+
+
+$filesToVectorize = (az storage fs file list `
+    -f $vectorizaitonInputContainerName `
+    --path $vectorizationInputFolderPath `
+    --account-name $vectorizationInputStorageAccountName `
+    --auth-mode login `
+    --query [].name -o tsv)
+
+foreach ($filePath in $filesToVectorize) {
+    
+    $fileName = Split-Path -Path $filePath -Leaf
+    $fileNameNoExtension = Split-Path -Path $filePath -LeafBase
+    write-host "Vectorizing file: $fileName..."
+
+    
+    write-host $vectorizationRequest
+}
+
+$vectorizationRequest = @"
+    {
+        "content_identifier": {
+            "content_source_profile_name": $contentSourceProfile,
+            "multipart_id": [
+                "$($vectorizationInputStorageAccountName).dfs.core.windows.net",
+                $vectorizaitonInputContainerName,
+                "$($vectorizationInputFolderPath)/$($fileName)"
+            ],
+            "canonical_id": "$($vectorizationCanonicalRootPath)/$($fileNameNoExtension)"
+        },
+        "processing_type": "Asynchronous",
+        "steps":[
+            {
+                "id": "extract",
+                "parameters": {
+                }
+            },
+            {
+                "id": "partition",
+                "parameters": {
+                    "text_partition_profile_name": $textPartitionProfile
+                }
+            },
+            {
+                "id": "embed",
+                "parameters": {
+                    "text_embedding_profile_name": $textEmbeddingProfile
+                }
+            },
+            {
+                "id": "index",
+                "parameters": {
+                    "indexing_profile_name": $indexingProfile
+                }
+            }
+        ]
+    }


### PR DESCRIPTION
# Sample for vectorizing all files in an Azure Data Lake storage account folder

## The issue or feature being addressed

Kickstarting vectorization for the entire (possibly recursive) content of an Azure Data Lake storage account folder is a tedious process when performed on a file by file basis.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
