### PR TITLE
Rename Environment Variables in Quick Start Deployment

### DIFF
--- a/deploy/starter/infra/main.bicep
+++ b/deploy/starter/infra/main.bicep
@@ -480,7 +480,7 @@ module authAcaService './app/authAcaService.bicep' = {
     imageName: authService.image
     envSettings: [
       {
-        name: 'FoundationaLLM__AuthorizationAPI__KeyVaultUri'
+        name: 'FoundationaLLM_AuthorizationAPI_KeyVaultURI'
         value: authKeyvault.outputs.endpoint
       }
     ]

--- a/deploy/starter/infra/main.parameters.json
+++ b/deploy/starter/infra/main.parameters.json
@@ -96,7 +96,8 @@
     "authService": {
       "value": {
         "name": "auth-api",
-        "image": "cropseastus2svinternal.azurecr.io/auth-api:prerelease-050"
+        "image": "cropseastus2svinternal.azurecr.io/auth-api:release-050-20240320",
+        "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString"
       }
     },
     "services": {
@@ -105,15 +106,15 @@
           "name": "agent-factory-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/agentfactory-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/agentfactory-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-agentfactoryapi-apikey"
         },
         {
           "name": "agent-hub-api",
           "useEndpoint": true,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/agenthub-api:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/agenthub-api:release-050-20240320",
           "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
           "apiKeySecretName": "foundationallm-apis-agenthubapi-apikey"
         },
@@ -121,7 +122,7 @@
           "name": "chat-ui",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/chat-ui:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/chat-ui:release-050-20240320",
           "appConfigEnvironmentVarName": "NUXT_APP_CONFIG_ENDPOINT",
           "apiKeySecretName": "foundationallm-apis-chatui-apikey"
         },
@@ -129,23 +130,23 @@
           "name": "core-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/core-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/core-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-coreapi-apikey"
         },
         {
           "name": "core-job",
           "useEndpoint": false,
           "hasIngress": false,
-          "image": "cropseastus2svinternal.azurecr.io/core-job:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/core-job:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-corejob-apikey"
         },
         {
           "name": "data-source-hub-api",
           "useEndpoint": true,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/datasourcehub-api:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/datasourcehub-api:release-050-20240320",
           "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
           "apiKeySecretName": "foundationallm-apis-datasourcehubapi-apikey"
         },
@@ -153,15 +154,15 @@
           "name": "gatekeeper-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/gatekeeper-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/gatekeeper-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-gatekeeperapi-apikey"
         },
         {
           "name": "gatekeeper-integration-api",
           "useEndpoint": true,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/gatekeeperintegration-api:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/gatekeeperintegration-api:release-050-20240320",
           "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
           "apiKeySecretName": "foundationallm-apis-gatekeeperintegrationapi-apikey"
         },
@@ -169,7 +170,7 @@
           "name": "langchain-api",
           "useEndpoint": true,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/langchain-api:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/langchain-api:release-050-20240320",
           "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
           "apiKeySecretName": "foundationallm-apis-langchainapi-apikey"
         },
@@ -177,15 +178,15 @@
           "name": "management-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/management-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/management-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-managementapi-apikey"
         },
         {
           "name": "management-ui",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/management-ui:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/management-ui:release-050-20240320",
           "appConfigEnvironmentVarName": "NUXT_APP_CONFIG_ENDPOINT",
           "apiKeySecretName": "foundationallm-apis-managementui-apikey"
         },
@@ -193,7 +194,7 @@
           "name": "prompt-hub-api",
           "useEndpoint": true,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/prompthub-api:prerelease-050",
+          "image": "cropseastus2svinternal.azurecr.io/prompthub-api:release-050-20240320",
           "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
           "apiKeySecretName": "foundationallm-apis-prompthubapi-apikey"
         },
@@ -201,24 +202,24 @@
           "name": "semantic-kernel-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/semantickernel-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/semantickernel-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-semantickernelapi-apikey"
         },
         {
           "name": "vectorization-api",
           "useEndpoint": false,
           "hasIngress": true,
-          "image": "cropseastus2svinternal.azurecr.io/vectorization-api:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/vectorization-api:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-vectorizationapi-apikey"
         },
         {
           "name": "vectorization-job",
           "useEndpoint": false,
           "hasIngress": false,
-          "image": "cropseastus2svinternal.azurecr.io/vectorization-job:prerelease-050",
-          "appConfigEnvironmentVarName": "FoundationaLLM__AppConfig__ConnectionString",
+          "image": "cropseastus2svinternal.azurecr.io/vectorization-job:release-050-20240320",
+          "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
           "apiKeySecretName": "foundationallm-apis-vectorizationworker-apikey"
         }
       ]


### PR DESCRIPTION
# Rename Environment Variables in Quick Start Deployment

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

This PR corrects the names of the `FoundationaLLM__AuthorizationAPI__KeyVaultUri` and `FoundationaLLM__AppConfig__ConnectionString` environment variables.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable