### PR TITLE
Fixes issues with polymorphic serialization in resource providers

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -167,29 +167,28 @@ namespace FoundationaLLM.Agent.ResourceProviders
 
         private async Task<ResourceProviderUpsertResult> UpdateAgent(ResourcePath resourcePath, string serializedAgent)
         {
-            var agentBase = JsonSerializer.Deserialize<AgentBase>(serializedAgent)
+            var agent = JsonSerializer.Deserialize<AgentBase>(serializedAgent)
                 ?? throw new ResourceProviderException("The object definition is invalid.",
                     StatusCodes.Status400BadRequest);
 
-            if (_agentReferences.TryGetValue(agentBase.Name!, out var existingAgentReference)
+            if (_agentReferences.TryGetValue(agent.Name!, out var existingAgentReference)
                 && existingAgentReference!.Deleted)
                 throw new ResourceProviderException($"The agent resource {existingAgentReference.Name} cannot be added or updated.",
                         StatusCodes.Status400BadRequest);
 
-            if (resourcePath.ResourceTypeInstances[0].ResourceId != agentBase.Name)
+            if (resourcePath.ResourceTypeInstances[0].ResourceId != agent.Name)
                 throw new ResourceProviderException("The resource path does not match the object definition (name mismatch).",
                     StatusCodes.Status400BadRequest);
 
             var agentReference = new AgentReference
             {
-                Name = agentBase.Name!,
-                Type = agentBase.Type!,
-                Filename = $"/{_name}/{agentBase.Name}.json",
+                Name = agent.Name!,
+                Type = agent.Type!,
+                Filename = $"/{_name}/{agent.Name}.json",
                 Deleted = false
             };
 
-            var agent = JsonSerializer.Deserialize(serializedAgent, agentReference.AgentType, _serializerSettings);
-            (agent as AgentBase)!.ObjectId = resourcePath.GetObjectId(_instanceSettings.Id, _name);
+            agent.ObjectId = resourcePath.GetObjectId(_instanceSettings.Id, _name);
 
             var validator = _resourceValidatorFactory.GetValidator(agentReference.AgentType);
             if (validator is IValidator agentValidator)
@@ -206,7 +205,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
             await _storageService.WriteFileAsync(
                 _storageContainerName,
                 agentReference.Filename,
-                JsonSerializer.Serialize(agent, agentReference.AgentType, _serializerSettings),
+                JsonSerializer.Serialize<AgentBase>(agent, _serializerSettings),
                 default,
                 default);
 

--- a/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
+++ b/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
@@ -157,29 +157,28 @@ namespace FoundationaLLM.DataSource.ResourceProviders
 
         private async Task<ResourceProviderUpsertResult> UpdateDataSource(ResourcePath resourcePath, string serializedDataSource)
         {
-            var dataSourceBase = JsonSerializer.Deserialize<DataSourceBase>(serializedDataSource)
+            var dataSource = JsonSerializer.Deserialize<DataSourceBase>(serializedDataSource)
                 ?? throw new ResourceProviderException("The object definition is invalid.",
                     StatusCodes.Status400BadRequest);
 
-            if (_dataSourceReferences.TryGetValue(dataSourceBase.Name!, out var existingDataSourceReference)
+            if (_dataSourceReferences.TryGetValue(dataSource.Name!, out var existingDataSourceReference)
                 && existingDataSourceReference!.Deleted)
                 throw new ResourceProviderException($"The data source resource {existingDataSourceReference.Name} cannot be added or updated.",
                         StatusCodes.Status400BadRequest);
 
-            if (resourcePath.ResourceTypeInstances[0].ResourceId != dataSourceBase.Name)
+            if (resourcePath.ResourceTypeInstances[0].ResourceId != dataSource.Name)
                 throw new ResourceProviderException("The resource path does not match the object definition (name mismatch).",
                     StatusCodes.Status400BadRequest);
 
             var dataSourceReference = new DataSourceReference
             {
-                Name = dataSourceBase.Name!,
-                Type = dataSourceBase.Type!,
-                Filename = $"/{_name}/{dataSourceBase.Name}.json",
+                Name = dataSource.Name!,
+                Type = dataSource.Type!,
+                Filename = $"/{_name}/{dataSource.Name}.json",
                 Deleted = false
             };
 
-            var dataSource = JsonSerializer.Deserialize(serializedDataSource, dataSourceReference.DataSourceType, _serializerSettings);
-            (dataSource as DataSourceBase)!.ObjectId = resourcePath.GetObjectId(_instanceSettings.Id, _name);
+            dataSource.ObjectId = resourcePath.GetObjectId(_instanceSettings.Id, _name);
 
             var validator = _resourceValidatorFactory.GetValidator(dataSourceReference.DataSourceType);
             if (validator is IValidator dataSourceValidator)
@@ -196,7 +195,7 @@ namespace FoundationaLLM.DataSource.ResourceProviders
             await _storageService.WriteFileAsync(
                 _storageContainerName,
                 dataSourceReference.Filename,
-                JsonSerializer.Serialize(dataSource, dataSourceReference.DataSourceType, _serializerSettings),
+                JsonSerializer.Serialize<DataSourceBase>(dataSource, _serializerSettings),
                 default,
                 default);
 


### PR DESCRIPTION
# Fixes issues with polymorphic serialization in resource providers

## The issue or feature being addressed

Polymorphic serialization does not persist the `type` property for resource managed by resource providers.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
