### PR TITLE
Only call authorize on non resource-type paths when listing resources

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
@@ -40,6 +40,14 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
         public bool IsRootPath => _isRootPath;
 
         /// <summary>
+        /// Indicates whether the resource path refers to a resource type (does not contain a resource name).
+        /// </summary>
+        public bool IsResourceTypePath =>
+            _resourceTypeInstances != null
+            && _resourceTypeInstances.Count > 0
+            && _resourceTypeInstances.Last().ResourceId == null;
+
+        /// <summary>
         /// The main resource type of the path.
         /// </summary>
         public string MainResourceType =>

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -190,9 +190,12 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
                 _allowedResourceTypes,
                 allowAction: false);
 
-            // Authorize access to the resource path.
-            await Authorize(parsedResourcePath, userIdentity, "read");
-
+            if(!parsedResourcePath.IsResourceTypePath)
+            {
+                // Authorize access to the resource path.
+                await Authorize(parsedResourcePath, userIdentity, "read");
+            }
+           
             return await GetResourcesAsync(parsedResourcePath, userIdentity);
         }
 


### PR DESCRIPTION
#  Only call authorize on non resource-type paths when listing resources

## Details on the issue fix or feature implementation

Introduce resource type path verification when authorizing access to a resource.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
