### PR TITLE
Disable read-only root filesystem for LangChain

### DIFF
--- a/deploy/common/helm/langchain-api/templates/deployment.yaml
+++ b/deploy/common/helm/langchain-api/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
# Disable read-only root filesystem for LangChain

## Details on the issue fix or feature implementation

This PR disables the read-only container file system for the LangChain API container, which is necessary for Knowledge Management agents to work.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
