### PR TITLE
Rename environment variable used by the Python SDK

### DIFF
--- a/deploy/common/helm/agent-hub-api/templates/configmap.yaml
+++ b/deploy/common/helm/agent-hub-api/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data: 
   AZURE_CLIENT_ID: {{ .Values.azureWorkloadIdentity.agentHubApiClientId }}
-  foundationallm-app-configuration-uri: {{ .Values.appConfig.uri }}
+  FOUNDATIONALLM_APP_CONFIGURATION_URI: {{ .Values.appConfig.uri }}

--- a/deploy/common/helm/agent-hub-api/values.yaml
+++ b/deploy/common/helm/agent-hub-api/values.yaml
@@ -28,6 +28,6 @@ ingress:
 env:
   configmap: 
     - name: AZURE_CLIENT_ID
-    - name: foundationallm-app-configuration-uri
+    - name: FOUNDATIONALLM_APP_CONFIGURATION_URI
   secret: {}
   values: {}

--- a/deploy/common/helm/data-source-hub-api/templates/configmap.yaml
+++ b/deploy/common/helm/data-source-hub-api/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data: 
   AZURE_CLIENT_ID: {{ .Values.azureWorkloadIdentity.dataSourceHubApiClientId }}
-  foundationallm-app-configuration-uri: {{ .Values.appConfig.uri }}
+  FOUNDATIONALLM_APP_CONFIGURATION_URI: {{ .Values.appConfig.uri }}

--- a/deploy/common/helm/data-source-hub-api/values.yaml
+++ b/deploy/common/helm/data-source-hub-api/values.yaml
@@ -28,6 +28,6 @@ ingress:
 env:
   configmap: 
     - name: AZURE_CLIENT_ID
-    - name: foundationallm-app-configuration-uri
+    - name: FOUNDATIONALLM_APP_CONFIGURATION_URI
   secret: {}
   values: {}

--- a/deploy/common/helm/gatekeeper-integration-api/templates/configmap.yaml
+++ b/deploy/common/helm/gatekeeper-integration-api/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data: 
   AZURE_CLIENT_ID: {{ .Values.azureWorkloadIdentity.gatekeeperIntegrationApiClientId }}
-  foundationallm-app-configuration-uri: {{ .Values.appConfig.uri }}
+  FOUNDATIONALLM_APP_CONFIGURATION_URI: {{ .Values.appConfig.uri }}

--- a/deploy/common/helm/gatekeeper-integration-api/values.yaml
+++ b/deploy/common/helm/gatekeeper-integration-api/values.yaml
@@ -28,6 +28,6 @@ ingress:
 env:
   configmap: 
     - name: AZURE_CLIENT_ID
-    - name: foundationallm-app-configuration-uri
+    - name: FOUNDATIONALLM_APP_CONFIGURATION_URI
   secret: {}
   values: {}

--- a/deploy/common/helm/langchain-api/templates/configmap.yaml
+++ b/deploy/common/helm/langchain-api/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data: 
   AZURE_CLIENT_ID: {{ .Values.azureWorkloadIdentity.langChainApiClientId }}
-  foundationallm-app-configuration-uri: {{ .Values.appConfig.uri }}
+  FOUNDATIONALLM_APP_CONFIGURATION_URI: {{ .Values.appConfig.uri }}

--- a/deploy/common/helm/langchain-api/values.yaml
+++ b/deploy/common/helm/langchain-api/values.yaml
@@ -28,6 +28,6 @@ ingress:
 env:
   configmap: 
     - name: AZURE_CLIENT_ID
-    - name: foundationallm-app-configuration-uri
+    - name: FOUNDATIONALLM_APP_CONFIGURATION_URI
   secret: {}
   values: {}

--- a/deploy/common/helm/prompt-hub-api/templates/configmap.yaml
+++ b/deploy/common/helm/prompt-hub-api/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data: 
   AZURE_CLIENT_ID: {{ .Values.azureWorkloadIdentity.promptHubApiClientId }}
-  foundationallm-app-configuration-uri: {{ .Values.appConfig.uri }}
+  FOUNDATIONALLM_APP_CONFIGURATION_URI: {{ .Values.appConfig.uri }}

--- a/deploy/common/helm/prompt-hub-api/values.yaml
+++ b/deploy/common/helm/prompt-hub-api/values.yaml
@@ -28,6 +28,6 @@ ingress:
 env:
   configmap: 
     - name: AZURE_CLIENT_ID
-    - name: foundationallm-app-configuration-uri
+    - name: FOUNDATIONALLM_APP_CONFIGURATION_URI
   secret: {}
   values: {}

--- a/deploy/quick-start/infra/main.parameters.json
+++ b/deploy/quick-start/infra/main.parameters.json
@@ -110,7 +110,7 @@
             "useEndpoint": true,
             "hasIngress": true,
             "image": "${SERVICE_AGENTHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/agent-hub-api:${FLLM_VERSION}}",
-            "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
+            "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
             "apiKeySecretName": "foundationallm-apis-agenthubapi-apikey"
           },
           {
@@ -142,7 +142,7 @@
             "useEndpoint": true,
             "hasIngress": true,
             "image": "${SERVICE_DATASOURCEHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/data-source-hub-api:${FLLM_VERSION}}",
-            "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
+            "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
             "apiKeySecretName": "foundationallm-apis-datasourcehubapi-apikey"
           },
           {
@@ -158,7 +158,7 @@
             "useEndpoint": true,
             "hasIngress": true,
             "image": "${SERVICE_GATEKEEPERINTEGRATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/gatekeeper-integration-api:${FLLM_VERSION}}",
-            "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
+            "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
             "apiKeySecretName": "foundationallm-apis-gatekeeperintegrationapi-apikey"
           },
           {
@@ -174,7 +174,7 @@
             "useEndpoint": true,
             "hasIngress": true,
             "image": "${SERVICE_LANGCHAINAPI_IMAGE=cropseastus2svinternal.azurecr.io/langchain-api:${FLLM_VERSION}}",
-            "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
+            "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
             "apiKeySecretName": "foundationallm-apis-langchainapi-apikey"
           },
           {
@@ -206,7 +206,7 @@
             "useEndpoint": true,
             "hasIngress": true,
             "image": "${SERVICE_PROMPTHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/prompt-hub-api:${FLLM_VERSION}}",
-            "appConfigEnvironmentVarName": "foundationallm-app-configuration-uri",
+            "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
             "apiKeySecretName": "foundationallm-apis-prompthubapi-apikey"
           },
           {

--- a/docs/development/development-local.md
+++ b/docs/development/development-local.md
@@ -4,7 +4,7 @@
 
 - Environment variables:
   - Create an environment variable for the Application Configuration Service connection string named `FoundationaLLM_AppConfig_ConnectionString`. This is used by the .NET projects.
-  - Create an environment variable for the Application Configuration Service URI named `foundationallm-app-configuration-uri`. This is used by the Python projects.
+  - Create an environment variable for the Application Configuration Service URI named `FOUNDATIONALLM_APP_CONFIGURATION_URI`. This is used by the Python projects.
   - Create an environment variable named `FOUNDATIONALLM_VERSION` and set it to the version of the FoundationaLLM deployment you are working with. This is used by the .NET projects to validate your environment configuration based on the version.
 
 > [!TIP]
@@ -337,11 +337,11 @@ The `CoreWorker` project is a .NET worker service that acts as the Cosmos DB cha
 
 ### Python Environment Variables
 
-Create a local environment variable named `foundationallm-app-configuration-uri`. The value should be the URI of the Azure App Configuration service and _not_ the connection string. We use role-based access controls (RBAC) to access the Azure App Configuration service, so the connection string is not required.
+Create a local environment variable named `FOUNDATIONALLM_APP_CONFIGURATION_URI`. The value should be the URI of the Azure App Configuration service and _not_ the connection string. We use role-based access controls (RBAC) to access the Azure App Configuration service, so the connection string is not required.
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
-| foundationallm-app-configuration-uri | REDACTED | Azure App Configuration URI |
+| FOUNDATIONALLM_APP_CONFIGURATION_URI | REDACTED | Azure App Configuration URI |
 
 ## Running the solution locally
 

--- a/src/python/IntegrationSDK/foundationallm/integration/config/configuration.py
+++ b/src/python/IntegrationSDK/foundationallm/integration/config/configuration.py
@@ -33,7 +33,7 @@ class Configuration:
 
         Raises an exception if the configuration value is not found.
         """
-        app_config_uri = os.environ['foundationallm-app-configuration-uri']
+        app_config_uri = os.environ['FOUNDATIONALLM_APP_CONFIGURATION_URI']
         credential = DefaultAzureCredential(
             exclude_environment_credential=True)
         # Connect to Azure App Configuration with key filter

--- a/src/python/PythonSDK/foundationallm/config/configuration.py
+++ b/src/python/PythonSDK/foundationallm/config/configuration.py
@@ -12,7 +12,7 @@ class Configuration():
     def __init__(self):
         """Init"""
         try:
-            app_config_uri = os.environ['foundationallm-app-configuration-uri']
+            app_config_uri = os.environ['FOUNDATIONALLM_APP_CONFIGURATION_URI']
         except Exception as e:
             raise e
 

--- a/tests/python/IntegrationSDK.Tests/foundationallm/integration/config/configuration_tests.py
+++ b/tests/python/IntegrationSDK.Tests/foundationallm/integration/config/configuration_tests.py
@@ -10,7 +10,7 @@ class ConfigurationTests:
     ConfigurationTests is responsible for testing the application configuration functionality .
     
     This is an integration test class and expects the following environment variable to be set:
-        foundationallm-app-configuration-uri      
+        FOUNDATIONALLM_APP_CONFIGURATION_URI      
             
     This test class also expects a valid Azure credential (DefaultAzureCredential) session.
     """

--- a/tests/python/PythonSDK.Tests/config/configuration_tests.py
+++ b/tests/python/PythonSDK.Tests/config/configuration_tests.py
@@ -13,13 +13,13 @@ class ConfigurationTests:
     ConfigurationTests is responsible for testing the application configuration functionality.
     
     This is an integration test class and expects the following environment variable to be set:
-        foundationallm-app-configuration-uri
+        FOUNDATIONALLM_APP_CONFIGURATION_URI
         
     This test class also expects a valid Azure credential (DefaultAzureCredential) session.
     """
 
     def test_config_setting_change(self):        
-        app_config_uri = os.environ['foundationallm-app-configuration-uri']
+        app_config_uri = os.environ['FOUNDATIONALLM_APP_CONFIGURATION_URI']
         client = AzureAppConfigurationClient(app_config_uri, DefaultAzureCredential())
         config_setting = client.add_configuration_setting(ConfigurationSetting(
             key='FoundationaLLM:Test:TestSetting',


### PR DESCRIPTION
# Rename environment variable used by the Python SDK

## The issue or feature being addressed

`foundationallm-app-configuration-uri` -> `FOUNDATIONALLM_APP_CONFIGURATION_URI`

## Details on the issue fix or feature implementation

Due to the hyphens contained in the name, the original environment variable cannot be set in Azure Web Applications.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
