### PR TITLE
Gateway App Config Settings Validation Update

### DIFF
--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -509,7 +509,7 @@ namespace FoundationaLLM.Configuration.Catalog
 
             new(
                 key: AppConfigurationKeys.FoundationaLLM_APIs_GatewayAPI_APIUrl,
-                minimumVersion: "0.6.0",
+                minimumVersion: "0.8.0",
                 defaultValue: "",
                 description: "The URL of the Gateway API.",
                 keyVaultSecretName: "",
@@ -519,7 +519,7 @@ namespace FoundationaLLM.Configuration.Catalog
 
             new(
                 key: AppConfigurationKeys.FoundationaLLM_APIs_GatewayAPI_APIKey,
-                minimumVersion: "0.6.0",
+                minimumVersion: "0.8.0",
                 defaultValue: "Key Vault secret name: `foundationallm-apis-gatewayapi-apikey`",
                 description: "The API key of the Gateway API.",
                 keyVaultSecretName: KeyVaultSecretNames.FoundationaLLM_APIs_GatewayAPI_APIKey,
@@ -530,7 +530,7 @@ namespace FoundationaLLM.Configuration.Catalog
             new(
                 key: AppConfigurationKeys
                     .FoundationaLLM_APIs_GatewayAPI_AppInsightsConnectionString,
-                minimumVersion: "0.6.0",
+                minimumVersion: "0.8.0",
                 defaultValue: "Key Vault secret name: `foundationallm-app-insights-connection-string`",
                 description:
                 "The connection string to the Application Insights instance used by the vectorization API.",

--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -509,7 +509,7 @@ namespace FoundationaLLM.Configuration.Catalog
 
             new(
                 key: AppConfigurationKeys.FoundationaLLM_APIs_GatewayAPI_APIUrl,
-                minimumVersion: "0.8.0",
+                minimumVersion: "0.7.0",
                 defaultValue: "",
                 description: "The URL of the Gateway API.",
                 keyVaultSecretName: "",
@@ -519,7 +519,7 @@ namespace FoundationaLLM.Configuration.Catalog
 
             new(
                 key: AppConfigurationKeys.FoundationaLLM_APIs_GatewayAPI_APIKey,
-                minimumVersion: "0.8.0",
+                minimumVersion: "0.7.0",
                 defaultValue: "Key Vault secret name: `foundationallm-apis-gatewayapi-apikey`",
                 description: "The API key of the Gateway API.",
                 keyVaultSecretName: KeyVaultSecretNames.FoundationaLLM_APIs_GatewayAPI_APIKey,
@@ -530,7 +530,7 @@ namespace FoundationaLLM.Configuration.Catalog
             new(
                 key: AppConfigurationKeys
                     .FoundationaLLM_APIs_GatewayAPI_AppInsightsConnectionString,
-                minimumVersion: "0.8.0",
+                minimumVersion: "0.7.0",
                 defaultValue: "Key Vault secret name: `foundationallm-app-insights-connection-string`",
                 description:
                 "The connection string to the Application Insights instance used by the vectorization API.",

--- a/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
@@ -97,7 +97,7 @@ namespace FoundationaLLM.Configuration.Catalog
             ),
             new (
                 secretName: KeyVaultSecretNames.FoundationaLLM_APIs_GatewayAPI_APIKey,
-                minimumVersion: "0.8.0",
+                minimumVersion: "0.7.0",
                 description: "The API key of the Gateway API"
             )
         ];

--- a/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/KeyVaultSecretsCatalog.cs
@@ -97,7 +97,7 @@ namespace FoundationaLLM.Configuration.Catalog
             ),
             new (
                 secretName: KeyVaultSecretNames.FoundationaLLM_APIs_GatewayAPI_APIKey,
-                minimumVersion: "0.6.0",
+                minimumVersion: "0.8.0",
                 description: "The API key of the Gateway API"
             )
         ];


### PR DESCRIPTION
# Gateway App Config Settings Validation Update

## The issue or feature being addressed

This PR raises the minimum version for App Config keys and Key Vault secrets associated with Gateway API to 0.8.0.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
