### PR TITLE
Get Resource bug in SemanticKernelBase

### DIFF
--- a/src/dotnet/SemanticKernel/Agents/SemanticKernelAgentBase.cs
+++ b/src/dotnet/SemanticKernel/Agents/SemanticKernelAgentBase.cs
@@ -98,7 +98,8 @@ namespace FoundationaLLM.SemanticKernel.Core.Agents
                     UserId = "SemanticKernelAPI",
                     Username = "SemanticKernelAPI"
                 });
-            return (result as List<T>)!.First();
+            var resource = (result as List<ResourceProviderGetResult<T>>)!.First().Resource;
+            return resource;
         }
 
         private void ValidateRequest()


### PR DESCRIPTION
# Get Resource bug in SemanticKernelBase

## Details on the issue fix or feature implementation

HandleGetAsync returns List<ResourceGetResult<T>> and not List<T> as was previously anticipated.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable