### PR TITLE
Updated manifest to build Agent Factory instead of Orchestration API

### DIFF
--- a/tests/config/pre-release-manifest.json
+++ b/tests/config/pre-release-manifest.json
@@ -79,11 +79,11 @@
             "azd_env_key": "SERVICE_MANAGEMENTUI_IMAGE"
         },
         {
-            "name": "orchestration-api",
+            "name": "agent-factory-api",
             "context": "./src",
-            "dockerfile": "./src/dotnet/OrchestrationAPI/Dockerfile",
-            "helm_chart": "./deploy/common/helm/orchestration-api",
-            "azd_env_key": "SERVICE_ORCHESTRATIONAPI_IMAGE"
+            "dockerfile": "./src/dotnet/AgentFactoryAPI/Dockerfile",
+            "helm_chart": "./deploy/common/helm/agent-factory-api",
+            "azd_env_key": "SERVICE_AGENTFACTORYAPI_IMAGE"
         },
         {
             "name": "prompt-hub-api",


### PR DESCRIPTION
# Updated manifest to build Agent Factory instead of Orchestration API

## The issue or feature being addressed

This PR builds the Agent Factory API image, instead of Orchestration API, which is not part of 0.6.0.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
