### PR TITLE
Implementation of dynamic load of vectorization profiles

### DIFF
--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
@@ -145,13 +145,13 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
             resourcePath.ResourceTypeInstances[0].ResourceType switch
             {
                 VectorizationResourceTypeNames.TextPartitioningProfiles =>
-                    LoadResources<TextPartitioningProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _textPartitioningProfiles),
+                    await LoadResources<TextPartitioningProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _textPartitioningProfiles),
                 VectorizationResourceTypeNames.TextEmbeddingProfiles =>
-                    LoadResources<TextEmbeddingProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _textEmbeddingProfiles),
+                    await LoadResources<TextEmbeddingProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _textEmbeddingProfiles),
                 VectorizationResourceTypeNames.IndexingProfiles =>
-                    LoadResources<IndexingProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _indexingProfiles),
+                    await LoadResources<IndexingProfile, VectorizationProfileBase>(resourcePath.ResourceTypeInstances[0], _indexingProfiles),
                 VectorizationResourceTypeNames.VectorizationPipelines =>
-                    LoadResources<VectorizationPipeline, VectorizationPipeline>(resourcePath.ResourceTypeInstances[0], _pipelines),
+                    await LoadResources<VectorizationPipeline, VectorizationPipeline>(resourcePath.ResourceTypeInstances[0], _pipelines),
                 VectorizationResourceTypeNames.VectorizationRequests =>
                     await LoadVectorizationRequestResources(resourcePath.ResourceTypeInstances[0], _vectorizationRequests),
                 _ => throw new ResourceProviderException($"The resource type {resourcePath.ResourceTypeInstances[0].ResourceType} is not supported by the {_name} resource provider.",
@@ -160,7 +160,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
 
         #region Helpers for GetResourcesAsyncInternal
 
-        private List<TBase> LoadResources<T, TBase>(ResourceTypeInstance instance, ConcurrentDictionary<string, TBase> resourceStore)
+        private async Task<List<TBase>> LoadResources<T, TBase>(ResourceTypeInstance instance, ConcurrentDictionary<string, TBase> resourceStore)
             where T : TBase
             where TBase: ResourceBase
         {
@@ -175,8 +175,25 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
             {
                 if (!resourceStore.TryGetValue(instance.ResourceId, out var resource)
                     || resource.Deleted)
+                {
+                    if (resource is null)
+                    {
+                        //reload resource store and check again
+                        await LoadResourceStore<T, TBase>(instance.ResourceType switch
+                        {
+                            VectorizationResourceTypeNames.TextPartitioningProfiles => TEXT_PARTITIONING_PROFILES_FILE_PATH,
+                            VectorizationResourceTypeNames.TextEmbeddingProfiles => TEXT_EMBEDDING_PROFILES_FILE_PATH,
+                            VectorizationResourceTypeNames.IndexingProfiles => INDEXING_PROFILES_FILE_PATH,
+                            VectorizationResourceTypeNames.VectorizationPipelines => PIPELINES_FILE_PATH,
+                            _ => throw new ResourceProviderException($"The resource type {instance.ResourceType} is not supported by the {_name} resource provider.",
+                                                       StatusCodes.Status400BadRequest)
+                        }, resourceStore);
+                        resourceStore.TryGetValue(instance.ResourceId, out resource);
+                    }
+                }
+                if (resource is null || resource.Deleted)
                     throw new ResourceProviderException($"Could not locate the {instance.ResourceId} vectorization resource.",
-                        StatusCodes.Status404NotFound);
+                                               StatusCodes.Status404NotFound);
 
                 return [resource];
             }


### PR DESCRIPTION
# Implementation of dynamic load of vectorization profiles

## Details on the issue fix or feature implementation

If a vectorization profile resource is requested and not in the in-memory cache, reload the profiles from storage to ensure the instance is up-to-date prior to issuing a 404.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

