### PR TITLE
Make chat sidebar resizable

### DIFF
--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -1,7 +1,5 @@
 <template>
-		<div class="chat-sidebar" :style="{ width: sidebarWidth }">
-			<!-- Sidebar content -->
-
+	<div class="chat-sidebar">
 		<!-- Sidebar section header -->
 		<div class="chat-sidebar__section-header--mobile">
 			<img v-if="appConfigStore.logoUrl !== ''" :src="$filters.enforceLeadingSlash(appConfigStore.logoUrl)" />
@@ -130,7 +128,6 @@ export default {
 			sessionToDelete: null as Session | null,
 			accountName: '' as string,
 			userName: '' as string,
-			sidebarWidth: '300px',
 		};
 	},
 
@@ -210,13 +207,12 @@ export default {
 
 <style lang="scss" scoped>
 .chat-sidebar {
-	resize: horizontal; /* Allow horizontal resizing */
-	overflow: auto; /* Enable scrolling when content exceeds the sidebar width */
 	width: 300px;
 	max-width: 100%;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	flex: 1;
 	background-color: var(--primary-color);
 	z-index: 3;
 }

--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="chat-sidebar">
+		<div class="chat-sidebar" :style="{ width: sidebarWidth }">
+			<!-- Sidebar content -->
+
 		<!-- Sidebar section header -->
 		<div class="chat-sidebar__section-header--mobile">
 			<img v-if="appConfigStore.logoUrl !== ''" :src="$filters.enforceLeadingSlash(appConfigStore.logoUrl)" />
@@ -128,6 +130,7 @@ export default {
 			sessionToDelete: null as Session | null,
 			accountName: '' as string,
 			userName: '' as string,
+			sidebarWidth: '300px',
 		};
 	},
 
@@ -207,6 +210,8 @@ export default {
 
 <style lang="scss" scoped>
 .chat-sidebar {
+	resize: horizontal; /* Allow horizontal resizing */
+	overflow: auto; /* Enable scrolling when content exceeds the sidebar width */
 	width: 300px;
 	max-width: 100%;
 	height: 100%;

--- a/src/ui/UserPortal/pages/index/index.vue
+++ b/src/ui/UserPortal/pages/index/index.vue
@@ -2,7 +2,10 @@
 	<div class="chat-app">
 		<NavBar />
 		<div class="chat-content">
-			<ChatSidebar v-show="!appStore.isSidebarClosed" class="chat-sidebar" />
+			<div v-show="!appStore.isSidebarClosed" class="chat-sidebar-wrapper" ref="sidebar">
+				<ChatSidebar class="chat-sidebar" :style="{ width: sidebarWidth + 'px' }" />
+				<div class="resize-handle" @mousedown="startResizing"></div>
+			</div>
 			<div v-show="!appStore.isSidebarClosed" class="sidebar-blur" @click="appStore.toggleSidebar" />
 			<ChatThread />
 		</div>
@@ -14,9 +17,44 @@ import { mapStores } from 'pinia';
 import { useAppStore } from '@/stores/appStore';
 export default {
 	name: 'Index',
-
+	data() {
+		return {
+			sidebarWidth: 305,
+		};
+	},
 	computed: {
 		...mapStores(useAppStore),
+	},
+	methods: {
+		startResizing(event) {
+			// Prevent default action and bubbling
+			event.preventDefault();
+			document.addEventListener('mousemove', this.resizeSidebar);
+			document.addEventListener('mouseup', this.stopResizing);
+		},
+		resizeSidebar(event) {
+			const sidebarRect = this.$refs.sidebar.getBoundingClientRect();
+			const minWidth = 305; // Minimum sidebar width
+			const maxWidth = 600; // Maximum sidebar width, adjust as needed
+
+			// Calculate new width based on mouse movement, ensuring it's within the min and max bounds
+			let newWidth = event.clientX - sidebarRect.left;
+
+			// Apply minimum and maximum constraints
+			if (newWidth < minWidth) {
+				newWidth = minWidth;
+			} else if (newWidth > maxWidth) {
+				newWidth = maxWidth;
+			}
+
+			// Update the sidebar width
+			this.sidebarWidth = newWidth;
+			this.$refs.sidebar.style.width = `${this.sidebarWidth}px`;
+		},
+		stopResizing() {
+			document.removeEventListener('mousemove', this.resizeSidebar);
+			document.removeEventListener('mouseup', this.stopResizing);
+		},
 	},
 };
 </script>
@@ -35,6 +73,25 @@ export default {
 	background-color: var(--primary-bg);
 }
 
+.chat-sidebar-wrapper {
+	display: flex;
+	align-items: stretch;
+	flex-direction: row;
+	position: relative;
+	height: 100%;
+}
+
+.resize-handle {
+	z-index: 10;
+	position: absolute;
+	right: 0;
+	top: 0;
+	cursor: col-resize;
+	width: 5px;
+	background-color: #ccc;
+	height: 100%;
+}
+
 @media only screen and (max-width: 620px) {
 	.sidebar-blur {
 		position:absolute;
@@ -49,7 +106,7 @@ export default {
 
 @media only screen and (max-width: 950px) {
     .chat-sidebar {
-        position: absolute;
+        // position: absolute;
 		top: 0px;
         box-shadow: 5px 0px 10px rgba(0, 0, 0, 0.4)
     }


### PR DESCRIPTION
# Make chat sidebar resizable

## Details on the issue fix or feature implementation

Adds a draggable area to the right-hand side of the chat sidebar in the User Portal to allow users to resize it to see more of the chat session titles.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
