### PR TITLE
Azure OpenAI Direct Prompt Loading Fix

### DIFF
--- a/src/dotnet/Orchestration/Services/AzureOpenAIDirectService.cs
+++ b/src/dotnet/Orchestration/Services/AzureOpenAIDirectService.cs
@@ -72,7 +72,7 @@ namespace FoundationaLLM.Orchestration.Core.Services
                     if (!_resourceProviderServices.TryGetValue(ResourceProviderNames.FoundationaLLM_Prompt, out var promptResourceProvider))
                         throw new ResourceProviderException($"The resource provider {ResourceProviderNames.FoundationaLLM_Prompt} was not loaded.");
 
-                    var prompt = await promptResourceProvider.GetResource<MultipartPrompt>(agent.PromptObjectId, _callContext.CurrentUserIdentity!);
+                    var prompt = await promptResourceProvider.GetResource<PromptBase>(agent.PromptObjectId, _callContext.CurrentUserIdentity!) as MultipartPrompt;
 
                     systemPrompt = new SystemCompletionMessage
                     {


### PR DESCRIPTION
# Azure OpenAI Direct Prompt Loading Fix

## The issue or feature being addressed

This PR fixes an issue regarding the loading of prompts within the Azure OpenAI Direct orchestrator. This is the same fix present in the AI Direct orchestrator.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
