### PR TITLE
Removing trigger on poc/* branch pattern from release E2E testing pipeline

### DIFF
--- a/.github/workflows/e2e-release-testing.yml
+++ b/.github/workflows/e2e-release-testing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - release/**
-    - poc/**
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
# Removing trigger on poc/* branch pattern from release E2E testing pipeline

## The issue or feature being addressed

Removes the branch trigger for the pattern `poc/**` from the Release E2E Testing pipeline.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

