### PR TITLE
Adding CosmosDB SQL roles assignments to Core API and Core Worker services in Standard deployment

### DIFF
--- a/deploy/standard/bicep/modules/service.bicep
+++ b/deploy/standard/bicep/modules/service.bicep
@@ -54,6 +54,7 @@ var kvServiceType = 'kv'
 /** Outputs **/
 @description('Service Managed Identity Client Id.')
 output serviceClientId string = managedIdentity.properties.clientId
+output servicePrincipalId string = managedIdentity.properties.principalId
 
 @description('Service Api Key Secret KeyVault Uri.')
 #disable-next-line outputs-should-not-contain-secrets

--- a/deploy/standard/bicep/modules/sqlRoleAssignments.bicep
+++ b/deploy/standard/bicep/modules/sqlRoleAssignments.bicep
@@ -1,0 +1,32 @@
+@description('Principal ID to assign roles to.')
+param principalId string
+
+@description('Roles to assign.')
+param roleDefinitionIds object
+
+@description('CosmosDB Resource Id')
+param accountName string
+
+resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' existing = {
+  name: accountName
+}
+
+/** Locals **/
+@description('Role Assignments to create')
+var roleAssignmentsToCreate = [for roleDefinitionId in items(roleDefinitionIds): {
+  name: guid(principalId, resourceGroup().id, roleDefinitionId.value)
+  roleDefinitionId: roleDefinitionId.value
+}]
+
+/** Resources **/
+resource roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2023-11-15' = [
+  for roleAssignmentToCreate in roleAssignmentsToCreate: {
+    name: guid(roleAssignmentToCreate.roleDefinitionId, principalId, cosmosDb.id)
+    parent: cosmosDb
+    properties: {
+      principalId: principalId
+      roleDefinitionId: resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', cosmosDb.name, roleAssignmentToCreate.roleDefinitionId)
+      scope: cosmosDb.id
+    }
+  }
+]


### PR DESCRIPTION
# Adding CosmosDB SQL roles assignments to Core API and Core Worker services in Standard deployment

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

