### PR TITLE
Fix typo in Prompt Hub API router

### DIFF
--- a/src/python/PromptHubAPI/PromptHubAPI.pyproj
+++ b/src/python/PromptHubAPI/PromptHubAPI.pyproj
@@ -16,6 +16,7 @@
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>HOSTNAME=localhost</Environment>
     <IsWindowsApplication>False</IsWindowsApplication>
+    <SuppressPackageInstallationPrompt>True</SuppressPackageInstallationPrompt>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/python/PromptHubAPI/app/routers/resolve.py
+++ b/src/python/PromptHubAPI/app/routers/resolve.py
@@ -1,4 +1,4 @@
-AgentHi8"""
+"""
 The API endpoint for returning the appropriate agent prompt for the specified user prompt.
 """
 from typing import Optional


### PR DESCRIPTION
# Fix typo in Prompt Hub API router

## The issue or feature being addressed

A typo in the Prompt Hub API router prevents the service from starting.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
