### PR TITLE
Bring Your Own Network 

### DIFF
--- a/deploy/standard/scripts/tests/New-BYO-Network.ps1
+++ b/deploy/standard/scripts/tests/New-BYO-Network.ps1
@@ -1,0 +1,72 @@
+#! /usr/bin/pwsh
+
+Param(
+    [parameter(Mandatory = $false)][bool]$init = $true,
+    [parameter(Mandatory = $false)][string]$manifestName = "Deployment-Manifest.json"
+)
+
+Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+function Invoke-CLICommand {
+    <#
+    .SYNOPSIS
+    Invoke a CLI Command and allow all output to print to the terminal.  Does not check for return values or pass the output to the caller.
+    #>
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Message,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [ScriptBlock]$ScriptBlock
+    )
+
+    Write-Host "${message}..." -ForegroundColor Blue
+    & $ScriptBlock
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed ${message} (code: ${LASTEXITCODE})"
+    }
+}
+
+
+# Navigate to the script directory so that we can use relative paths.
+Push-Location $($MyInvocation.InvocationName | Split-Path)
+try {
+    Write-Host "Loading Deployment Manifest ../../${manifestName}" -ForegroundColor Blue
+    $manifest = $(Get-Content -Raw -Path ../../${manifestName} | ConvertFrom-Json)
+
+    if ($init) {
+        Invoke-CLICommand "Login to Azure" {
+            az login
+            az account set --subscription $manifest.subscription
+            az account show
+        }
+    }
+
+    # Convert the manifest resource groups to a hashtable for easier access
+    $resourceGroup = @{}
+    $manifest.resourceGroups.PSObject.Properties | ForEach-Object { $resourceGroup[$_.Name] = $_.Value }
+    $vnetName = "vnet-$($manifest.project)-$($manifest.environment)-$($manifest.location)-pre"
+
+    # Use the Azure CLI to create the "net" resource group
+    Invoke-CLICommand "Create Resource Group" {
+        az group create `
+            --name $resourceGroup["net"] `
+            --location $manifest.location
+    }
+
+    # Use the Azure CLI to create a virtual network in the resource group
+    Invoke-CLICommand "Create Virtual Network" {
+        az network vnet create `
+            --name $vnetName `
+            --resource-group $resourceGroup["net"] `
+            --location $manifest.location `
+            --address-prefixes '10.220.128.0/21'
+    }
+}
+finally {
+    Pop-Location
+    Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+}

--- a/docs/deployment/standard/manifest.md
+++ b/docs/deployment/standard/manifest.md
@@ -25,6 +25,7 @@ The root section of the Deployment Manifest defines the general properties of th
 | `k8sNamespace`     | The Kubernetes namespace for the FLLM Helm deployments.              | String               | `fllm`                                 |
 | `letsEncryptEmail` | The email address for Let's Encrypt notifications.                   | Email Address        | `admin@example.com`                    |
 | `location`         | The Azure region where the deployment resources will be created.     | Azure Region         | `eastus2`, `francecentral`             |
+| `networkName`      | The name of the network pre-provisioned before the deployment.       | String               | `fllm-network`                         |
 | `project`          | A token for naming deployment resources in the environment.          | String               | `ai`, `fllm`, `rd`, `fred`, `sally`    |
 | `subscription`     | The Azure subscription ID for the deployment.                        | GUID                 | `ad82622e-458a-4a48-8023-6b18eed1cf79` |
 
@@ -48,6 +49,8 @@ The root section of the Deployment Manifest defines the general properties of th
     | **Sweden Central** | X                          | X                   | X                    | X              |
     | **UK South**       | X                          | X                   | X                    | X              |
     | West US            | X                          |                     | X                    |                |
+
+- `networkName` is the name of the network pre-provisioned before the deployment.  The deployment will create the requird subnets and other networking resources in this network.  If you do not have a pre-provisioned network, the template will create one for you.  The network should be created in the networking resource group described later in the manifest.
 
 ## Entra Client IDs
 


### PR DESCRIPTION
# Bring Your Own Network 

## The issue or feature being addressed

Some organizations have policies segregating who can deploy network resources.  To support these organizations, we need to consume a pre-provisioned network created before the standard deployment runs.

## Details on the issue fix or feature implementation

If the network name is provided in the deployment manifest, the template will use it when provisioning subnets and other resources in the networking resource group.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable


