### PR TITLE
Fix Variable Substitution for Resource Provider Templates

### DIFF
--- a/deploy/starter/data/role-assignments/.gitignore
+++ b/deploy/starter/data/role-assignments/.gitignore
@@ -1,1 +1,5 @@
-DefaultRoleAssignments.json
+# Ignore everything
+*
+# Except these files
+!.gitignore
+!**.template.*

--- a/deploy/starter/test-hook.ps1
+++ b/deploy/starter/test-hook.ps1
@@ -1,0 +1,33 @@
+#!/usr/bin/env pwsh
+
+Param(
+    [Parameter(Mandatory = $true)][string]$envValues
+)
+
+Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+function Set-EnvironmentVariables {
+    param(
+        [Parameter(Mandatory = $true)][string]$envFile
+    )
+
+    if (!(Test-Path $envFile -PathType Leaf)) {
+        throw "$envFile is not a file."
+    }
+
+    Get-Content $envFile | `
+        Where-Object { -not $_.StartsWith('#') } | `
+        ForEach-Object `
+    {
+        $name, $value = $_.split('=')
+        $value = $value.Trim('"')
+        Set-Content env:\$name $value
+        Write-Host "Wrote ${value} to environment variable ${name}." -ForegroundColor Green
+    }
+}
+
+
+Set-EnvironmentVariables -envFile $envValues
+. ./azd-hooks/postprovision.ps1


### PR DESCRIPTION
# Fix variable substitution for resource provider templates

## The issue or feature being addressed

The post-provisioning script did not use `envsubst` on the resource provider templates.

The resource provider templates did not render correctly because they contained multiple lines.

## Details on the issue fix or feature implementation

The PR updates the postprovision script to treat all templates as multiline templates (since this also works for single lines).  

The PR refactors the script to handle all substitutions using two shared strategies.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
