### PR TITLE
Make path separator os-specific

### DIFF
--- a/deploy/quick-start/azd-hooks/postprovision.ps1
+++ b/deploy/quick-start/azd-hooks/postprovision.ps1
@@ -156,18 +156,21 @@ Invoke-AndRequireSuccess "Loading AppConfig Values" {
 
 if ($IsWindows) {
     $os = "windows"
+    $separator = ";"
 }
 elseif ($IsMacOS) {
     $os = "mac"
+    $separator = ":"
 }
 elseif ($IsLinux) {
     $os = "linux"
+    $separator = ":"
 }
 
 if ($env:PIPELINE_DEPLOY) {
     Write-Host "Using agent provided AzCopy"
 } else {
-    $env:PATH="$($env:PATH):$($pwd.Path)/tools/azcopy_${os}_amd64_${AZCOPY_VERSION}"
+    $env:PATH = $env:PATH, "$($pwd.Path)/tools/azcopy_${os}_amd64_${AZCOPY_VERSION}" -join $separator
 }
 
 $status = (azcopy login status)


### PR DESCRIPTION
# Make path separator os-specific

## The issue or feature being addressed

Post-provision.ps1 fails to find azcopy on Windows.

## Details on the issue fix or feature implementation

Account for the OS path separator differences between *nix and Widnows.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

