### PR TITLE
Add conditional Azure AI Service app registration

### DIFF
--- a/tests/dotnet/Core.Examples/Example0016_CompletionQualityMeasurements.cs
+++ b/tests/dotnet/Core.Examples/Example0016_CompletionQualityMeasurements.cs
@@ -31,7 +31,7 @@ namespace FoundationaLLM.Core.Examples
 			if (agentPrompts == null || agentPrompts.Length == 0)
 			{
 				WriteLine("No agent prompts found. Make sure you enter them in testsettings.json.");
-				return;
+                Assert.True(agentPrompts is {Length: > 0}, "Failed to run the test because there are no configured agent prompts.");
 			}
 			foreach (var agentPrompt in agentPrompts)
 			{

--- a/tests/dotnet/Core.Examples/Services/AgentConversationTestService.cs
+++ b/tests/dotnet/Core.Examples/Services/AgentConversationTestService.cs
@@ -16,7 +16,7 @@ namespace FoundationaLLM.Core.Examples.Services
     public class AgentConversationTestService(
         ICoreAPITestManager coreAPITestManager,
         IManagementAPITestManager managementAPITestManager,
-        IAzureAIService azureAIService) : IAgentConversationTestService
+        IAzureAIService azureAIService = null) : IAgentConversationTestService
     {
         /// <inheritdoc/>
         public async Task<IEnumerable<Message>> RunAgentConversationWithSession(string agentName,
@@ -151,6 +151,12 @@ namespace FoundationaLLM.Core.Examples.Services
         {
             var sessionCreated = false;
             var completionQualityMeasurementOutput = new CompletionQualityMeasurementOutput();
+
+            if (azureAIService == null)
+            {
+                throw new InvalidOperationException("The Azure AI service is required for this operation. Please make sure you have configured your testsettings.json file with the CompletionQualityMeasurementConfiguration section and its AgentPrompts.");
+            }
+
             if (string.IsNullOrWhiteSpace(sessionId))
             {
                 // Create a new session since an existing ID was not provided.


### PR DESCRIPTION
# Add conditional Azure AI Service app registration

## The issue or feature being addressed

Fixes E2E test errors when there are no App Config settings for Azure AI Studio, even if you are not running tests that require them.

## Details on the issue fix or feature implementation

Makes the DI for Azure AI Studio conditional, based on whether the user has configured the `CompletionQualityMeasurementConfiguration` section with agent prompts in `localsettings.json`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
