### PR TITLE
Make resource name checks case-insensitive

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -247,7 +247,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
         private ResourceNameCheckResult CheckAgentName(string serializedAction)
         {
             var resourceName = JsonSerializer.Deserialize<ResourceName>(serializedAction);
-            return _agentReferences.Values.Any(ar => ar.Name == resourceName!.Name)
+            return _agentReferences.Values.Any(ar => ar.Name.Equals(resourceName!.Name, StringComparison.OrdinalIgnoreCase))
                 ? new ResourceNameCheckResult
                 {
                     Name = resourceName!.Name,

--- a/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
+++ b/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
@@ -237,7 +237,7 @@ namespace FoundationaLLM.DataSource.ResourceProviders
         private ResourceNameCheckResult CheckDataSourceName(string serializedAction)
         {
             var resourceName = JsonSerializer.Deserialize<ResourceName>(serializedAction);
-            return _dataSourceReferences.Values.Any(ar => ar.Name == resourceName!.Name)
+            return _dataSourceReferences.Values.Any(ar => ar.Name.Equals(resourceName!.Name, StringComparison.OrdinalIgnoreCase))
                 ? new ResourceNameCheckResult
                 {
                     Name = resourceName!.Name,


### PR DESCRIPTION
# Make resource name checks case-insensitive

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

Fixes issues where the name check would not match on names that only differed by their casing.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
