### PR TITLE
Remove LangChain and SemanticKernel APIs from info page

### DIFF
--- a/src/ui/ManagementPortal/pages/info.vue
+++ b/src/ui/ManagementPortal/pages/info.vue
@@ -38,9 +38,7 @@
           { name: 'gatekeeperApiUrl', displayName: 'Gatekeeper API', url: this.$appConfigStore.gatekeeperApiUrl },
           { name: 'gatekeeperIntegrationApiUrl', displayName: 'Gatekeeper Integration API', url: this.$appConfigStore.gatekeeperIntegrationApiUrl },
           { name: 'gatewayApiUrl', displayName: 'Gateway API', url: this.$appConfigStore.gatewayApiUrl },
-          { name: 'langChainApiUrl', displayName: 'LangChain API', url: this.$appConfigStore.langChainApiUrl },
           { name: 'orchestrationApiUrl', displayName: 'Orchestration API', url: this.$appConfigStore.orchestrationApiUrl },
-          { name: 'semanticKernelApiUrl', displayName: 'Semantic Kernel API', url: this.$appConfigStore.semanticKernelApiUrl },
           { name: 'vectorizationApiUrl', displayName: 'Vectorization API', url: this.$appConfigStore.vectorizationApiUrl },
           { name: 'vectorizationWorkerApiUrl', displayName: 'Vectorization Worker API', url: this.$appConfigStore.vectorizationWorkerApiUrl },
         ];


### PR DESCRIPTION
# Remove LangChain and SemanticKernel APIs from info page

## Details on the issue fix or feature implementation

Remove LangChain and SemanticKernel APIs from info page since they are subordinates of the OrchestrationAPI.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
