### PR TITLE
E2E Release Testing Pipeline

### DIFF
--- a/.github/workflows/e2e-release-testing.yml
+++ b/.github/workflows/e2e-release-testing.yml
@@ -1,0 +1,39 @@
+name: Daily End to End Testing
+
+on:
+  push:
+    branches:
+    - release/**
+    - poc/**
+  workflow_dispatch: {}
+
+jobs:
+  get_version:
+    name: Get Release Version
+    runs-on: ubuntu-latest
+    if: ${{ (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/poc/')) }}
+    outputs:
+      version: ${{ steps.get-version.outputs.result }}
+    steps:
+    - name: Get Release Version
+      id: get-version
+      run: |
+        VERSION=$(echo ${{ github.ref_name }} | cut -d'/' -f 2)
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "VERSION: $VERSION"
+        echo "result=$VERSION" >> $GITHUB_OUTPUT
+
+  daily_e2e_test:
+    if: ${{ (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/poc/')) }}
+    uses: ./.github/workflows/e2e-testing.yml
+    needs: get_version
+    with:
+      environment: "fllm-e2e-aca-release-${{ needs.get_version.outputs.version }}-${{ github.run_id }}"
+      deployOpenAi: true
+      openAiName: fllm-01
+      openAiResourceGroup: fllm-shared-01
+      location: EastUS2
+      enableTeardown: true
+      bypassAndTeardown: false
+      target: e2e
+    secrets: inherit


### PR DESCRIPTION
# E2E Release Testing Pipeline

## The issue or feature being addressed

Addresses Task 17856 (ADO) around setting up the E2E testing pipeline to trigger on merges to release branches.

## Details on the issue fix or feature implementation

Set up a new E2E pipeline that consumes the existing E2E testing pipeline as a child template with appropriate inputs.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

