### PR TITLE
(0.5.1) Implement graph group paging and set the page size to a higher value

### DIFF
--- a/src/dotnet/Common/Services/Security/MicrosoftGraphGroupMembershipService.cs
+++ b/src/dotnet/Common/Services/Security/MicrosoftGraphGroupMembershipService.cs
@@ -1,6 +1,7 @@
 ﻿using FoundationaLLM.Common.Authentication;
 using FoundationaLLM.Common.Interfaces;
 using Microsoft.Graph;
+using System.Collections.Generic;
 
 namespace FoundationaLLM.Common.Services.Security
 {
@@ -15,10 +16,36 @@ namespace FoundationaLLM.Common.Services.Security
         /// <inheritdoc/>
         public async Task<List<string>> GetGroupsForPrincipal(string userPrincipalName)
         {
-            var result = await _graphClient.Users[userPrincipalName].TransitiveMemberOf.GraphGroup.GetAsync().ConfigureAwait(false);
-            return result == null || result.Value == null
+            var groupMembership = new List<Microsoft.Graph.Models.Group>();
+            var groups = await _graphClient.Users[userPrincipalName].TransitiveMemberOf.GraphGroup.GetAsync(requestConfiguration =>
+            {
+                requestConfiguration.QueryParameters.Top = 500;
+            }).ConfigureAwait(false);
+
+            while (groups?.Value != null)
+            {
+                foreach (var group in groups.Value)
+                {
+                    Console.WriteLine(group.DisplayName);
+                    groupMembership.Add(group);
+                }
+
+                // Invoke paging if required.
+                if (!string.IsNullOrEmpty(groups.OdataNextLink))
+                {
+                    groups = await _graphClient.Users[userPrincipalName].TransitiveMemberOf.GraphGroup
+                        .WithUrl(groups.OdataNextLink)
+                        .GetAsync();
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return groupMembership.Count == 0
                 ? []
-                : result.Value.Where(x => x.Id != null).Select(x => x.Id!).ToList();
+                : groupMembership.Where(x => x.Id != null).Select(x => x.Id!).ToList();
         }
     }
 }


### PR DESCRIPTION
# (0.5.1) Implement graph group paging and set the page size to a higher value

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

This fixes issues where a user with a high number of Entra ID group memberships may not have the group ID in their user context, in which they are a member and assigned RBAC permissions.

## Details on the issue fix or feature implementation

Implements paging support for Microsoft Graph SDK calls to fetch group memberships.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
