### PR TITLE
Setting up e2e testing workflow to be called from a daily workflow

### DIFF
--- a/.github/workflows/e2e-daily-testing.yml
+++ b/.github/workflows/e2e-daily-testing.yml
@@ -1,0 +1,19 @@
+name: Daily End to End Testing
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  daily_e2e_test:
+    uses: ./.github/workflows/e2e-testing.yml
+    with:
+      environment: fllm-e2e-aca-daily
+      deployOpenAi: true
+      openAiName: fllm-01
+      openAiResourceGroup: fllm-shared-01
+      location: EastUS2
+      enableTeardown: true
+      bypassAndTeardown: false
+      target: e2e

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -44,6 +44,32 @@ on:
           - sandbox
           - e2e
         default: e2e
+  workflow_call:
+    inputs:
+      environment:
+        description: AZD Environment Name
+        type: string
+      deployOpenAi:
+        description: Deploy a new OpenAI Instance
+        type: boolean
+      openAiName:
+        description: Shared OpenAI Instance Name
+        type: string
+      openAiResourceGroup:
+        description: Shared OpenAI Resource Group
+        type: string
+      location:
+        description: AZD Target Location
+        type: string
+      enableTeardown:
+        description: Enable teardown of environment
+        type: boolean
+      bypassAndTeardown:
+        description: Bypass Tests and Force Teardown
+        type: boolean
+      target:
+        description: Select target tenant/subscription
+        type: string
 
 jobs:
   generate_matrix:


### PR DESCRIPTION
# Setting up e2e testing workflow to be called from a daily workflow

## The issue or feature being addressed

End to End tests need to be triggered daily.

## Details on the issue fix or feature implementation

Calling the existing e2e action as a workflow call from a daily triggered workflow that sets up the inputs.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
