### PR TITLE
Changing CMD to ENTRYPOINT in Dockerfiles to resolve issue in Standard deployment for frontends

### DIFF
--- a/src/ui/ManagementPortal/Dockerfile
+++ b/src/ui/ManagementPortal/Dockerfile
@@ -30,6 +30,6 @@ ENV PORT=$PORT
 
 COPY --from=build /src/.output /src/.output
 
-CMD [ "node", ".output/server/index.mjs" ]
+ENTRYPOINT [ "node", ".output/server/index.mjs" ]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
 LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}

--- a/src/ui/UserPortal/Dockerfile
+++ b/src/ui/UserPortal/Dockerfile
@@ -30,6 +30,6 @@ ENV PORT=$PORT
 
 COPY --from=build /src/.output /src/.output
 
-CMD [ "node", ".output/server/index.mjs" ]
+ENTRYPOINT [ "node", ".output/server/index.mjs" ]
 LABEL org.opencontainers.image.source=https://github.com/solliancenet/foundationallm
 LABEL ai.foundationallm.version=${FOUNDATIONALLM_VERSION:-0.0.0}


### PR DESCRIPTION
# Changing CMD to ENTRYPOINT in Dockerfiles to resolve issue in Standard deployment for frontends

## The issue or feature being addressed

Resolves Task 17831 (ADO)

## Details on the issue fix or feature implementation

The frontend Docker images are not being created because they specify the entrypoint into the container using a CMD directive instead of an ENTRYPOINT.  The AKS cluster is refusing to start the frontend containers because of this. This PR makes this change. 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

