### PR TITLE
Translate an attachment object_id into a data lake url in Orchestration API

### DIFF
--- a/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
+++ b/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
@@ -348,10 +348,18 @@ namespace FoundationaLLM.Attachment.ResourceProviders
                 ?? throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId!} of type {resourcePath.ResourceTypeInstances[0].ResourceType} was not found.");
         }
 
+        /// <inheritdoc/>
+        protected override T GetResourceReferenceInternal<T>(ResourcePath resourcePath)
+        {
+            _attachmentReferences.TryGetValue(resourcePath.ResourceTypeInstances[0].ResourceId!, out var attachmentReference);
+            return attachmentReference as T
+                ?? throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId!} of type {resourcePath.ResourceTypeInstances[0].ResourceType} was not found."); ;
+        }
+
 
         #region Event handling
 
-        /// <inheritdoc/>
+            /// <inheritdoc/>
         protected override async Task HandleEvents(EventSetEventArgs e)
         {
             _logger.LogInformation("{EventsCount} events received in the {EventsNamespace} events namespace.",

--- a/src/dotnet/Common/Interfaces/IResourceProviderService.cs
+++ b/src/dotnet/Common/Interfaces/IResourceProviderService.cs
@@ -38,5 +38,13 @@ namespace FoundationaLLM.Common.Interfaces
         /// <param name="resource">The instance of the resource being created or updated.</param>
         /// <returns>The object id of the resource.</returns>
         Task<string> UpsertResourceAsync<T>(string resourcePath, T resource) where T : class;
+
+        /// <summary>
+        /// Gets a resource reference based on its logical path.
+        /// </summary>
+        /// <typeparam name="T">The type of the resource.</typeparam>
+        /// <param name="resourcePath">The logical path of the resource.</param>
+        /// <returns>The reference of the resource corresponding to the specified logical path.</returns>
+        T GetResourceReference<T>(string resourcePath) where T : ResourceReference;
     }
 }

--- a/src/dotnet/Common/Models/Orchestration/CompletionRequest.cs
+++ b/src/dotnet/Common/Models/Orchestration/CompletionRequest.cs
@@ -13,4 +13,10 @@ public class CompletionRequest : OrchestrationRequest
     /// </summary>
     [JsonPropertyName("message_history")]
     public List<MessageHistoryItem>? MessageHistory { get; init; } = [];
+
+    /// <summary>
+    /// The list of attachment object IDs associated with the completion request.
+    /// </summary>
+    [JsonPropertyName("attachment_object_ids")]
+    public List<string>? AttachmentObjectIds { get; set; }
 }

--- a/src/dotnet/Common/Models/Orchestration/LLMCompletionRequest.cs
+++ b/src/dotnet/Common/Models/Orchestration/LLMCompletionRequest.cs
@@ -37,5 +37,11 @@ namespace FoundationaLLM.Common.Models.Orchestration
         /// </summary>
         [JsonPropertyName("settings")]
         public OrchestrationSettings? Settings { get; set; }
+
+        /// <summary>
+        /// List of attachment data lake URLs.
+        /// </summary>
+        [JsonPropertyName("attachment_data_lake_urls")]
+        public List<string>? AttachmentDataLakeUrls { get; set; }
     }
 }

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -348,6 +348,15 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
             return parsedResourcePath.GetObjectId(_instanceSettings.Id, _name);
         }
 
+        /// <inheritdoc/>
+        public T GetResourceReference<T>(string resourcePath) where T : ResourceReference
+        {
+            if (!_isInitialized)
+                throw new ResourceProviderException($"The resource provider {_name} is not initialized.");
+            var parsedResourcePath = new ResourcePath(resourcePath, _allowedResourceProviders, _allowedResourceTypes);
+            return GetResourceReferenceInternal<T>(parsedResourcePath);
+        }
+
         #region Virtuals to override in derived classes
 
         /// <summary>
@@ -369,6 +378,15 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
             await Task.CompletedTask;
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// The internal implementation of GetResourceReference. Must be overridden in derived classes.
+        /// </summary>
+        /// <param name="resourcePath">A <see cref="ResourcePath"/> containing information about the resource path.</param>
+        /// <returns></returns>
+        protected virtual T GetResourceReferenceInternal<T>(ResourcePath resourcePath) where T : ResourceReference =>
+            throw new NotImplementedException();
+
 
         #endregion
 

--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -1,7 +1,9 @@
 ﻿using FoundationaLLM.Common.Constants.ResourceProviders;
+using FoundationaLLM.Common.Exceptions;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Orchestration;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
+using FoundationaLLM.Common.Models.ResourceProviders.Prompt;
 using FoundationaLLM.Orchestration.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 
@@ -21,11 +23,13 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
         KnowledgeManagementAgent agent,
         ICallContext callContext,
         ILLMOrchestrationService orchestrationService,
-        ILogger<OrchestrationBase> logger) : OrchestrationBase(orchestrationService)
+        ILogger<OrchestrationBase> logger,
+        Dictionary<string, IResourceProviderService> resourceProviderServices) : OrchestrationBase(orchestrationService)
     {
         private readonly ICallContext _callContext = callContext;
         private readonly ILogger<OrchestrationBase> _logger = logger;
         private readonly KnowledgeManagementAgent _agent = agent;
+        private readonly Dictionary<string, IResourceProviderService> _resourceProviderServices = resourceProviderServices;
 
         /// <inheritdoc/>
         public override async Task<CompletionResponse> GetCompletion(CompletionRequest completionRequest)
@@ -36,7 +40,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                     UserPrompt = completionRequest.UserPrompt!,
                     Agent = _agent,
                     MessageHistory = completionRequest.MessageHistory,
-                    Settings = completionRequest.Settings
+                    Settings = completionRequest.Settings,
+                    AttachmentDataLakeUrls = await GetUrlFromObjectId(completionRequest.AttachmentObjectIds)
                 });
 
             if (result.Citations != null)
@@ -58,6 +63,23 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                 PromptTokens = result.PromptTokens,
                 CompletionTokens = result.CompletionTokens,
             };
+        }
+
+        private async Task<List<string>> GetUrlFromObjectId(List<string>? attachmentObjectIds)
+        {
+            //if (!resourceProviderServices.TryGetValue(ResourceProviderNames.FoundationaLLM_Attachment, out var attachmentResourceProvider))
+            //    throw new OrchestrationException($"The resource provider {ResourceProviderNames.FoundationaLLM_Attachment} was not loaded.");
+
+            List<string> result = new List<string>();
+            //foreach(var attachmentObjectId in attachmentObjectIds)
+            //{
+            //    var attachment = await attachmentResourceProvider.GetResource<Attachment>(
+            //       attachmentObjectId,
+            //       _callContext.CurrentUserIdentity);
+
+            //    result.Add(attachmentURL);
+            //}
+            return result;
         }
     }
 }

--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -57,7 +57,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                     (KnowledgeManagementAgent)agentBase,
                     callContext,
                     orchestrationService,
-                    loggerFactory.CreateLogger<OrchestrationBase>());
+                    loggerFactory.CreateLogger<OrchestrationBase>(),
+                    resourceProviderServices);
 
                 return kmOrchestration;
             }

--- a/src/dotnet/Orchestration/Services/OrchestrationService.cs
+++ b/src/dotnet/Orchestration/Services/OrchestrationService.cs
@@ -124,6 +124,7 @@ public class OrchestrationService : IOrchestrationService
                 SessionId = completionRequest.SessionId,
                 Settings = completionRequest.Settings,
                 MessageHistory = completionRequest.MessageHistory,
+                AttachmentObjectIds = completionRequest.AttachmentObjectIds,
                 UserPrompt = currentCompletionResponse == null
                     ? conversationStep.UserPrompt
                     : $"{currentCompletionResponse.Completion}{Environment.NewLine}{conversationStep.UserPrompt}"

--- a/src/dotnet/OrchestrationAPI/OrchestrationAPI.csproj
+++ b/src/dotnet/OrchestrationAPI/OrchestrationAPI.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Attachments\Attachment.csproj" />
     <ProjectReference Include="..\Configuration\Configuration.csproj" />
     <ProjectReference Include="..\Orchestration\Orchestration.csproj" />
     <ProjectReference Include="..\Agent\Agent.csproj" />

--- a/src/dotnet/OrchestrationAPI/Program.cs
+++ b/src/dotnet/OrchestrationAPI/Program.cs
@@ -59,6 +59,7 @@ namespace FoundationaLLM.Orchestration.API
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_DataSource);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_Attachment);
             });
             if (builder.Environment.IsDevelopment())
                 builder.Configuration.AddJsonFile("appsettings.development.json", true, true);
@@ -129,6 +130,7 @@ namespace FoundationaLLM.Orchestration.API
             builder.AddVectorizationResourceProvider();
             builder.AddConfigurationResourceProvider();
             builder.AddDataSourceResourceProvider();
+            builder.AddAttachmentResourceProvider();
 
             // Register the downstream services and HTTP clients.
             RegisterDownstreamServices(builder);

--- a/src/python/PythonSDK/foundationallm/models/orchestration/completion_request_base.py
+++ b/src/python/PythonSDK/foundationallm/models/orchestration/completion_request_base.py
@@ -11,4 +11,5 @@ class CompletionRequestBase(BaseModel):
     session_id: Optional[str] = None
     user_prompt: str    
     message_history: Optional[List[MessageHistoryItem]] = []
+    attachment_data_lake_urls: Optional[List[str]] = None
     settings: Optional[OrchestrationSettings] = None


### PR DESCRIPTION
# Translate an attachment object_id into a data lake url in Orchestration API

## Details on the issue fix or feature implementation

Convert object ids into data lake urls

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
