### PR TITLE
Add footer text property to portal branding

### DIFF
--- a/src/dotnet/Common/Constants/Configuration/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Constants/Configuration/AppConfigurationKeys.cs
@@ -495,6 +495,10 @@
         /// </summary>
         public const string FoundationaLLM_Branding_SecondaryButtonTextColor = "FoundationaLLM:Branding:SecondaryButtonTextColor";
         /// <summary>
+        /// The key for the FoundationaLLM:Branding:FooterText app configuration setting.
+        /// </summary>
+        public const string FoundationaLLM_Branding_FooterText = "FoundationaLLM:Branding:FooterText";
+        /// <summary>
         /// The key for the FoundationaLLM:Chat:Entra:CallbackPath app configuration setting.
         /// </summary>
         public const string FoundationaLLM_Chat_Entra_CallbackPath = "FoundationaLLM:Chat:Entra:CallbackPath";

--- a/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
+++ b/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
@@ -79,5 +79,9 @@ namespace FoundationaLLM.Common.Models.Configuration.Branding
         /// The text color that overlays the <see cref="SecondaryColor"/> of the client in hex format.
         /// </summary>
         public string? SecondaryTextColor { get; set; }
+        /// <summary>
+        /// The footer text displayed in the client.
+        /// </summary>
+        public string? FooterText { get; set; }
     }
 }

--- a/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
+++ b/src/dotnet/Configuration/Catalog/AppConfigurationCatalog.cs
@@ -1099,6 +1099,16 @@ namespace FoundationaLLM.Configuration.Catalog
                 keyVaultSecretName: "",
                 contentType: "text/plain",
                 sampleObject: null
+            ),
+
+            new(
+                key: AppConfigurationKeys.FoundationaLLM_Branding_FooterText,
+                minimumVersion: "0.8.0",
+                defaultValue: "",
+                description: "",
+                keyVaultSecretName: "",
+                contentType: "text/plain",
+                sampleObject: null
             )
         ];
 

--- a/src/ui/ManagementPortal/server/api/config.ts
+++ b/src/ui/ManagementPortal/server/api/config.ts
@@ -28,6 +28,7 @@ const allowedKeys = [
 	'FoundationaLLM:Branding:PrimaryButtonTextColor',
 	'FoundationaLLM:Branding:SecondaryButtonBackgroundColor',
 	'FoundationaLLM:Branding:SecondaryButtonTextColor',
+	'FoundationaLLM:Branding:FooterText',
 
 	'FoundationaLLM:APIs:AgentHubAPI:APIUrl',
 	'FoundationaLLM:APIs:AuthorizationAPI:APIUrl',

--- a/src/ui/ManagementPortal/stores/appConfigStore.ts
+++ b/src/ui/ManagementPortal/stores/appConfigStore.ts
@@ -33,6 +33,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		primaryButtonText: null,
 		secondaryButtonBg: null,
 		secondaryButtonText: null,
+		footerText: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -72,6 +73,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				primaryButtonText,
 				secondaryButtonBg,
 				secondaryButtonText,
+				footerText,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -105,6 +107,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				api.getConfigValue('FoundationaLLM:Branding:PrimaryButtonTextColor'),
 				api.getConfigValue('FoundationaLLM:Branding:SecondaryButtonBackgroundColor'),
 				api.getConfigValue('FoundationaLLM:Branding:SecondaryButtonTextColor'),
+				api.getConfigValue('FoundationaLLM:Branding:FooterText'),
 
 				api.getConfigValue('FoundationaLLM:Management:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:Management:Entra:Instance'),
@@ -140,6 +143,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.primaryButtonText = primaryButtonText;
 			this.secondaryButtonBg = secondaryButtonBg;
 			this.secondaryButtonText = secondaryButtonText;
+			this.footerText = footerText;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -24,6 +24,7 @@ const allowedKeys = [
 	'FoundationaLLM:Branding:PrimaryButtonTextColor',
 	'FoundationaLLM:Branding:SecondaryButtonBackgroundColor',
 	'FoundationaLLM:Branding:SecondaryButtonTextColor',
+	'FoundationaLLM:Branding:FooterText',
 	'FoundationaLLM:Chat:Entra:ClientId',
 	'FoundationaLLM:Chat:Entra:Instance',
 	'FoundationaLLM:Chat:Entra:TenantId',

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -25,6 +25,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		primaryButtonText: null,
 		secondaryButtonBg: null,
 		secondaryButtonText: null,
+		footerText: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -55,6 +56,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				primaryButtonText,
 				secondaryButtonBg,
 				secondaryButtonText,
+				footerText,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -77,6 +79,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				api.getConfigValue('FoundationaLLM:Branding:PrimaryButtonTextColor'),
 				api.getConfigValue('FoundationaLLM:Branding:SecondaryButtonBackgroundColor'),
 				api.getConfigValue('FoundationaLLM:Branding:SecondaryButtonTextColor'),
+				api.getConfigValue('FoundationaLLM:Branding:FooterText'),
 				api.getConfigValue('FoundationaLLM:Chat:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:Chat:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:Chat:Entra:TenantId'),
@@ -102,6 +105,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.primaryButtonText = primaryButtonText;
 			this.secondaryButtonBg = secondaryButtonBg;
 			this.secondaryButtonText = secondaryButtonText;
+			this.footerText = footerText;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/tests/dotnet/Common.Tests/Models/Configuration/Branding/ClientBrandingConfigurationTests.cs
+++ b/tests/dotnet/Common.Tests/Models/Configuration/Branding/ClientBrandingConfigurationTests.cs
@@ -27,7 +27,8 @@ namespace FoundationaLLM.Common.Tests.Models.Configuration.Branding
                 BackgroundColor = "#F0F0F0",
                 PrimaryTextColor = "#FFFFFF",
                 SecondaryTextColor = "#000000",
-                KioskMode = false
+                KioskMode = false,
+                FooterText = "Footer"
             };
 
             // Assert
@@ -43,6 +44,7 @@ namespace FoundationaLLM.Common.Tests.Models.Configuration.Branding
             Assert.Equal("#FFFFFF", brandingConfig.PrimaryTextColor);
             Assert.Equal("#000000", brandingConfig.SecondaryTextColor);
             Assert.False(brandingConfig.KioskMode);
+            Assert.Equal("Footer", brandingConfig.FooterText);
 
         }
     }


### PR DESCRIPTION
# Add footer text property to portal branding

## The issue or feature being addressed

User portal branding has no support for custom footer text.

## Details on the issue fix or feature implementation

Adds a footer text property to portal branding

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
