### PR TITLE
Moving Cognitive Search role assignments outside of acaService.bicep and adding the Search Index Data Contributor role to the vectorization services

### DIFF
--- a/deploy/starter/infra/app/acaService.bicep
+++ b/deploy/starter/infra/app/acaService.bicep
@@ -4,7 +4,6 @@ param tags object = {}
 
 param appConfigName string
 param eventgridName string
-param cogsearchName string
 param identityName string
 param keyvaultName string
 param storageAccountName string
@@ -226,22 +225,6 @@ resource apiKey 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = [
     }
   }
 ]
-
-resource search 'Microsoft.Search/searchServices@2022-09-01' existing = {
-  name: cogsearchName
-}
-
-resource searchIndexDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: search
-  name: guid(subscription().id, resourceGroup().id, identity.id, 'searchIndexDataReaderRole')
-  properties: {
-    roleDefinitionId: subscriptionResourceId(
-      'Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f')
-    principalType: 'ServicePrincipal'
-    principalId: identity.properties.principalId
-  }
-}
-
 
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
 output name string = app.name

--- a/deploy/starter/infra/shared/roleAssignments.bicep
+++ b/deploy/starter/infra/shared/roleAssignments.bicep
@@ -1,0 +1,25 @@
+@description('Principal ID to assign roles to.')
+param principalId string
+
+@description('Roles to assign.')
+param roleDefinitionIds object
+
+@description('Principal type.')
+param principalType string = 'ServicePrincipal'
+
+/** Locals **/
+@description('Role Assignments to create')
+var roleAssignmentsToCreate = [for roleDefinitionId in items(roleDefinitionIds): {
+  name: guid(principalId, resourceGroup().id, roleDefinitionId.value)
+  roleDefinitionId: roleDefinitionId.value
+}]
+
+/** Resources **/
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for roleAssignmentToCreate in roleAssignmentsToCreate: {
+  name: roleAssignmentToCreate.name
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignmentToCreate.roleDefinitionId)
+    principalType: principalType
+  }
+}]


### PR DESCRIPTION
# Moving Cognitive Search role assignments outside of acaService.bicep and adding the Search Index Data Contributor role to the vectorization services

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

