### PR TITLE
Adding inner exception for blob and data lake storage when one occurs

### DIFF
--- a/src/dotnet/Common/Services/Storage/BlobStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/BlobStorageService.cs
@@ -118,10 +118,10 @@ namespace FoundationaLLM.Common.Services.Storage
                         "Reason: an existing lease is preventing acquiring a new lease.",
                         filePath, containerName);
                     throw new StorageException($"Could not get a lease for the blob {filePath} from container {containerName}. " +
-                        "Reason: an existing lease is preventing acquiring a new lease.");
+                        "Reason: an existing lease is preventing acquiring a new lease.", ex);
                 }
 
-                throw new StorageException($"Could not get a lease for the blob {filePath} from container {containerName}. Reason: unknown.");
+                throw new StorageException($"Could not get a lease for the blob {filePath} from container {containerName}. Reason: unknown.", ex);
             }
             finally
             {

--- a/src/dotnet/Common/Services/Storage/BlobStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/BlobStorageService.cs
@@ -114,7 +114,7 @@ namespace FoundationaLLM.Common.Services.Storage
                 if (ex.Status == (int)HttpStatusCode.Conflict
                         && ex.ErrorCode == "LeaseAlreadyPresent")
                 {
-                    _logger.LogError("Could not get a lease for the blob {FilePath} from container {ContainerName}. " +
+                    _logger.LogError(ex, "Could not get a lease for the blob {FilePath} from container {ContainerName}. " +
                         "Reason: an existing lease is preventing acquiring a new lease.",
                         filePath, containerName);
                     throw new StorageException($"Could not get a lease for the blob {filePath} from container {containerName}. " +

--- a/src/dotnet/Common/Services/Storage/DataLakeStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/DataLakeStorageService.cs
@@ -134,10 +134,10 @@ namespace FoundationaLLM.Common.Services.Storage
                         "Reason: an existing lease is preventing acquiring a new lease.",
                         filePath, containerName);
                     throw new StorageException($"Could not get a lease for the file {filePath} from container {containerName}. " +
-                        "Reason: an existing lease is preventing acquiring a new lease.");
+                        "Reason: an existing lease is preventing acquiring a new lease.", ex);
                 }
 
-                throw new StorageException($"Could not get a lease for the file {filePath} from container {containerName}. Reason: unknown.");
+                throw new StorageException($"Could not get a lease for the file {filePath} from container {containerName}. Reason: unknown.", ex);
             }
             finally
             {

--- a/src/dotnet/Common/Services/Storage/DataLakeStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/DataLakeStorageService.cs
@@ -130,7 +130,7 @@ namespace FoundationaLLM.Common.Services.Storage
                 if (ex.Status == (int)HttpStatusCode.Conflict
                         && ex.ErrorCode == "LeaseAlreadyPresent")
                 {
-                    _logger.LogError("Could not get a lease for the file {FilePath} from container {ContainerName}. " +
+                    _logger.LogError(ex, "Could not get a lease for the file {FilePath} from container {ContainerName}. " +
                         "Reason: an existing lease is preventing acquiring a new lease.",
                         filePath, containerName);
                     throw new StorageException($"Could not get a lease for the file {filePath} from container {containerName}. " +


### PR DESCRIPTION
# Inner exception added for blob and data lake storage when one occurs

## Details on the issue fix or feature implementation

Missing inner exception for blob and data lake storage.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
