### PR TITLE
Add parameter to return options for default data source and indexes

### DIFF
--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -113,16 +113,18 @@ export default {
 		}
 	},
 	
-	async getAgentDataSources(): Promise<DataSource[]> {
+	async getAgentDataSources(addDefaultOption: boolean = false): Promise<DataSource[]> {
 		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.DataSource/dataSources?api-version=${this.apiVersion}`) as DataSource[];
-		const defaultDataSource: DataSource = {
-			name: "Select default data source",
-			type: "DEFAULT",
-			object_id: "",
-			resolved_configuration_references: {},
-			configuration_references: {},
-		};
-		data.unshift(defaultDataSource);
+		if (addDefaultOption) {
+			const defaultDataSource: DataSource = {
+				name: "Select default data source",
+				type: "DEFAULT",
+				object_id: "",
+				resolved_configuration_references: {},
+				configuration_references: {},
+			};
+			data.unshift(defaultDataSource);
+		}
 		return data;
 	},
 
@@ -235,15 +237,17 @@ export default {
 	},
 
 	// Indexes
-	async getAgentIndexes(): Promise<AgentIndex[]> {
+	async getAgentIndexes(addDefaultOption: boolean = false): Promise<AgentIndex[]> {
 		const data = await this.fetch(`/instances/${this.instanceId}/providers/FoundationaLLM.Vectorization/indexingProfiles?api-version=${this.apiVersion}`);
-		const defaultAgentIndex: AgentIndex = {
-			name: "Select default index source",
-			object_id: "",
-			settings: {},
-			configuration_references: {},
-		};
-		data.unshift(defaultAgentIndex);
+		if (addDefaultOption) {
+			const defaultAgentIndex: AgentIndex = {
+				name: "Select default index source",
+				object_id: "",
+				settings: {},
+				configuration_references: {},
+			};
+			data.unshift(defaultAgentIndex);
+		}
 		return data;
 	},
 

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -591,10 +591,10 @@ export default {
 
 		try {
 			this.loadingStatusText = 'Retrieving indexes...';
-			this.indexSources = await api.getAgentIndexes();
+			this.indexSources = await api.getAgentIndexes(true);
 
 			this.loadingStatusText = 'Retrieving data sources...';
-			this.dataSources = await api.getAgentDataSources();
+			this.dataSources = await api.getAgentDataSources(true);
 		} catch (error) {
 			this.$toast.add({
 				severity: 'error',


### PR DESCRIPTION
# Add parameter to return options for default data source and indexes

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

Fixes issue where the option to select a default data source or vectorization index profile were showing up in other places within the Management Portal outside of their respective select lists.

## Details on the issue fix or feature implementation

{Detail}

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
