### PR TITLE
Release 0.7.0 : Set the type when adding a role assignment

### DIFF
--- a/src/dotnet/Authorization/Services/AuthorizationCore.cs
+++ b/src/dotnet/Authorization/Services/AuthorizationCore.cs
@@ -216,7 +216,8 @@ namespace FoundationaLLM.Authorization.Services
                     if (!exists)
                     {
                         var roleAssignment = new RoleAssignment()
-                        { 
+                        {
+                            Type = $"{ResourceProviderNames.FoundationaLLM_Authorization}/{AuthorizationResourceTypeNames.RoleAssignments}",
                             Name = roleAssignmentRequest.Name,
                             Description = roleAssignmentRequest.Description,
                             ObjectId = roleAssignmentRequest.ObjectId,


### PR DESCRIPTION
# Set the type when adding a role assignment

## The issue or feature being addressed

Type property is null for new role assignments.

## Details on the issue fix or feature implementation

Sets the type property when creating a new role assignment.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
