### PR TITLE
Excel parsing fixes, remove non-required app settings from catalog

### DIFF
--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -1926,9 +1926,7 @@ namespace FoundationaLLM.Configuration.Catalog
             allEntries.AddRange(AgentHub);
             allEntries.AddRange(APIs);
             allEntries.AddRange(Attachment);
-            allEntries.AddRange(AzureContentSafety);
-            allEntries.AddRange(LakeraGuard);
-            allEntries.AddRange(EnkryptGuardrails);
+            allEntries.AddRange(AzureContentSafety);            
             allEntries.AddRange(AzureOpenAI);
             allEntries.AddRange(BlobStorageMemorySource);
             allEntries.AddRange(Branding);

--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -633,64 +633,6 @@ namespace FoundationaLLM.Configuration.Catalog
 
         #endregion
 
-        #region LakeraGuard
-
-        /// <summary>
-        /// The Lakera Guard configuration entries for the solution.
-        /// </summary>
-        public static readonly List<AppConfigurationEntry> LakeraGuard =
-        [
-            new(
-                key: AppConfigurationKeys.FoundationaLLM_APIs_Gatekeeper_LakeraGuard_APIKey,
-                minimumVersion: "0.7.0",
-                defaultValue: "Key Vault secret name: `foundationallm-lakera-guard-api-key`",
-                description: "This is a Key Vault reference.",
-                keyVaultSecretName: KeyVaultSecretNames.FoundationaLLM_AzureContentSafety_APIKey,
-                contentType: "text/plain",
-                sampleObject: null
-            ),
-
-            new(
-                key: AppConfigurationKeys.FoundationaLLM_APIs_Gatekeeper_LakeraGuard_APIUrl,
-                minimumVersion: "0.7.0",
-                defaultValue: "Enter the URL to the service.",
-                description: "",
-                keyVaultSecretName: "",
-                contentType: "text/plain",
-                sampleObject: null
-            ),
-        ];
-        #endregion
-
-        #region Enkrypt Guardrails
-
-        /// <summary>
-        /// The Enkrypt Guardrails configuration entries for the solution.
-        /// </summary>
-        public static readonly List<AppConfigurationEntry> EnkryptGuardrails =
-        [
-            new(
-                key: AppConfigurationKeys.FoundationaLLM_APIs_Gatekeeper_EnkryptGuardrails_APIKey,
-                minimumVersion: "0.7.0",
-                defaultValue: "Key Vault secret name: `foundationallm-enkrypt-guardrails-apikey`",
-                description: "This is a Key Vault reference.",
-                keyVaultSecretName: KeyVaultSecretNames.FoundationaLLM_AzureContentSafety_APIKey,
-                contentType: "text/plain",
-                sampleObject: null
-            ),
-
-            new(
-                key: AppConfigurationKeys.FoundationaLLM_APIs_Gatekeeper_EnkryptGuardrails_APIUrl,
-                minimumVersion: "0.7.0",
-                defaultValue: "Enter the URL to the service.",
-                description: "",
-                keyVaultSecretName: "",
-                contentType: "text/plain",
-                sampleObject: null
-            ),
-        ];
-        #endregion
-
         #region AzureContentSafety
 
         /// <summary>

--- a/src/dotnet/Vectorization/DataFormats/Office/XLSXTextExtractor.cs
+++ b/src/dotnet/Vectorization/DataFormats/Office/XLSXTextExtractor.cs
@@ -77,35 +77,43 @@ namespace FoundationaLLM.Vectorization.DataFormats.Office
                     sb.AppendLine(this._worksheetNumberTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
                 }
 
-                foreach (IXLRangeRow? row in worksheet.RangeUsed()!.RowsUsed())
+                if(worksheet.RangeUsed() is not null)
                 {
-                    if (row == null) { continue; }
-
-                    var cells = row.CellsUsed().ToList();
-
-                    sb.Append(this._rowPrefix);
-                    for (var i = 0; i < cells.Count; i++)
+                    foreach (IXLRangeRow? row in worksheet.RangeUsed()!.RowsUsed())
                     {
-                        IXLCell? cell = cells[i];
+                        if (row == null) { continue; }
 
-                        if (this._withQuotes && cell is { Value.IsText: true })
+                        var cells = row.CellsUsed().ToList();
+
+                        sb.Append(this._rowPrefix);
+                        for (var i = 0; i < cells.Count; i++)
                         {
-                            sb.Append('"')
-                                .Append(cell.Value.GetText().Replace("\"", "\"\"", StringComparison.Ordinal))
-                                .Append('"');
-                        }
-                        else
-                        {
-                            sb.Append(cell.Value);
+                            IXLCell? cell = cells[i];
+
+                            if (this._withQuotes && cell is { Value.IsText: true })
+                            {
+                                sb.Append('"')
+                                    .Append(cell.Value.GetText().Replace("\"", "\"\"", StringComparison.Ordinal))
+                                    .Append('"');
+                            }
+                            else
+                            {
+                                sb.Append(cell.Value);
+                            }
+
+                            if (i < cells.Count - 1)
+                            {
+                                sb.Append(this._columnSeparator);
+                            }
                         }
 
-                        if (i < cells.Count - 1)
-                        {
-                            sb.Append(this._columnSeparator);
-                        }
+                        sb.AppendLine(this._rowSuffix);
                     }
 
-                    sb.AppendLine(this._rowSuffix);
+                }
+                else
+                {
+                    sb.AppendLine($"No data found in Worksheet number: {worksheetNumber}");
                 }
 
                 if (this._withEndOfWorksheetMarker)

--- a/src/dotnet/Vectorization/Handlers/IndexingHandler.cs
+++ b/src/dotnet/Vectorization/Handlers/IndexingHandler.cs
@@ -51,7 +51,7 @@ namespace FoundationaLLM.Vectorization.Handlers
                 || textEmbeddingArtifacts.Count == 0)
             {
                 state.Log(this, request.Name!, _messageId, "The text embedding artifacts were not found.");
-                return false;
+                throw new VectorizationException("The text embedding artifacts were not found");
             }
 
             await _stateService.LoadArtifacts(state, VectorizationArtifactType.TextPartition);
@@ -61,7 +61,7 @@ namespace FoundationaLLM.Vectorization.Handlers
                 || textPartitioningArtifacts.Count == 0)
             {
                 state.Log(this, request.Name!, _messageId, "The text partition artifacts were not found.");
-                return false;
+                throw new VectorizationException("The text partitioning artifacts were not found.");
             }
 
             var serializerOptions = new JsonSerializerOptions

--- a/src/dotnet/Vectorization/Vectorization.csproj
+++ b/src/dotnet/Vectorization/Vectorization.csproj
@@ -15,11 +15,9 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.17.1" />
+    <PackageReference Include="ClosedXML" Version="0.104.0-preview2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="ClosedXML" Version="0.104.0-preview2" />
-    <PackageReference Include="ClosedXML.Parser" Version="1.2.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Parquet.Net" Version="4.23.5" />
     <PackageReference Include="PdfPig" Version="0.1.8" />


### PR DESCRIPTION
# Excel parsing fixes, remove non-required app settings from catalog

## Details on the issue fix or feature implementation

Allow the ClosedXML package to control it's dependent package versions (issue was DocumentFormats.OpenXML library v3 and above are not supported by the latest version of ClosedXML.

Small fix where a worksheet has no Used Range (added null check)

Removed Lakera and Enkrypt app config settings from the App Settings Catalog since they are not required.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

