### PR TITLE
KM Agent support for list of indexing profiles in configuration for .NET

### DIFF
--- a/src/dotnet/Agent/Validation/Metadata/KnowledgeManagementAgentValidator.cs
+++ b/src/dotnet/Agent/Validation/Metadata/KnowledgeManagementAgentValidator.cs
@@ -15,7 +15,7 @@ namespace FoundationaLLM.Agent.Validation.Metadata
         {
             Include(new AgentBaseValidator());
 
-            RuleFor(x => x.IndexingProfileObjectId).NotEmpty().WithMessage("Indexing profile is required for Knowledge Management Agents.");
+            RuleFor(x => x.IndexingProfileObjectIds).NotEmpty().WithMessage("Indexing profile is required for Knowledge Management Agents.");
             RuleFor(x => x.TextEmbeddingProfileObjectId).NotEmpty().WithMessage("Embedding profile is required for Knowledge Management Agents.");
         }
     }

--- a/src/dotnet/Common/Models/Agents/KnowledgeManagementAgent.cs
+++ b/src/dotnet/Common/Models/Agents/KnowledgeManagementAgent.cs
@@ -16,8 +16,8 @@ namespace FoundationaLLM.Common.Models.Agents
         /// <summary>
         /// The vectorization indexing profile resource path.
         /// </summary>
-        [JsonPropertyName("indexing_profile_object_id")]
-        public string? IndexingProfileObjectId { get; set; }
+        [JsonPropertyName("indexing_profile_object_ids")]
+        public List<string>? IndexingProfileObjectIds { get; set; }
 
         /// <summary>
         /// The vectorization text embedding profile resource path.

--- a/src/dotnet/SemanticKernel/Plugins/KnowledgeManagementAgentPlugin.cs
+++ b/src/dotnet/SemanticKernel/Plugins/KnowledgeManagementAgentPlugin.cs
@@ -33,7 +33,9 @@ namespace FoundationaLLM.SemanticKernel.Core.Plugins
             var internalContext = true;
             var messageHistoryEnabled = false;
 
-            if (request.Agent.IndexingProfileObjectId != null && request.Agent.TextEmbeddingProfileObjectId != null)
+            if (request.Agent.IndexingProfileObjectIds != null
+                && request.Agent.IndexingProfileObjectIds.Count > 0
+                && request.Agent.TextEmbeddingProfileObjectId != null)
             {
                 internalContext = false;
             }

--- a/tests/dotnet/Common.Tests/Models/Agents/KnowledgeManagementAgentTests.cs
+++ b/tests/dotnet/Common.Tests/Models/Agents/KnowledgeManagementAgentTests.cs
@@ -18,7 +18,7 @@ namespace FoundationaLLM.Common.Tests.Models.Agents
         public void KnowledgeManagementAgent_IndexingProfile_DefaultIsNull()
         {
             // Assert
-            Assert.Null(_knowledgeManagementAgent.IndexingProfileObjectId);
+            Assert.Null(_knowledgeManagementAgent.IndexingProfileObjectIds);
         }
 
         [Fact]


### PR DESCRIPTION
# Add support for list of indexing profiles in KM Agent configuration in .NET

## The issue or feature being addressed

The Knowledge Management Agent supports a single indexing profile. 

## Details on the issue fix or feature implementation

Adds support for multiple indexing profiles for the Knowledge Management Agent

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
