### PR TITLE
Replace API Key with Managed Identity for Azure AI Content Safety

### DIFF
--- a/src/dotnet/Gatekeeper/Gatekeeper.csproj
+++ b/src/dotnet/Gatekeeper/Gatekeeper.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Azure.AI.ContentSafety" Version="1.0.0-beta.1" />
+    <PackageReference Include="Azure.AI.ContentSafety" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replace API Key with Managed Identity for Azure AI Content Safety

## The issue or feature being addressed

Removal of API Keys where alternatives exist

## Details on the issue fix or feature implementation

Updated the Azure.AI.ContentSafety package to the latest version
Replaced AzureKeyCredential with DefaultAuthentication.GetAzureCredential()

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
