### PR TITLE
RELEASE 0.7.0: Fix prompt casting bug

### DIFF
--- a/src/dotnet/Orchestration/Services/AzureAIDirectService.cs
+++ b/src/dotnet/Orchestration/Services/AzureAIDirectService.cs
@@ -67,10 +67,10 @@ namespace FoundationaLLM.Orchestration.Core.Services
             if (!string.IsNullOrWhiteSpace(agent.PromptObjectId))
             {
                 if (!_resourceProviderServices.TryGetValue(ResourceProviderNames.FoundationaLLM_Prompt, out var promptResourceProvider))
-                    throw new ResourceProviderException($"The resource provider {ResourceProviderNames.FoundationaLLM_Prompt} was not loaded.");
-
-                var prompt = await promptResourceProvider.GetResource<MultipartPrompt>(agent.PromptObjectId, _callContext.CurrentUserIdentity!);
-
+                    throw new ResourceProviderException($"The resource provider {ResourceProviderNames.FoundationaLLM_Prompt} was not loaded.");                                
+                 
+                var prompt = await promptResourceProvider.GetResource<PromptBase>(agent.PromptObjectId, _callContext.CurrentUserIdentity!) as MultipartPrompt;
+                                
                 // We are adding an empty assistant prompt and setting the system prompt to the user role to support
                 // some models (like Mistral) that require user/assistant prompts and not system prompts.
                 systemPrompt = new SystemCompletionMessage


### PR DESCRIPTION
# Fix prompt casting bug

## Details on the issue fix or feature implementation
The GetResource<T> call is unable to cast directly to type MultiPartPrompt, instead request PromptBase then issue an explicit cast.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
