### PR TITLE
Use connection string for Gateway API

### DIFF
--- a/deploy/quick-start/infra/main.parameters.json
+++ b/deploy/quick-start/infra/main.parameters.json
@@ -163,7 +163,7 @@
           },
           {
             "name": "gateway-api",
-            "useEndpoint": true,
+            "useEndpoint": false,
             "hasIngress": true,
             "image": "${SERVICE_GATEWAYAPI_IMAGE=cropseastus2svinternal.azurecr.io/gateway-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",


### PR DESCRIPTION
# Use connection string for Gateway API

## The issue or feature being addressed

Gateway API ACA currently receives the App Config URI, rather than the Connection String.

## Details on the issue fix or feature implementation

This PR enables the Gateway API ACA instance to receive the App Config Connection String.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
