### PR TITLE
Fixes for message queue 404 issues

### DIFF
--- a/src/dotnet/Common/Tasks/TaskInfo.cs
+++ b/src/dotnet/Common/Tasks/TaskInfo.cs
@@ -14,5 +14,10 @@
         /// The <see cref="Task"/> being run.
         /// </summary>
         public required Task Task { get; set; }
+
+        /// <summary>
+        /// The latest pop receipt for the payload message.
+        /// </summary>
+        public string? PopReceipt { get; set; }
     }
 }

--- a/src/dotnet/Common/Tasks/TaskPool.cs
+++ b/src/dotnet/Common/Tasks/TaskPool.cs
@@ -61,5 +61,19 @@ namespace FoundationaLLM.Common.Tasks
         /// <returns>True if the task pool already has a running task for the specified payload, false otherwise.</returns>
         public bool HasRunningTaskForPayload(string payloadId) =>
             _taskInfo.Any(ti => ti != null && ti.PayloadId == payloadId && _runningStates.Contains(ti.Task.Status));
+
+        // <summary>
+        /// Updates the popReceipt for a task with the given payloadId.
+        /// </summary>
+        /// <param name="payloadId">The identifier of the payload.</param>
+        /// <param name="newPopReceipt">The new popReceipt value.</param>
+        public void UpdatePopReceipt(string payloadId, string newPopReceipt)
+        {
+            var taskInfo = _taskInfo.FirstOrDefault(ti => ti != null && ti.PayloadId == payloadId);
+            if (taskInfo != null)
+            {
+                taskInfo.PopReceipt = newPopReceipt;
+            }
+        }
     }
 }

--- a/src/dotnet/Vectorization/Interfaces/IRequestSourceService.cs
+++ b/src/dotnet/Vectorization/Interfaces/IRequestSourceService.cs
@@ -1,6 +1,4 @@
 ﻿using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
-using FoundationaLLM.Vectorization.Models;
-using System.Threading.Tasks;
 
 namespace FoundationaLLM.Vectorization.Interfaces
 {
@@ -52,7 +50,7 @@ namespace FoundationaLLM.Vectorization.Interfaces
         /// <param name="messageId">The identifier of the existing item in the request source.</param>
         /// <param name="popReceipt">This value is required to update the request.</param>
         /// <param name="request">The <see cref="VectorizationRequest"/> to update.</param>
-        /// <returns></returns>
-        Task UpdateRequest(string messageId, string popReceipt, VectorizationRequest request);
+        /// <returns>New popReceipt value</returns>
+        Task<string> UpdateRequest(string messageId, string popReceipt, VectorizationRequest request);
     }
 }

--- a/src/dotnet/Vectorization/Services/RequestSources/MemoryRequestSourceService.cs
+++ b/src/dotnet/Vectorization/Services/RequestSources/MemoryRequestSourceService.cs
@@ -1,10 +1,6 @@
-﻿    using FoundationaLLM.Vectorization.Models;
-using System.Threading.Tasks;
-using System;
-using FoundationaLLM.Vectorization.Interfaces;
+﻿using FoundationaLLM.Vectorization.Interfaces;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using FoundationaLLM.Vectorization.Models.Configuration;
 using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
 
@@ -39,12 +35,12 @@ namespace FoundationaLLM.Vectorization.Services.RequestSources
 
             for (int i = 0; i < count; i++)
             {
-                if (_requests.TryDequeue(out var request))                    
-                    result.Add(new (request, string.Empty, string.Empty, 0));
+                if (_requests.TryDequeue(out var request))
+                    result.Add(new(request, string.Empty, string.Empty, 0));
                 else
                     break;
             }
-            
+
             return Task.FromResult<IEnumerable<(VectorizationRequest, string, string, long)>>(result);
         }
 
@@ -59,10 +55,10 @@ namespace FoundationaLLM.Vectorization.Services.RequestSources
         }
 
         /// <inheritdoc/>
-        public Task UpdateRequest(string requestId, string popReceipt, VectorizationRequest request)
+        public Task<string> UpdateRequest(string requestId, string popReceipt, VectorizationRequest request)
         {
             _requests.Single(r => r.Name == request.Name).ErrorCount = request.ErrorCount;
-            return Task.CompletedTask;
+            return Task.FromResult(string.Empty);
         }
     }
 }

--- a/src/dotnet/Vectorization/Services/RequestSources/StorageQueueRequestSourceService.cs
+++ b/src/dotnet/Vectorization/Services/RequestSources/StorageQueueRequestSourceService.cs
@@ -96,10 +96,11 @@ namespace FoundationaLLM.Vectorization.Services.RequestSources
         }
 
         /// <inheritdoc/>
-        public async Task UpdateRequest(string messageId, string popReceipt, VectorizationRequest request)
+        public async Task<string> UpdateRequest(string messageId, string popReceipt, VectorizationRequest request)
         {
             var serializedMessage = JsonSerializer.Serialize(request);
-            await _queueClient.UpdateMessageAsync(messageId, popReceipt, serializedMessage);
+            var updateReceipt = await _queueClient.UpdateMessageAsync(messageId, popReceipt, serializedMessage);
+            return updateReceipt.Value.PopReceipt;
         }
     }
 }


### PR DESCRIPTION
# Fixes for message queue 404 issues

## Details on the issue fix or feature implementation

When a message is updated in a queue, the pop receipt value changes. This propagates the change up to the task pool so that the most recent pop receipt is associated with the internal task pool TaskInfo array.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
