### PR TITLE
Moving Cognitive Search role assignments outside of acaService.bicep and adding the Search Index Data Contributor role to the vectorization services

### DIFF
--- a/deploy/starter/infra/app/acaService.bicep
+++ b/deploy/starter/infra/app/acaService.bicep
@@ -4,7 +4,6 @@ param tags object = {}
 
 param appConfigName string
 param eventgridName string
-param cogsearchName string
 param identityName string
 param keyvaultName string
 param storageAccountName string
@@ -226,22 +225,6 @@ resource apiKey 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = [
     }
   }
 ]
-
-resource search 'Microsoft.Search/searchServices@2022-09-01' existing = {
-  name: cogsearchName
-}
-
-resource searchIndexDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: search
-  name: guid(subscription().id, resourceGroup().id, identity.id, 'searchIndexDataReaderRole')
-  properties: {
-    roleDefinitionId: subscriptionResourceId(
-      'Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f')
-    principalType: 'ServicePrincipal'
-    principalId: identity.properties.principalId
-  }
-}
-
 
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
 output name string = app.name

--- a/deploy/starter/infra/main.bicep
+++ b/deploy/starter/infra/main.bicep
@@ -231,6 +231,42 @@ module cogSearch './shared/search.bicep' = {
   scope: rg
 }
 
+var searchReaderRoleTargets = [
+  'langchain-api'
+  'semantic-kernel-api'
+]
+
+var searchWriterRoleTargets = [
+  'vectorization-api'
+  'vectorization-job'
+]
+
+module searchReaderRoles './shared/roleAssignments.bicep' = [
+  for target in searchReaderRoleTargets: {
+    scope: rg
+    name: '${target}-search-reader-role'
+    params: {
+      principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
+      roleDefinitionIds: {
+        'Search Index Data Reader': '1407120a-92aa-4202-b7e9-c0e197c71c8f'
+      }
+    }
+  }
+]
+
+module searchWriterRoles './shared/roleAssignments.bicep' = [
+  for target in searchWriterRoleTargets: {
+    scope: rg
+    name: '${target}-search-contrib-role'
+    params: {
+      principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
+      roleDefinitionIds: {
+        'Search Index Data Contributor': '8ebe5a00-799e-43f5-93ac-243d3dce84a7'
+      }
+    }
+  }
+]
+
 module dashboard './shared/dashboard-web.bicep' = {
   name: 'dashboard'
   params: {
@@ -491,11 +527,11 @@ module acaServices './app/acaService.bicep' = [for service in services: {
     tags: tags
     appConfigName: appConfig.outputs.name
     eventgridName: eventgrid.outputs.name
-    cogsearchName: cogSearch.outputs.name
     identityName: '${abbrs.managedIdentityUserAssignedIdentities}${service.name}-${resourceToken}'
     keyvaultName: keyVault.outputs.name
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     containerAppsEnvironmentName: appsEnv.outputs.name
+    storageAccountName: storage.outputs.name
     exists: servicesExist['${service.name}'] == 'true'
     appDefinition: serviceDefinition
     hasIngress: service.hasIngress

--- a/deploy/starter/infra/shared/roleAssignments.bicep
+++ b/deploy/starter/infra/shared/roleAssignments.bicep
@@ -1,0 +1,25 @@
+@description('Principal ID to assign roles to.')
+param principalId string
+
+@description('Roles to assign.')
+param roleDefinitionIds object
+
+@description('Principal type.')
+param principalType string = 'ServicePrincipal'
+
+/** Locals **/
+@description('Role Assignments to create')
+var roleAssignmentsToCreate = [for roleDefinitionId in items(roleDefinitionIds): {
+  name: guid(principalId, resourceGroup().id, roleDefinitionId.value)
+  roleDefinitionId: roleDefinitionId.value
+}]
+
+/** Resources **/
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for roleAssignmentToCreate in roleAssignmentsToCreate: {
+  name: roleAssignmentToCreate.name
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignmentToCreate.roleDefinitionId)
+    principalType: principalType
+  }
+}]


### PR DESCRIPTION
# Moving Cognitive Search role assignments outside of acaService.bicep and adding the Search Index Data Contributor role to the vectorization services

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

