### PR TITLE
Build pre-release images from poc/ branches

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -62,7 +62,7 @@ jobs:
 
   helm_build:
     name: Package Helm Charts
-    if: startsWith(github.ref, 'refs/heads/release/')
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/poc/')
     needs: generate_matrix
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
 
   docker_build:
     name: Build Docker Images
-    if: startsWith(github.ref, 'refs/heads/release/')
+    if: startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/poc/')
     needs: generate_matrix
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Build pre-release images from poc/ branches

## The issue or feature being addressed

This PR adds support for launching build jobs from branches with names like `poc/x.y.z-[POC NAME]`.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
