### PR TITLE
Change the way group membership is retrieved

### DIFF
--- a/src/dotnet/Common/Interfaces/IGroupMembershipService.cs
+++ b/src/dotnet/Common/Interfaces/IGroupMembershipService.cs
@@ -8,8 +8,8 @@
         /// <summary>
         /// Retrieves the group identifiers list of the groups where the specified user principal is a member.
         /// </summary>
-        /// <param name="userPrincipalName">The user principal name (UPN) for which group membership is retrieved.</param>
+        /// <param name="userIdentifier">The user identifier for which group membership is retrieved. Can be either an object id or a user principal name (UPN).</param>
         /// <returns></returns>
-        Task<List<string>> GetGroupsForPrincipal(string userPrincipalName);
+        Task<List<string>> GetGroupsForPrincipal(string userIdentifier);
     }
 }

--- a/src/dotnet/Common/Middleware/CallContextMiddleware.cs
+++ b/src/dotnet/Common/Middleware/CallContextMiddleware.cs
@@ -47,7 +47,7 @@ namespace FoundationaLLM.Common.Middleware
                 if (callContext.CurrentUserIdentity != null)
                 {
                     callContext.CurrentUserIdentity.GroupIds = await groupMembershipService.GetGroupsForPrincipal(
-                        callContext.CurrentUserIdentity.UPN!);
+                        callContext.CurrentUserIdentity.UserId!);
                 }
             }
             else

--- a/src/dotnet/Common/Services/Security/MicrosoftGraphGroupMembershipService.cs
+++ b/src/dotnet/Common/Services/Security/MicrosoftGraphGroupMembershipService.cs
@@ -14,10 +14,10 @@ namespace FoundationaLLM.Common.Services.Security
             DefaultAuthentication.GetAzureCredential());
 
         /// <inheritdoc/>
-        public async Task<List<string>> GetGroupsForPrincipal(string userPrincipalName)
+        public async Task<List<string>> GetGroupsForPrincipal(string userIdentifier)
         {
             var groupMembership = new List<Microsoft.Graph.Models.Group>();
-            var groups = await _graphClient.Users[userPrincipalName].TransitiveMemberOf.GraphGroup.GetAsync(requestConfiguration =>
+            var groups = await _graphClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup.GetAsync(requestConfiguration =>
             {
                 requestConfiguration.QueryParameters.Top = 500;
             }).ConfigureAwait(false);
@@ -32,7 +32,7 @@ namespace FoundationaLLM.Common.Services.Security
                 // Invoke paging if required.
                 if (!string.IsNullOrEmpty(groups.OdataNextLink))
                 {
-                    groups = await _graphClient.Users[userPrincipalName].TransitiveMemberOf.GraphGroup
+                    groups = await _graphClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup
                         .WithUrl(groups.OdataNextLink)
                         .GetAsync();
                 }


### PR DESCRIPTION
# Change the way group membership is retrieved

## The issue or feature being addressed

Group membership is not retrieved correctly for guest accounts in Entra ID.

## Details on the issue fix or feature implementation

The JWT tokens generated for guest accounts do not include a User Principal Name. Because of this, we default to `preferred_username` which is the UPN from the source tenant, not the UPN of the guest account.

To fix this, we now use the object id (`oid` claim) of the user account to retrieve group membership (instead of the previously used UPN).

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
