### PR TITLE
Updated KV role assignment type

### DIFF
--- a/deploy/starter/infra/shared/keyvault.bicep
+++ b/deploy/starter/infra/shared/keyvault.bicep
@@ -19,7 +19,7 @@ resource adminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   properties: {
     principalId: principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefiniitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
-    principalType: 'User'
+    principalType: 'servicePrincipal'
   }
 }
 


### PR DESCRIPTION
# Updated KV role assignment type

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

Currently, Key Vault fails to make a role assignment to a Service Principal because the `principalType` key is set incorrectly.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable