### PR TITLE
Remove unused app config references

### DIFF
--- a/deploy/standard/config/appconfig.template.json
+++ b/deploy/standard/config/appconfig.template.json
@@ -1128,13 +1128,6 @@
         "tags": {}
       },
       {
-        "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:APIKey",
-        "value": "{\"uri\":\"{{keyvaultUri}}secrets/search-key\"}",
-        "label": null,
-        "content_type": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
-        "tags": {}
-      },
-      {
         "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:AuthenticationType",
         "value": "APIKey",
         "label": null,
@@ -1146,13 +1139,6 @@
         "value": "{{cognitiveSearchEndpointUri}}",
         "label": null,
         "content_type": "",
-        "tags": {}
-      },
-      {
-        "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:QueryAPIKey",
-        "value": "{\"uri\":\"{{keyvaultUri}}secrets/search-key\"}",
-        "label": null,
-        "content_type": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
         "tags": {}
       },
       {

--- a/deploy/starter/config/appconfig.template.json
+++ b/deploy/starter/config/appconfig.template.json
@@ -1135,13 +1135,6 @@
       "tags": {}
     },
     {
-      "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:APIKey",
-      "value": "{\"uri\":\"${env:AZURE_KEY_VAULT_ENDPOINT}secrets/search-key\"}",
-      "label": null,
-      "content_type": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
-      "tags": {}
-    },
-    {
       "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:AuthenticationType",
       "value": "APIKey",
       "label": null,
@@ -1153,13 +1146,6 @@
       "value": "${env:AZURE_COGNITIVE_SEARCH_ENDPOINT}",
       "label": null,
       "content_type": "",
-      "tags": {}
-    },
-    {
-      "key": "FoundationaLLM:Vectorization:AzureAISearchIndexingService:QueryAPIKey",
-      "value": "{\"uri\":\"${env:AZURE_KEY_VAULT_ENDPOINT}secrets/search-key\"}",
-      "label": null,
-      "content_type": "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
       "tags": {}
     },
     {

--- a/docs/deployment/app-configuration-values.md
+++ b/docs/deployment/app-configuration-values.md
@@ -172,13 +172,7 @@ FoundationaLLM uses Azure App Configuration to store configuration values, Key V
 | `FoundationaLLM:Events:AzureEventGridEventService:Profiles:VectorizationAPI` | | FLLM eventing infrastructure configuration for the Vectorization API. |
 | `FoundationaLLM:Events:AzureEventGridEventService:Profiles:VectorizationWorker` | | FLLM eventing infrastructure configuration for the Vectorization Worker. |
 | `FoundationaLLM:Configuration:ResourceProviderService:Storage:AuthenticationType` | | The authentication type used to connect to the underlying storage. Can be one of `AzureIdentity`, `AccountKey`, or `ConnectionString`. |
-| `FoundationaLLM:Configuration:ResourceProviderService:Storage:ConnectionString` | Key Vault secret name: `foundationallm-configuration-resourceprovider-storage-connectionstring` | This is a Key Vault reference. |
-| `FoundationaLLM:Vectorization:AzureAISearchIndexingService:AuthenticationType` | `APIKey` | |
-| `FoundationaLLM:Vectorization:AzureAISearchIndexingService:APIKey` | Key Vault secret name: `search-key` | This is a Key Vault reference. |
 | `FoundationaLLM:Vectorization:AzureAISearchIndexingService:Endpoint` | | Azure AI Search service endpoint. |
-| `FoundationaLLM:Vectorization:AzureAISearchIndexingService:QueryAPIKey` | Key Vault secret name: `search-key` | This is a Key Vault reference. |
-| `FoundationaLLM:Vectorization:ContentSources:DefaultAzureDataLake:AuthenticationType` | `ConnectionString` | This is a Key Vault reference. |
-| `FoundationaLLM:Vectorization:ContentSources:DefaultAzureDataLake:ConnectionString` | Key Vault secret name: `search-key` | This is a Key Vault reference. |
 | `FoundationaLLM:Vectorization:SemanticKernelTextEmbeddingService:APIVersion` | `2023-05-15` | |
 | `FoundationaLLM:Vectorization:SemanticKernelTextEmbeddingService:DeploymentName` | `embeddings` | |
 | `FoundationaLLM:Vectorization:SemanticKernelTextEmbeddingService:Endpoint` | Enter the URL to the service. | |


### PR DESCRIPTION
# Remove unused app config references

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Removes references to a Key Vault secret (`search-key`) that is no longer used. Also removes unused App Config settings and their documentation.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
