### PR TITLE
Move production parameter setting before first use

### DIFF
--- a/src/dotnet/AgentFactoryAPI/Program.cs
+++ b/src/dotnet/AgentFactoryAPI/Program.cs
@@ -43,6 +43,8 @@ namespace FoundationaLLM.AgentFactory.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            DefaultAuthentication.Production = builder.Environment.IsProduction();
+
             builder.Configuration.Sources.Clear();
             builder.Configuration.AddJsonFile("appsettings.json", false, true);
             builder.Configuration.AddEnvironmentVariables();
@@ -60,8 +62,6 @@ namespace FoundationaLLM.AgentFactory.API
             });
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-            DefaultAuthentication.Production = builder.Environment.IsProduction();
 
             // Add services to the container.
             // Add the OpenTelemetry telemetry service and send telemetry data to Azure Monitor.

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -39,6 +39,8 @@ namespace FoundationaLLM.Core.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            DefaultAuthentication.Production = builder.Environment.IsProduction();
+
             builder.Configuration.Sources.Clear();
             builder.Configuration.AddJsonFile("appsettings.json", false, true);
             builder.Configuration.AddEnvironmentVariables();
@@ -58,8 +60,6 @@ namespace FoundationaLLM.Core.API
             });
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-            DefaultAuthentication.Production = builder.Environment.IsProduction();
 
             var allowAllCorsOrigins = "AllowAllOrigins";
             builder.Services.AddCors(policyBuilder =>

--- a/src/dotnet/CoreWorker/Program.cs
+++ b/src/dotnet/CoreWorker/Program.cs
@@ -8,6 +8,8 @@ using FoundationaLLM.Core.Worker;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+DefaultAuthentication.Production = builder.Environment.IsProduction();
+
 builder.Configuration.Sources.Clear();
 builder.Configuration.AddJsonFile("appsettings.json", false, true);
 builder.Configuration.AddEnvironmentVariables();

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -38,6 +38,8 @@ namespace FoundationaLLM.Gatekeeper.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            DefaultAuthentication.Production = builder.Environment.IsProduction();
+
             builder.Configuration.Sources.Clear();
             builder.Configuration.AddJsonFile("appsettings.json", false, true);
             builder.Configuration.AddEnvironmentVariables();
@@ -54,8 +56,6 @@ namespace FoundationaLLM.Gatekeeper.API
             });
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-            DefaultAuthentication.Production = builder.Environment.IsProduction();
 
             // Add services to the container.
             // Add the OpenTelemetry telemetry service and send telemetry data to Azure Monitor.

--- a/src/dotnet/ManagementAPI/Program.cs
+++ b/src/dotnet/ManagementAPI/Program.cs
@@ -45,6 +45,8 @@ namespace FoundationaLLM.Management.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            DefaultAuthentication.Production = builder.Environment.IsProduction();
+
             builder.Configuration.Sources.Clear();
             builder.Configuration.AddJsonFile("appsettings.json", false, true);
             builder.Configuration.AddEnvironmentVariables();
@@ -66,8 +68,6 @@ namespace FoundationaLLM.Management.API
 
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-            DefaultAuthentication.Production = builder.Environment.IsProduction();
 
             // Add the Configuration resource provider
             builder.AddConfigurationResourceProvider();

--- a/src/dotnet/SemanticKernelAPI/Program.cs
+++ b/src/dotnet/SemanticKernelAPI/Program.cs
@@ -30,6 +30,8 @@ namespace FoundationaLLM.SemanticKernel.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            DefaultAuthentication.Production = builder.Environment.IsProduction();
+
             builder.Configuration.Sources.Clear();
             builder.Configuration.AddJsonFile("appsettings.json", false, true);
             builder.Configuration.AddEnvironmentVariables();
@@ -52,8 +54,6 @@ namespace FoundationaLLM.SemanticKernel.API
             });
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-            DefaultAuthentication.Production = builder.Environment.IsProduction();
 
             // Add services to the container.
             //builder.Services.AddApplicationInsightsTelemetry();

--- a/src/dotnet/VectorizationAPI/Program.cs
+++ b/src/dotnet/VectorizationAPI/Program.cs
@@ -25,6 +25,8 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 var builder = WebApplication.CreateBuilder(args);
 
+DefaultAuthentication.Production = builder.Environment.IsProduction();
+
 builder.Configuration.Sources.Clear();
 builder.Configuration.AddJsonFile("appsettings.json", false, true);
 builder.Configuration.AddEnvironmentVariables();
@@ -43,8 +45,6 @@ builder.Configuration.AddAzureAppConfiguration(options =>
 });
 if (builder.Environment.IsDevelopment())
     builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-DefaultAuthentication.Production = builder.Environment.IsProduction();
 
 // Add the Configuration resource provider
 builder.AddConfigurationResourceProvider();

--- a/src/dotnet/VectorizationWorker/Program.cs
+++ b/src/dotnet/VectorizationWorker/Program.cs
@@ -26,6 +26,8 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
+DefaultAuthentication.Production = builder.Environment.IsProduction();
+
 builder.Configuration.Sources.Clear();
 builder.Configuration.AddJsonFile("appsettings.json", false, true);
 builder.Configuration.AddEnvironmentVariables();
@@ -45,8 +47,6 @@ builder.Configuration.AddAzureAppConfiguration(options =>
 
 if (builder.Environment.IsDevelopment())
     builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
-
-DefaultAuthentication.Production = builder.Environment.IsProduction();
 
 // Add the Configuration resource provider
 builder.AddConfigurationResourceProvider();


### PR DESCRIPTION
# Move production parameter setting before first use

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes issue in deployed environments where the `DefaultAuthentication.Production` property is accessed before being set.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
