### PR TITLE
Fixed build by removing references to deprecated KV secrets

### DIFF
--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -1737,19 +1737,6 @@ namespace FoundationaLLM.Configuration.Catalog
 
             new(
                 key: AppConfigurationKeys
-                    .FoundationaLLM_Vectorization_StateService_Storage_ConnectionString,
-                minimumVersion: "0.3.0",
-                defaultValue: "Key Vault secret name: `foundationallm-vectorization-state-connectionstring`",
-                description:
-                "The connection string to the Azure Storage account used for the vectorization state service.",
-                keyVaultSecretName: KeyVaultSecretNames
-                    .FoundationaLLM_Vectorization_State_ConnectionString,
-                contentType: "text/plain",
-                sampleObject: null
-            ),
-
-            new(
-                key: AppConfigurationKeys
                     .FoundationaLLM_Vectorization_ResourceProviderService_Storage_AuthenticationType,
                 minimumVersion: "0.3.0",
                 defaultValue: "",

--- a/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
@@ -15,18 +15,6 @@ namespace FoundationaLLM.Configuration.Catalog
         public static readonly List<KeyVaultSecretEntry> GenericEntries =
         [
             new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_AgentHub_StorageManager_BlobStorage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description: ""
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_Agent_ResourceProvider_Storage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description: "The connection string to the Azure Storage account used for the agent resource provider."
-            ),
-            new(
                 secretName: KeyVaultSecretNames.FoundationaLLM_APIs_AgentFactoryAPI_APIKey,
                 minimumVersion: "0.3.0",
                 description: ""
@@ -62,12 +50,6 @@ namespace FoundationaLLM.Configuration.Catalog
                 description: ""
             ),
             new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_Prompt_ResourceProvider_Storage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description: "The connection string to the Azure Storage account used for the prompt resource provider."
-            ),
-            new(
                 secretName: KeyVaultSecretNames.FoundationaLLM_APIs_PromptHubAPI_APIKey,
                 minimumVersion: "0.3.0",
                 description: ""
@@ -88,31 +70,7 @@ namespace FoundationaLLM.Configuration.Catalog
                 description: ""
             ),
             new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_BlobStorageMemorySource_Blobstorageconnection,
-                minimumVersion: "0.3.0",
-                description: ""
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_DataSourceHub_StorageManager_BlobStorage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description: ""
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_DataSourceHub_StorageManager_BlobStorage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description: ""
-            ),
-            new(
                 secretName: KeyVaultSecretNames.FoundationaLLM_OpenAI_Api_Key,
-                minimumVersion: "0.3.0",
-                description: ""
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_PromptHub_StorageManager_BlobStorage_ConnectionString,
                 minimumVersion: "0.3.0",
                 description: ""
             ),
@@ -132,29 +90,10 @@ namespace FoundationaLLM.Configuration.Catalog
                 description: "The API key of the vectorization worker API."
             ),
             new(
-                secretName: KeyVaultSecretNames.FoundationaLLM_Vectorization_State_ConnectionString,
-                minimumVersion: "0.3.0",
-                description:
-                "The connection string to the Azure Storage account used for the vectorization state service."
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_Vectorization_ResourceProvider_Storage_ConnectionString,
-                minimumVersion: "0.3.0",
-                description:
-                "The connection string to the Azure Storage account used for the vectorization state service."
-            ),
-            new(
                 secretName: KeyVaultSecretNames.FoundationaLLM_Events_AzureEventGrid_APIKey,
                 minimumVersion: "0.4.0",
                 description:
                 "The API key for the Azure Event Grid service."
-            ),
-            new(
-                secretName: KeyVaultSecretNames
-                    .FoundationaLLM_DataSource_ResourceProvider_Storage_ConnectionString,
-                minimumVersion: "0.5.0",
-                description: "The connection string to the Azure Storage account used for the data source resource provider."
             ),
         ];
 


### PR DESCRIPTION
# Fixed build by removing references to deprecated KV secrets

## Details on the issue fix or feature implementation

This PR fixes the broken build by removing deprecated Key Vault secrets from the .NET catalog.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
