### PR TITLE
Python: Incorporate hostname and version in health check endpoints

### DIFF
--- a/src/python/AgentHubAPI/AgentHubAPI.pyproj
+++ b/src/python/AgentHubAPI/AgentHubAPI.pyproj
@@ -14,8 +14,7 @@
     <RootNamespace>AgentHubAPI</RootNamespace>
     <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <Environment>
-    </Environment>
+    <Environment>HOSTNAME=localhost</Environment>
     <IsWindowsApplication>False</IsWindowsApplication>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/python/AgentHubAPI/app/routers/status.py
+++ b/src/python/AgentHubAPI/app/routers/status.py
@@ -4,6 +4,7 @@ Status API endpoint that acts as a health check for the API.
 import os
 from fastapi import APIRouter
 from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from app.dependencies import API_NAME
 
 router = APIRouter(
     prefix='/status',
@@ -22,7 +23,7 @@ async def get_status():
         Object containing the name, instance, version, and status of the API.
     """    
     statusMessage = {
-        "name": "AgentHubAPI",
+        "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"

--- a/src/python/AgentHubAPI/app/routers/status.py
+++ b/src/python/AgentHubAPI/app/routers/status.py
@@ -1,6 +1,7 @@
 """
 Status API endpoint that acts as a health check for the API.
 """
+import os
 from fastapi import APIRouter
 
 router = APIRouter(
@@ -10,13 +11,19 @@ router = APIRouter(
 )
 
 @router.get('')
-async def get_status() -> str:
+async def get_status():
     """
     Retrieves the status of the API.
     
     Returns
     -------
-    string
-        String containing the current status of the API.
-    """
-    return 'ready'
+    JSON
+        Object containing the name, instance, version, and status of the API.
+    """    
+    statusMessage = {
+        "name": "AgentHubAPI",
+        "instance": os.environ["HOSTNAME"],
+        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "Status": "ready"
+    }
+    return statusMessage

--- a/src/python/AgentHubAPI/app/routers/status.py
+++ b/src/python/AgentHubAPI/app/routers/status.py
@@ -3,6 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
+from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 
 router = APIRouter(
     prefix='/status',
@@ -22,8 +23,8 @@ async def get_status():
     """    
     statusMessage = {
         "name": "AgentHubAPI",
-        "instance": os.environ["HOSTNAME"],
-        "version": os.environ["FOUNDATIONALLM_VERSION"],
-        "Status": "ready"
+        "instance": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
     }
     return statusMessage

--- a/src/python/DataSourceHubAPI/DataSourceHubAPI.pyproj
+++ b/src/python/DataSourceHubAPI/DataSourceHubAPI.pyproj
@@ -18,8 +18,7 @@
     <IsWindowsApplication>False</IsWindowsApplication>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
-    <Environment>
-    </Environment>
+    <Environment>HOSTNAME=localhost</Environment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/python/DataSourceHubAPI/app/routers/status.py
+++ b/src/python/DataSourceHubAPI/app/routers/status.py
@@ -4,6 +4,7 @@ Status API endpoint that acts as a health check for the API.
 import os
 from fastapi import APIRouter
 from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from app.dependencies import API_NAME
 
 router = APIRouter(
     prefix='/status',
@@ -22,7 +23,7 @@ async def get_status():
         Object containing the name, instance, version, and status of the API.
     """    
     statusMessage = {
-        "name": "DataSourceHubAPI",
+        "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"

--- a/src/python/DataSourceHubAPI/app/routers/status.py
+++ b/src/python/DataSourceHubAPI/app/routers/status.py
@@ -1,6 +1,7 @@
 """
 Status API endpoint that acts as a health check for the API.
 """
+import os
 from fastapi import APIRouter
 
 router = APIRouter(
@@ -16,7 +17,13 @@ async def get_status():
     
     Returns
     -------
-    string
-        String containing the current status of the API.
-    """
-    return 'ready'
+    JSON
+        Object containing the name, instance, version, and status of the API.
+    """    
+    statusMessage = {
+        "name": "DataSourceHubAPI",
+        "instance": os.environ["HOSTNAME"],
+        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "Status": "ready"
+    }
+    return statusMessage

--- a/src/python/DataSourceHubAPI/app/routers/status.py
+++ b/src/python/DataSourceHubAPI/app/routers/status.py
@@ -3,6 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
+from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 
 router = APIRouter(
     prefix='/status',
@@ -22,8 +23,8 @@ async def get_status():
     """    
     statusMessage = {
         "name": "DataSourceHubAPI",
-        "instance": os.environ["HOSTNAME"],
-        "version": os.environ["FOUNDATIONALLM_VERSION"],
-        "Status": "ready"
+        "instance": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
     }
     return statusMessage

--- a/src/python/GatekeeperIntegrationAPI/GatekeeperIntegrationAPI.pyproj
+++ b/src/python/GatekeeperIntegrationAPI/GatekeeperIntegrationAPI.pyproj
@@ -15,6 +15,7 @@
     <IsWindowsApplication>False</IsWindowsApplication>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
+    <Environment>HOSTNAME=localhost</Environment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -4,6 +4,7 @@ Status API endpoint that acts as a health check for the API.
 import os
 from fastapi import APIRouter
 from foundationallm.integration.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from app.dependencies import API_NAME
 
 router = APIRouter(
     prefix='/status',
@@ -22,7 +23,7 @@ async def get_status():
         Object containing the name, instance, version, and status of the API.
     """    
     statusMessage = {
-        "name": "GatekeeperIntegrationAPI",
+        "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"

--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -3,6 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
+from foundationallm.integration.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 
 router = APIRouter(
     prefix='/status',
@@ -22,8 +23,8 @@ async def get_status():
     """    
     statusMessage = {
         "name": "GatekeeperIntegrationAPI",
-        "instance": os.environ["HOSTNAME"],
-        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "instance": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"
     }
     return statusMessage

--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -26,6 +26,6 @@ async def get_status():
         "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
-        "Status": "ready"
+        "status": "ready"
     }
     return statusMessage

--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -1,6 +1,7 @@
 """
 Status API endpoint that acts as a health check for the API.
 """
+import os
 from fastapi import APIRouter
 
 router = APIRouter(
@@ -10,13 +11,19 @@ router = APIRouter(
 )
 
 @router.get('')
-async def get_status() -> str:
+async def get_status():
     """
     Retrieves the status of the API.
     
     Returns
     -------
-    string
-        String containing the current status of the API.
-    """
-    return 'ready'
+    JSON
+        Object containing the name, instance, version, and status of the API.
+    """    
+    statusMessage = {
+        "name": "GatekeeperIntegrationAPI",
+        "instance": os.environ["HOSTNAME"],
+        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "Status": "ready"
+    }
+    return statusMessage

--- a/src/python/IntegrationSDK/IntegrationSDK.pyproj
+++ b/src/python/IntegrationSDK/IntegrationSDK.pyproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="foundationallm\integration\config\configuration.py" />
+    <Compile Include="foundationallm\integration\config\environment_variables.py" />
     <Compile Include="foundationallm\integration\config\__init__.py" />
     <Compile Include="foundationallm\integration\models\analyze_request.py" />
     <Compile Include="foundationallm\integration\models\analyze_response.py" />

--- a/src/python/IntegrationSDK/foundationallm/integration/config/environment_variables.py
+++ b/src/python/IntegrationSDK/foundationallm/integration/config/environment_variables.py
@@ -1,0 +1,14 @@
+"""
+Environment variable key constants
+"""
+
+"""
+The Azure Container App or Azure Kubernetes Service hostname.
+"""
+HOSTNAME = "HOSTNAME"
+
+"""
+The build version of the container. This is also used for the app version used
+to validate the minimum version of the app required to use certain configuration entries.
+"""
+FOUNDATIONALLM_VERSION = "FOUNDATIONALLM_VERSION"

--- a/src/python/LangChainAPI/LangChainAPI.pyproj
+++ b/src/python/LangChainAPI/LangChainAPI.pyproj
@@ -22,8 +22,7 @@
     <TestFramework>none</TestFramework>
     <UnitTestPattern>test*.py</UnitTestPattern>
     <UnitTestRootDirectory>.</UnitTestRootDirectory>
-    <Environment>
-    </Environment>
+    <Environment>HOSTNAME=localhost</Environment>
     <SuppressPackageInstallationPrompt>True</SuppressPackageInstallationPrompt>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -1,6 +1,7 @@
 """
 Status API endpoint that acts as a health check for the API.
 """
+import os
 from fastapi import APIRouter
 
 router = APIRouter(
@@ -10,13 +11,19 @@ router = APIRouter(
 )
 
 @router.get('')
-async def get_status() -> str:
+async def get_status():
     """
     Retrieves the status of the API.
     
     Returns
     -------
-    string
-        String containing the current status of the API.
-    """
-    return 'ready'
+    JSON
+        Object containing the name, instance, version, and status of the API.
+    """    
+    statusMessage = {
+        "name": "LangChainAPI",
+        "instance": os.environ["HOSTNAME"],
+        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "Status": "ready"
+    }
+    return statusMessage

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -26,6 +26,6 @@ async def get_status():
         "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
-        "Status": "ready"
+        "status": "ready"
     }
     return statusMessage

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -4,6 +4,7 @@ Status API endpoint that acts as a health check for the API.
 import os
 from fastapi import APIRouter
 from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from app.dependencies import API_NAME
 
 router = APIRouter(
     prefix='/status',
@@ -22,7 +23,7 @@ async def get_status():
         Object containing the name, instance, version, and status of the API.
     """    
     statusMessage = {
-        "name": "LangChainAPI",
+        "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -3,6 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
+from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 
 router = APIRouter(
     prefix='/status',
@@ -22,8 +23,8 @@ async def get_status():
     """    
     statusMessage = {
         "name": "LangChainAPI",
-        "instance": os.environ["HOSTNAME"],
-        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "instance": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"
     }
     return statusMessage

--- a/src/python/PromptHubAPI/PromptHubAPI.pyproj
+++ b/src/python/PromptHubAPI/PromptHubAPI.pyproj
@@ -14,8 +14,7 @@
     <RootNamespace>PromptHubAPI</RootNamespace>
     <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <Environment>
-    </Environment>
+    <Environment>HOSTNAME=localhost</Environment>
     <IsWindowsApplication>False</IsWindowsApplication>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -26,6 +26,6 @@ async def get_status():
         "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
-        "Status": "ready"
+        "status": "ready"
     }
     return statusMessage

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -4,6 +4,7 @@ Status API endpoint that acts as a health check for the API.
 import os
 from fastapi import APIRouter
 from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from app.dependencies import API_NAME
 
 router = APIRouter(
     prefix='/status',
@@ -22,7 +23,7 @@ async def get_status():
         Object containing the name, instance, version, and status of the API.
     """    
     statusMessage = {
-        "name": "PromptHubAPI",
+        "name": API_NAME,
         "instance": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -1,6 +1,7 @@
 """
 Status API endpoint that acts as a health check for the API.
 """
+import os
 from fastapi import APIRouter
 
 router = APIRouter(
@@ -10,13 +11,19 @@ router = APIRouter(
 )
 
 @router.get('')
-async def get_status() -> str:
+async def get_status():
     """
     Retrieves the status of the API.
     
     Returns
     -------
-    string
-        String containing the current status of the API.
-    """
-    return 'ready'
+    JSON
+        Object containing the name, instance, version, and status of the API.
+    """    
+    statusMessage = {
+        "name": "PromptHubAPI",
+        "instance": os.environ["HOSTNAME"],
+        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "Status": "ready"
+    }
+    return statusMessage

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -3,6 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
+from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 
 router = APIRouter(
     prefix='/status',
@@ -22,8 +23,8 @@ async def get_status():
     """    
     statusMessage = {
         "name": "PromptHubAPI",
-        "instance": os.environ["HOSTNAME"],
-        "version": os.environ["FOUNDATIONALLM_VERSION"],
+        "instance": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
         "Status": "ready"
     }
     return statusMessage

--- a/src/python/PythonSDK/PythonSDK.pyproj
+++ b/src/python/PythonSDK/PythonSDK.pyproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="foundationallm\config\context.py" />
+    <Compile Include="foundationallm\config\environment_variables.py" />
     <Compile Include="foundationallm\config\user_identity.py" />
     <Compile Include="foundationallm\hubs\data_source\data_sources\cxo\cxo_data_source_metadata.py" />
     <Compile Include="foundationallm\hubs\data_source\data_sources\cxo\__init__.py" />

--- a/src/python/PythonSDK/foundationallm/config/environment_variables.py
+++ b/src/python/PythonSDK/foundationallm/config/environment_variables.py
@@ -1,0 +1,14 @@
+"""
+Environment variable key constants
+"""
+
+"""
+The Azure Container App or Azure Kubernetes Service hostname.
+"""
+HOSTNAME = "HOSTNAME"
+
+"""
+The build version of the container. This is also used for the app version used
+to validate the minimum version of the app required to use certain configuration entries.
+"""
+FOUNDATIONALLM_VERSION = "FOUNDATIONALLM_VERSION"


### PR DESCRIPTION
# Python: Incorporate hostname and version in health check endpoints


## Details on the issue fix or feature implementation

Incorporate hostname and version in health check endpoints

Adds HOSTNAME environment variable directly in project environment variables (for local development)

Modifies status endpoint response with JSON object containing name, instance, version, and status.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
