### PR TITLE
Add filter action and default profile name to vectorization profiles

### DIFF
--- a/src/dotnet/DataSource/Constants/DataSourceResourceProviderActions.cs
+++ b/src/dotnet/DataSource/Constants/DataSourceResourceProviderActions.cs
@@ -9,6 +9,9 @@
         /// Check the validity of a resource name.
         /// </summary>
         public const string CheckName = "checkname";
+        /// <summary>
+        /// Apply a filter for data source retrieval.
+        /// </summary>
         public const string Filter = "filter";
     }
 }

--- a/src/dotnet/Vectorization/Constants/VectorizationResourceProviderActions.cs
+++ b/src/dotnet/Vectorization/Constants/VectorizationResourceProviderActions.cs
@@ -9,5 +9,9 @@
         /// Check the validity of a resource name.
         /// </summary>
         public const string CheckName = "checkname";
+        /// <summary>
+        /// Apply a filter for vectorization resource retrieval.
+        /// </summary>
+        public const string Filter = "filter";
     }
 }

--- a/src/dotnet/Vectorization/Models/Resources/ProfileStore`1.cs
+++ b/src/dotnet/Vectorization/Models/Resources/ProfileStore`1.cs
@@ -11,6 +11,11 @@
         public required List<T> Profiles { get; set; }
 
         /// <summary>
+        /// The name of the default profile.
+        /// </summary>
+        public string? DefaultProfileName { get; set; }
+
+        /// <summary>
         /// Creates a new profile store from a dictionary.
         /// </summary>
         /// <param name="dictionary">The dictionary containing the profiles.</param>

--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderMetadata.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderMetadata.cs
@@ -92,6 +92,9 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
                     Actions = [
                             new ResourceTypeAction(VectorizationResourceProviderActions.CheckName, false, true, [
                                 new ResourceTypeAllowedTypes(HttpMethod.Post.Method, [], [typeof(ResourceName)], [typeof(ResourceNameCheckResult)])
+                            ]),
+                            new ResourceTypeAction(VectorizationResourceProviderActions.Filter, false, true, [
+                                new ResourceTypeAllowedTypes(HttpMethod.Post.Method, [], [typeof(ResourceFilter)], [typeof(IndexingProfile)])
                             ])
                         ]
                 }


### PR DESCRIPTION
# Add filter action and default profile name to vectorization profiles

## Details on the issue fix or feature implementation

Provides the ability to specify a default profile name to one or more vectorization profile types. Adds a filter action to apply filters, such as whether to return a default indexing profile.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
