### PR TITLE
Implementation of the prompt component for e2e testing

### DIFF
--- a/tests/dotnet/Core.Examples/Interfaces/IManagementAPITestManager.cs
+++ b/tests/dotnet/Core.Examples/Interfaces/IManagementAPITestManager.cs
@@ -1,4 +1,5 @@
 ﻿using FoundationaLLM.Common.Models.ResourceProviders.Agent;
+using FoundationaLLM.Common.Models.ResourceProviders.Prompt;
 using FoundationaLLM.Core.Examples.Exceptions;
 
 namespace FoundationaLLM.Core.Examples.Interfaces;
@@ -22,6 +23,20 @@ public interface IManagementAPITestManager
     /// <param name="agentName">The name of the agent and its dependencies to delete.</param>
     /// <returns></returns>
     Task DeleteAgent(string agentName);
+
+    /// <summary>
+    /// Creates a prompt.
+    /// </summary>
+    /// <param name="promptName">The name of the prompt to retrieve from the test catalog.</param>
+    /// <returns>The created prompt.</returns>
+    Task<PromptBase> CreatePrompt(string promptName);
+
+    /// <summary>
+    /// Deletes a prompt.
+    /// </summary>
+    /// <param name="promptName">The name of the prompt to delete.</param>
+    /// <returns></returns>
+    Task DeletePrompt(string promptName);
 
     /// <summary>
     /// Retrieves one or more resources.


### PR DESCRIPTION
# Implementation of the prompt component for e2e testing

## Details on the issue fix or feature implementation

Extends the Management API test manager to support the creation and deletion of Prompt resources based on the definitions in the PromptCatalog.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

