### PR TITLE
(0.7.0) Remove old App Config reference from the catalog

### DIFF
--- a/src/dotnet/Common/Constants/Configuration/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Constants/Configuration/AppConfigurationKeys.cs
@@ -521,11 +521,6 @@
         /// </summary>
         public const string FoundationaLLM_LangChain_Summary_ModelName = "FoundationaLLM:LangChain:Summary:ModelName";
         /// <summary>
-        /// The key for the FoundationaLLM:LangChainAPI:Key app configuration setting.
-        /// This is a Key Vault reference.
-        /// </summary>
-        public const string FoundationaLLM_LangChainAPI_Key = "FoundationaLLM:LangChainAPI:Key";
-        /// <summary>
         /// The key for the FoundationaLLM:Management:Entra:CallbackPath app configuration setting.
         /// </summary>
         public const string FoundationaLLM_Management_Entra_CallbackPath = "FoundationaLLM:Management:Entra:CallbackPath";

--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -1330,26 +1330,6 @@ namespace FoundationaLLM.Configuration.Catalog
 
         #endregion
 
-        #region LangChainAPI
-
-        /// <summary>
-        /// The LangChain API configuration entries for the solution.
-        /// </summary>
-        public static readonly List<AppConfigurationEntry> LangChainAPI =
-        [
-            new(
-                key: AppConfigurationKeys.FoundationaLLM_LangChainAPI_Key,
-                minimumVersion: "0.3.0",
-                defaultValue: "Key Vault secret name: `foundationallm-apis-langchainapi-apikey`",
-                description: "This is a Key Vault reference.",
-                keyVaultSecretName: KeyVaultSecretNames.FoundationaLLM_APIs_LangChainAPI_APIKey,
-                contentType: "text/plain",
-                sampleObject: null
-            )
-        ];
-
-        #endregion
-
         #region Management
 
         /// <summary>
@@ -1828,7 +1808,6 @@ namespace FoundationaLLM.Configuration.Catalog
             allEntries.AddRange(Event);
             allEntries.AddRange(Instance);
             allEntries.AddRange(LangChain);
-            allEntries.AddRange(LangChainAPI);
             allEntries.AddRange(Management);
             allEntries.AddRange(ManagementAPI);
             allEntries.AddRange(OpenAI);


### PR DESCRIPTION
# (0.7.0) Remove old App Config reference from the catalog

## The issue or feature being addressed

Fixes startup error after removing the unused `FoundationaLLM:LangChainAPI:Key` App Config key.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
