### PR TITLE
Apply default data source and indexing profile on agent creation if none selected

### DIFF
--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -6,6 +6,7 @@ import type {
 	AppConfigUnion,
 	AgentIndex,
 	AgentGatekeeper,
+	FilterRequest,
 	CreateAgentRequest,
 	CheckNameResponse,
 	Prompt,
@@ -94,9 +95,35 @@ export default {
 			body: payload,
 		});
 	},
+
+	async getDefaultDataSource(): Promise<DataSource | null> {
+		const payload: FilterRequest = {
+			default: true
+		};
+
+		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.DataSource/dataSources/filter?api-version=${this.apiVersion}`, {
+			method: 'POST',
+			body: payload,
+		});
+
+		if (data && data.length > 0) {
+			return data[0] as DataSource;
+		} else {
+			return null;
+		}
+	},
 	
 	async getAgentDataSources(): Promise<DataSource[]> {
-		return await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.DataSource/dataSources?api-version=${this.apiVersion}`) as DataSource[];
+		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.DataSource/dataSources?api-version=${this.apiVersion}`) as DataSource[];
+		const defaultDataSource: DataSource = {
+			name: "Select default data source",
+			type: "DEFAULT",
+			object_id: "",
+			resolved_configuration_references: {},
+			configuration_references: {},
+		};
+		data.unshift(defaultDataSource);
+		return data;
 	},
 
 	async getDataSource(dataSourceId: string): Promise<DataSource> {
@@ -209,7 +236,32 @@ export default {
 
 	// Indexes
 	async getAgentIndexes(): Promise<AgentIndex[]> {
-		return await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.Vectorization/indexingProfiles?api-version=${this.apiVersion}`);
+		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.Vectorization/indexingProfiles?api-version=${this.apiVersion}`);
+		const defaultAgentIndex: AgentIndex = {
+			name: "Select default index source",
+			object_id: "",
+			settings: {},
+			configuration_references: {},
+		};
+		data.unshift(defaultAgentIndex);
+		return data;
+	},
+
+	async getDefaultAgentIndex(): Promise<AgentIndex | null> {
+		const payload: FilterRequest = {
+			default: true
+		};
+
+		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.Vectorization/indexingProfiles/filter?api-version=${this.apiVersion}`, {
+			method: 'POST',
+			body: payload,
+		});
+
+		if (data && data.length > 0) {
+			return data[0] as AgentIndex;
+		} else {
+			return null;
+		}
 	},
 
 	// Text embedding profiles

--- a/src/ui/ManagementPortal/js/types.ts
+++ b/src/ui/ManagementPortal/js/types.ts
@@ -198,6 +198,10 @@ export type CheckNameResponse = {
 	message: string;
 };
 
+export type FilterRequest = {
+	default?: boolean
+};
+
 export type AgentGatekeeper = {};
 
 export type MockCreateAgentRequest = {


### PR DESCRIPTION
# Apply default data source and indexing profile on agent creation if none selected

## Details on the issue fix or feature implementation

Allows a streamlined agent creation experience when a default data source and default vectorization indexing profile are defined. By not selecting one or both of these values when creating an agent (or selecting the "default" option), the agent form in the Management Portal retrieves the default data source/indexing profile and applies its object ID to the agent's vectorization settings.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
