### PR TITLE
Integrate Prompt Shields service with Gatekeeper API

### DIFF
--- a/src/dotnet/Gatekeeper/Interfaces/IContentSafetyService.cs
+++ b/src/dotnet/Gatekeeper/Interfaces/IContentSafetyService.cs
@@ -14,4 +14,11 @@ public interface IContentSafetyService
     /// <returns>The text analysis restult, which includes a boolean flag that represents if the content is considered safe. 
     /// In case the content is unsafe, also returns the reason.</returns>
     Task<AnalyzeTextFilterResult> AnalyzeText(string content);
+
+    /// <summary>
+    /// Detects attempted prompt injections and jailbreaks in user prompts.
+    /// </summary>
+    /// <param name="content">The text content that needs to be analyzed.</param>
+    /// <returns>The text analysis restult, which includes flags that represents if the content contains prompt injections or jailbreaks.</returns>
+    Task<string?> DetectPromptInjection(string content);
 }

--- a/src/dotnet/Gatekeeper/Models/ContentSafety/PromptShieldResult.cs
+++ b/src/dotnet/Gatekeeper/Models/ContentSafety/PromptShieldResult.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Gatekeeper.Core.Models.ContentSafety
+{
+    /// <summary>
+    /// Prompt shield result.
+    /// </summary>
+    public class PromptShieldResult
+    {
+        /// <summary>
+        /// Contains analysis results for the user prompt.	
+        /// </summary>
+        [JsonPropertyName("userPromptAnalysis")]
+        public required PromptShieldDetails UserPromptAnalysis { get; set; }
+
+        /// <summary>
+        /// Contains a list of analysis results for each document provided.
+        /// </summary>
+        [JsonPropertyName("documentsAnalysis")]
+        public required List<PromptShieldDetails> DocumentsAnalysis { get; set; }
+    }
+
+    /// <summary>
+    /// Contains analysis results for the user prompt.
+    /// </summary>
+    public class PromptShieldDetails
+    {
+        /// <summary>
+        /// Indicates whether a User Prompt attack (for example, malicious input, security threat) has been detected in the user prompt.
+        /// </summary>
+        [JsonPropertyName("attackDetected")]
+        public bool AttackDetected { get; set; }
+    }
+}

--- a/src/dotnet/Gatekeeper/Services/AzureContentSafetyService.cs
+++ b/src/dotnet/Gatekeeper/Services/AzureContentSafetyService.cs
@@ -6,6 +6,9 @@ using FoundationaLLM.Gatekeeper.Core.Models.ConfigurationOptions;
 using FoundationaLLM.Gatekeeper.Core.Models.ContentSafety;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Text;
+using System.Text.Json;
+
 
 namespace FoundationaLLM.Gatekeeper.Core.Services
 {
@@ -14,6 +17,7 @@ namespace FoundationaLLM.Gatekeeper.Core.Services
     /// </summary>
     public class AzureContentSafetyService : IContentSafetyService
     {
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ContentSafetyClient _client;
         private readonly AzureContentSafetySettings _settings;
         private readonly ILogger _logger;
@@ -21,24 +25,22 @@ namespace FoundationaLLM.Gatekeeper.Core.Services
         /// <summary>
         /// Constructor for the Azure Content Safety service.
         /// </summary>
+        /// <param name="httpClientFactory">The HTTP client factory.</param>
         /// <param name="options">The configuration options for the Azure Content Safety service.</param>
         /// <param name="logger">The logger for the Azure Content Safety service.</param>
         public AzureContentSafetyService(
+            IHttpClientFactory httpClientFactory,
             IOptions<AzureContentSafetySettings> options,
             ILogger<AzureContentSafetyService> logger)
         {
+            _httpClientFactory = httpClientFactory;
             _settings = options.Value;
             _logger = logger;
 
             _client = new ContentSafetyClient(new Uri(_settings.APIUrl), DefaultAuthentication.AzureCredential);
         }
 
-        /// <summary>
-        /// Checks if a text is safe or not based on pre-configured content filters.
-        /// </summary>
-        /// <param name="content">The text content that needs to be analyzed.</param>
-        /// <returns>The text analysis restult, which includes a boolean flag that represents if the content is considered safe. 
-        /// In case the content is unsafe, also returns the reason.</returns>
+        /// <inheritdoc/>
         public async Task<AnalyzeTextFilterResult> AnalyzeText(string content)
         {
             var request = new AnalyzeTextOptions(content);
@@ -86,6 +88,42 @@ namespace FoundationaLLM.Gatekeeper.Core.Services
             }
 
             return new AnalyzeTextFilterResult() { Safe = safe, Reason = safe ? string.Empty : reason };
+        }
+
+        /// <inheritdoc/>
+        public async Task<string?> DetectPromptInjection(string content)
+        {
+            var client = CreateHttpClient();
+
+            var response = await client.PostAsync("/contentsafety/text:shieldPrompt?api-version=2024-02-15-preview",
+                new StringContent(JsonSerializer.Serialize(new
+                {
+                    userPrompt = content,
+                    documents = new List<string>()
+                }),
+                Encoding.UTF8, "application/json"));
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var results = JsonSerializer.Deserialize<PromptShieldResult>(responseContent);
+
+                if (results!.UserPromptAnalysis.AttackDetected)
+                {
+                    return "The prompt text did not pass the safety filter. Reason: Prompt injection or jailbreak detected.";
+                }
+            }
+            return null;
+        }
+
+        private HttpClient CreateHttpClient()
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            httpClient.BaseAddress = new Uri(_settings.APIUrl);
+            httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", _settings.APIKey);
+
+            return httpClient;
         }
     }
 }

--- a/src/dotnet/Gatekeeper/Services/GatekeeperService.cs
+++ b/src/dotnet/Gatekeeper/Services/GatekeeperService.cs
@@ -67,6 +67,11 @@ namespace FoundationaLLM.Gatekeeper.Core.Services
 
             if (_gatekeeperServiceSettings.EnableAzureContentSafety)
             {
+                var promptInjectionResult = await _contentSafetyService.DetectPromptInjection(completionRequest.UserPrompt!);
+
+                if (!string.IsNullOrWhiteSpace(promptInjectionResult))
+                    return new CompletionResponse() { Completion = promptInjectionResult };
+
                 var contentSafetyResult = await _contentSafetyService.AnalyzeText(completionRequest.UserPrompt!);
 
                 if (!contentSafetyResult.Safe)


### PR DESCRIPTION
# Integrate Prompt Shields service with Gatekeeper API

## Details on the issue fix or feature implementation

Implements the /contentsafety/text:shieldPrompt endpoint of Prompt Shields service.
Detect prompt injection or jailbreaks.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
