### PR TITLE
Shorten nested deployment names

### DIFF
--- a/deploy/quick-start/infra/app/acaService.bicep
+++ b/deploy/quick-start/infra/app/acaService.bicep
@@ -10,17 +10,18 @@ param imageName string
 param keyvaultName string
 param location string = resourceGroup().location
 param name string
+param resourceToken string
 param secretSettings array = []
 param serviceName string
 param tags object = {}
-param timestamp string = utcNow()
+param timestamp int = dateTimeToEpoch(utcNow())
 
 @secure()
 param appDefinition object
 
 /** Locals **/
 var appSettingsArray = filter(array(appDefinition.settings), i => i.name != '')
-var formattedAppName = replace(name, '-', '')
+var formattedAppName = replace('${name}${resourceToken}', '-', '')
 var truncatedAppName = substring(formattedAppName, 0, min(length(formattedAppName), 32))
 
 var env = union(

--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -544,7 +544,8 @@ module acaServices './app/acaService.bicep' = [
       imageName: service.image
       keyvaultName: keyVault.outputs.name
       location: location
-      name: '${abbrs.appContainerApps}${service.name}${resourceToken}'
+      name: '${abbrs.appContainerApps}${service.name}'
+      resourceToken: resourceToken
       serviceName: service.name
       tags: tags
 


### PR DESCRIPTION
# Shorten nested deployment names

<!-- Thank you for contributing to FoundationaLLM!  Open source is only as strong as its contributors. -->

## The issue or feature being addressed

Gatekeeper API produced a deployment name that exceeded the length of the limit for azure deployments.

## Details on the issue fix or feature implementation

This PR shortens the names of all nested deployments in `acaService.bicep`

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
