### PR TITLE
Fix client account name issue when using managed identity

### DIFF
--- a/src/dotnet/Common/Services/Storage/BlobStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/BlobStorageService.cs
@@ -169,7 +169,7 @@ namespace FoundationaLLM.Common.Services.Storage
         /// <inheritdoc/>
         protected override void CreateClientFromIdentity(string accountName) =>
             _blobServiceClient = new BlobServiceClient(
-                new Uri($"https://{accountName}.dfs.core.windows.net"),
+                new Uri($"https://{accountName}.blob.core.windows.net"),
                 DefaultAuthentication.GetAzureCredential());
     }
 }


### PR DESCRIPTION
# Fix client account name issue when using managed identity

## Details on the issue fix or feature implementation

The URI should use .blob instead of .dfs. Using .dfs will result in an empty string for the AccountName.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
