### PR TITLE
Wire Up Service Namespace to AKS deployment scripts

### DIFF
--- a/deploy/standard/scripts/Deploy.ps1
+++ b/deploy/standard/scripts/Deploy.ps1
@@ -100,9 +100,10 @@ try {
     Invoke-AndRequireSuccess "Deploy Backend" {
         ./deploy/Deploy-Backend-Aks.ps1 `
             -aksName $backendAks `
+            -ingressNginxValues $ingressNginxValuesBackend `
             -resourceGroup $resourceGroup.app `
             -secretProviderClassManifest $secretProviderClassManifestBackend `
-            -ingressNginxValues $ingressNginxValuesBackend
+            -serviceNamespaceName $manifest.k8sNamespace
     }
 
     $frontendAks = Invoke-AndRequireSuccess "Get Frontend AKS" {
@@ -117,9 +118,10 @@ try {
     Invoke-AndRequireSuccess "Deploy Frontend" {
         ./deploy/Deploy-Frontend-Aks.ps1 `
             -aksName $frontendAks `
+            -ingressNginxValues $ingressNginxValuesFrontend `
             -resourceGroup $resourceGroup.app `
             -secretProviderClassManifest $secretProviderClassManifestFrontend `
-            -ingressNginxValues $ingressNginxValuesFrontend
+            -serviceNamespaceName $manifest.k8sNamespace
     }
 
     $clusters = @(


### PR DESCRIPTION
# Wire Up Service Namespace to AKS deployment scripts

## The issue or feature being addressed

The AKS deployment scripts do not respect the namespace specified in the deployment manifest, even though all the other scripts and templates do. The deployment scripts have an optional parameter for namespace, but the calling script does not pass the value.

## Details on the issue fix or feature implementation

Updates the caller to pass the namespace to the child script.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable


