### PR TITLE
Adding support for unique App Registration and AD Group names in E2E deployment pipeline

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -466,7 +466,7 @@ jobs:
     env:
       AZURE_ENV_NAME: ${{ inputs.environment }}
       AZURE_LOCATION: ${{ inputs.location }}
-    needs: [deploy_quickstart,run_e2e_tests]
+    needs: [generate_matrix,deploy_quickstart,run_e2e_tests]
     steps:
     - name: Sets Credentials for E2E
       run: |
@@ -543,6 +543,12 @@ jobs:
 
         Write-Host "Tear down App Registrations"
         Push-Location ./tests/scripts
-        ./Remove-EntraIdApps.ps1 -interactiveMode $false
+        ./Remove-EntraIdApps.ps1 `
+          -authAppName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -coreAppName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -coreClientAppName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -mgmtAppName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -mgmtClientAppName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -interactiveMode $false
         Pop-Location
       shell: pwsh

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -175,7 +175,7 @@ jobs:
     - name: Install azd
       uses: Azure/setup-azd@v1.0.0
       with:
-        version: '1.9.1'
+        version: '1.9.3'
 
     - name: Log in with Azure (Client Credentials)
       run: |
@@ -399,7 +399,7 @@ jobs:
     - name: Install azd
       uses: Azure/setup-azd@v1.0.0
       with:
-        version: '1.9.1'
+        version: '1.9.3'
 
     - name: Log in with Azure (Client Credentials)
       run: |
@@ -498,7 +498,7 @@ jobs:
     - name: Install azd
       uses: Azure/setup-azd@v1.0.0
       with:
-        version: '1.9.1'
+        version: '1.9.3'
 
     - name: Log in with Azure (Client Credentials)
       run: |

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -59,8 +59,8 @@ jobs:
       id: set-unique-id
       with:
         input: ${{ inputs.environment }}
-        method: SHA256
-        output_len: 8
+        method: SHA3
+        output_len: 32
 
     - name: Set Service Matrix
       uses: actions/github-script@v7

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -49,9 +49,18 @@ jobs:
       service_matrix: ${{ steps.set-service-matrix.outputs.result }}
       test_matrix: ${{ steps.set-test-matrix.outputs.result }}
       docker_tag: ${{ steps.docker-tag.outputs.docker_tag }}
+      unique_id: ${{ steps.set-unique-id.outputs.digest }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Generate Unique ID
+      uses: pplanel/hash-calculator-action@v1.3.1
+      id: set-unique-id
+      with:
+        input: ${{ inputs.environment }}
+        method: SHA256
+        output_len: 8
 
     - name: Set Service Matrix
       uses: actions/github-script@v7
@@ -197,7 +206,12 @@ jobs:
       run: |
         Write-Host "Provision App Registrations"  
         Push-Location ./tests/scripts
-        ./Create-FllmEntraIdApps.ps1
+        ./Create-FllmEntraIdApps.ps1 `
+          -authAppName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -coreAppName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -coreClientAppName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -mgmtAppName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -mgmtClientAppName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }}
         Pop-Location
       shell: pwsh
 
@@ -211,7 +225,9 @@ jobs:
         Push-Location ./tests/scripts
         $spObjectId = $(az ad sp list --filter "appId eq '$($info.clientId)'" --query '[].id' --output tsv)
         Write-Host "SP Object Id: $spObjectId"
-        ./Create-FllmAdminGroup.ps1 -spObjectId $spObjectId
+        ./Create-FllmAdminGroup.ps1 `
+          -groupName FLLM-E2E-Admins-${{ needs.generate_matrix.outputs.unique_id }} `
+          -spObjectId $spObjectId
         Pop-Location
       shell: pwsh
 
@@ -256,7 +272,13 @@ jobs:
         ../../tests/scripts/Set-AzdEnv.ps1 `
           -tenantId $($info.tenantId) `
           -principalType ServicePrincipal `
-          -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176
+          -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176 `
+          -fllmApiName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmClientName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmMgmtApiName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmMgmtClientName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmAuthApiName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmAdminGroupName FLLM-E2E-Admins-${{ needs.generate_matrix.outputs.unique_id }}
         Pop-Location
       shell: pwsh
 
@@ -269,7 +291,6 @@ jobs:
 
         Push-Location ./deploy/quick-start
         azd provision --no-prompt
-        azd env get-values
         Pop-Location
       shell: pwsh
 
@@ -290,7 +311,9 @@ jobs:
       run: |
         Write-Host "Update App Registration OAuth Callbacks"
         Push-Location ./deploy/quick-start
-        pwsh -File ../../tests/scripts/Update-OAuthCallbackUris.ps1
+        pwsh -File ../../tests/scripts/Update-OAuthCallbackUris.ps1 `
+          -fllmChatUiName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
+          -fllmMgmtUiName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }}
         Pop-Location
       shell: pwsh
 

--- a/tests/scripts/Create-FllmAdminGroup.ps1
+++ b/tests/scripts/Create-FllmAdminGroup.ps1
@@ -21,9 +21,6 @@ Param(
 
 # Try block to handle potential errors during the execution
 try {
-    # Define the name of the Azure AD group
-    $groupName = "FLLM-E2E-Admins"
-
     # Build the command to create the Azure AD group using Azure CLI
     $createGroupCommand = "az ad group create --display-name $groupName --mail-nickname $groupName"
 

--- a/tests/scripts/Create-FllmEntraIdApps.ps1
+++ b/tests/scripts/Create-FllmEntraIdApps.ps1
@@ -1,5 +1,13 @@
 #! /usr/bin/pwsh
 
+Param(
+    [parameter(Mandatory = $false)][string]$authAppName="FoundationaLLM-Authorization-E2E",
+    [parameter(Mandatory = $false)][string]$coreAppName="FoundationaLLM-E2E",
+    [parameter(Mandatory = $false)][string]$coreClientAppName="FoundationaLLM-E2E-Client",
+    [parameter(Mandatory = $false)][string]$mgmtAppName="FoundationaLLM-Management-E2E",
+    [parameter(Mandatory = $false)][string]$mgmtClientAppName="FoundationaLLM-Management-E2E-Client"
+)
+
 Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 
@@ -131,8 +139,8 @@ function New-FllmEntraIdApps {
 $fllmAppRegs = @{}
 # Create FoundationaLLM Core App Registrations
 $params = @{
-    fllmApi              = "FoundationaLLM-E2E"
-    fllmClient           = "FoundationaLLM-E2E-Client"
+    fllmApi              = $coreAppName
+    fllmClient           = $coreClientAppName
     fllmApiConfigPath    = "foundationalllm.json"
     fllmClientConfigPath = "foundationalllm-client.json"
     appPermissionsId     = "6da07102-bb6a-421d-a71e-dfdb6031d3d8"
@@ -143,8 +151,8 @@ $($fllmAppRegs).Core = New-FllmEntraIdApps @params
 
 # Create FoundationaLLM Management App Registrations
 $params = @{
-    fllmApi              = "FoundationaLLM-Management-E2E"
-    fllmClient           = "FoundationaLLM-Management-E2E-Client"
+    fllmApi              = $mgmtAppName
+    fllmClient           = $mgmtClientAppName
     fllmApiConfigPath    = "foundationalllm-management.json"
     fllmClientConfigPath = "foundationalllm-managementclient.json"
     appPermissionsId     = "c57f4633-0e58-455a-8ede-5de815fe6c9c"
@@ -155,7 +163,7 @@ $($fllmAppRegs).Management = New-FllmEntraIdApps @params
 
 # Create FoundationaLLM Authorization App Registration
 $params = @{
-    fllmApi           = "FoundationaLLM-Authorization-E2E"
+    fllmApi           = $authAppName
     fllmApiConfigPath = "foundationalllm-authorization.json"
     appPermissionsId  = "9e313dd4-51e4-4989-84d0-c713e38e467d"
     createClientApp   = $false

--- a/tests/scripts/Remove-EntraIdApps.ps1
+++ b/tests/scripts/Remove-EntraIdApps.ps1
@@ -9,11 +9,22 @@
 #>
 
 Param(
+    [parameter(Mandatory = $false)][string]$authAppName="FoundationaLLM-Authorization-E2E",
+    [parameter(Mandatory = $false)][string]$coreAppName="FoundationaLLM-E2E",
+    [parameter(Mandatory = $false)][string]$coreClientAppName="FoundationaLLM-E2E-Client",
+    [parameter(Mandatory = $false)][string]$mgmtAppName="FoundationaLLM-Management-E2E",
+    [parameter(Mandatory = $false)][string]$mgmtClientAppName="FoundationaLLM-Management-E2E-Client",
 	[parameter(Mandatory=$false)][bool]$interactiveMode = $true
 )
 
 # Predefined list of application names to delete
-$AppNames = @("FoundationaLLM-E2E", "FoundationaLLM-Authorization-E2E", "FoundationaLLM-Management-E2E-Client", "FoundationaLLM-Management-E2E", "FoundationaLLM-E2E-Client")
+$AppNames = @(
+	$coreAppName, 
+	$authAppName, 
+	$mgmtClientAppName, 
+	$mgmtAppName, 
+	$coreClientAppName
+)
 
 # Function to filter and delete Azure AD applications based on display name
 function Delete-AppByName {


### PR DESCRIPTION
# Adding support for unique App Registration and AD Group names in E2E deployment pipeline

## The issue or feature being addressed

Addresses ADO task 17643 adding a hash generated from the environment name to the end of the app registration names to prevent collisions between parallel runs/deployments.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

