### PR TITLE
Adding missing --auth-mode key parameter to AZCLI call

### DIFF
--- a/deploy/starter/azd-hooks/postprovision.ps1
+++ b/deploy/starter/azd-hooks/postprovision.ps1
@@ -197,5 +197,6 @@ Invoke-AndRequireSuccess "Uploading Default Role Assignments to Authorization St
         -s "./data/role-assignments/${env:FOUNDATIONALLM_INSTANCE_ID}.json" `
         --recursive `
         --only-show-errors `
+        --auth-mode key `
         --output none
 }


### PR DESCRIPTION
# Adding missing --auth-mode key parameter to AZCLI call

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

