### PR TITLE
Rename the AppConfig connection string environment variable

### DIFF
--- a/docs/development/development-local.md
+++ b/docs/development/development-local.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Environment variables:
-  - Create an environment variable for the Application Configuration Service connection string named `FoundationaLLM:AppConfig:ConnectionString`. This is used by the .NET projects.
+  - Create an environment variable for the Application Configuration Service connection string named `FoundationaLLM_AppConfig_ConnectionString`. This is used by the .NET projects.
   - Create an environment variable for the Application Configuration Service URI named `foundationallm-app-configuration-uri`. This is used by the Python projects.
   - Create an environment variable named `FOUNDATIONALLM_VERSION` and set it to the version of the FoundationaLLM deployment you are working with. This is used by the .NET projects to validate your environment configuration based on the version.
 
@@ -37,7 +37,7 @@ The `UserPortal` project is a Vue.js (Nuxt) project. To configure it to run loca
 
 1. Open the `/src/ui/UserPortal` folder in Visual Studio Code.
 2. Copy the `.env.example` file in the root directory to a new file named `.env` and update the values:
-   1. The `APP_CONFIG_ENDPOINT` value should be the Connection String for the Azure App Configuration service. This should be the same value as the `FoundationaLLM:AppConfig:ConnectionString` environment variable.
+   1. The `APP_CONFIG_ENDPOINT` value should be the Connection String for the Azure App Configuration service. This should be the same value as the `FoundationaLLM_AppConfig_ConnectionString` environment variable.
    2. The `LOCAL_API_URL` should be the URL of the local Core API service (https://localhost:63279). **Important:** Only set this value if you wish to debug the entire solution locally and bypass the App Config service value for the CORE API URL. If you do not wish to debug the entire solution locally, leave this value empty or comment it out.
 
 ### Management Portal
@@ -46,7 +46,7 @@ The `ManagementPortal` project is a Vue.js (Nuxt) project. To configure it to ru
 
 1. Open the `/src/ui/ManagementPortal` folder in Visual Studio Code.
 2. Copy the `.env.example` file in the root directory to a new file named `.env` and update the values:
-   1. The `APP_CONFIG_ENDPOINT` value should be the Connection String for the Azure App Configuration service. This should be the same value as the `FoundationaLLM:AppConfig:ConnectionString` environment variable.
+   1. The `APP_CONFIG_ENDPOINT` value should be the Connection String for the Azure App Configuration service. This should be the same value as the `FoundationaLLM_AppConfig_ConnectionString` environment variable.
    2. The `LOCAL_API_URL` should be the URL of the local Management API service (https://localhost:63267). **Important:** Only set this value if you wish to debug the entire solution locally and bypass the App Config service value for the MANAGEMENT API URL. If you do not wish to debug the entire solution locally, leave this value empty or comment it out.
 
 ## .NET projects

--- a/docs/setup-guides/vectorization/vectorization-configuration.md
+++ b/docs/setup-guides/vectorization/vectorization-configuration.md
@@ -18,7 +18,7 @@ The following table describes the environment variables required for the vectori
 
 Environment variable | Description
 --- | ---
-`FoundationaLLM:AppConfig:ConnectionString` | Connection string to the Azure App Configuration instance.
+`FoundationaLLM_AppConfig_ConnectionString` | Connection string to the Azure App Configuration instance.
 
 The following table describes the required configuration parameters for the vectorization pipelines.
 
@@ -52,7 +52,7 @@ The following table describes the environment variables required for the vectori
 
 | Environment variable | Description |
 | --- | --- |
-| `FoundationaLLM:AppConfig:ConnectionString` | Connection string to the Azure App Configuration instance. |
+| `FoundationaLLM_AppConfig_ConnectionString` | Connection string to the Azure App Configuration instance. |
 
 The following table describes the required App Configuration parameters for the vectorization pipelines.
 

--- a/src/dotnet/Common/Constants/EnvironmentVariables.cs
+++ b/src/dotnet/Common/Constants/EnvironmentVariables.cs
@@ -20,7 +20,7 @@
         /// The key for the FoundationaLLM:AppConfig:ConnectionString environment variable.
         /// This allows the caller to connect to the Azure App Configuration service.
         /// </summary>
-        public const string FoundationaLLM_AppConfig_ConnectionString = "FoundationaLLM:AppConfig:ConnectionString";
+        public const string FoundationaLLM_AppConfig_ConnectionString = "FoundationaLLM_AppConfig_ConnectionString";
 
         /// <summary>
         /// They key for the FoundationaLLM:Configuration:KeyVaultURI environment variable.


### PR DESCRIPTION
# Rename the AppConfig connection string environment variable

## The issue or feature being addressed

Variable name is incompatible with some OS environments.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
