### PR TITLE
(0.7.0) Include v1 token scope check for detecting service principals

### DIFF
--- a/src/dotnet/Common/Services/Security/EntraUserClaimsProviderService.cs
+++ b/src/dotnet/Common/Services/Security/EntraUserClaimsProviderService.cs
@@ -30,7 +30,8 @@ namespace FoundationaLLM.Common.Services.Security
         /// <inheritdoc/>
         public bool IsServicePrincipal(ClaimsPrincipal userPrincipal) =>
             // Service Principal tokens do not have a "scp" claim
-            userPrincipal.FindFirstValue(ClaimConstants.Scp) == null;
+            userPrincipal.FindFirstValue(ClaimConstants.Scp) == null &&
+            userPrincipal.FindFirstValue(ClaimConstants.Scope) == null;
 
         /// <summary>
         /// Resolves the username from the provided <see cref="ClaimsPrincipal"/> object.


### PR DESCRIPTION
# (0.7.0) Include v1 token scope check for detecting service principals

## The issue or feature being addressed

When an authenticated user has a v1 vs. v2 auth token, the `EntraUserClaimsProviderService.IsServicePrincipal` method incorrectly identifies the user as a service principal account since the token does not contain an `scp` claim. This PR adds an additional check for the v1 scope claim.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
