### PR TITLE
UX updates

### DIFF
--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -453,9 +453,14 @@ export default {
 	},
 
 	// Prompts
-	async getPrompt(promptId: string): Promise<Prompt> {
-		const data = await this.fetch(`${promptId}?api-version=${this.apiVersion}`);
-		return data[0];
+	async getPrompt(promptId: string): Promise<Prompt | null> {
+		// Attempt to retrieve the prompt. If it doesn't exist, return an empty object.
+		try {
+			const data = await this.fetch(`${promptId}?api-version=${this.apiVersion}`);
+			return data[0];
+		} catch (error) {
+			return null;
+		}
 	},
 
 	async createOrUpdatePrompt(agentId: string, request: CreatePromptRequest): Promise<any> {

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -87,7 +87,6 @@ export default {
 		disabled: {
 			handler(newValue) {
 				if (!newValue) {
-					// Place the cursor at the beginning of the text area
 					this.$nextTick(() => {
 						const textInput = this.$refs.inputRef as HTMLTextAreaElement;
 						textInput.focus();

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -15,11 +15,13 @@
 			>
 				<textarea
 					ref="inputRef"
+					id="chat-input"
 					v-model="text"
 					class="input"
 					:disabled="disabled"
 					placeholder="What would you like to ask?"
 					@keydown="handleKeydown"
+					autofocus
 				/>
 				<template #no-result>
 					<div class="dim">No result</div>
@@ -79,6 +81,18 @@ export default {
 		text: {
 			handler() {
 				this.adjustTextareaHeight();
+			},
+			immediate: true,
+		},
+		disabled: {
+			handler(newValue) {
+				if (!newValue) {
+					// Place the cursor at the beginning of the text area
+					this.$nextTick(() => {
+						const textInput = this.$refs.inputRef as HTMLTextAreaElement;
+						textInput.focus();
+					});
+				}
 			},
 			immediate: true,
 		},


### PR DESCRIPTION
# UX updates

## Details on the issue fix or feature implementation

Adds two simple UX updates:

1. Management Portal
    - Handle error when opening an agent in the agent form, and the Prompt object is null. The form was previously left in an unusable state if this happened.
2. User Portal
    - Return the cursor focus back to the chat input box after receiving a response from the agent.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
