### PR TITLE
Resource provider should set fields created_by and updated_by

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -274,6 +274,11 @@ namespace FoundationaLLM.Agent.ResourceProviders
                 }
             }
 
+            if (existingAgentReference == null)
+                agent.CreatedBy = userIdentity.UPN;
+            else
+                agent.UpdatedBy = userIdentity.UPN;
+
             await _storageService.WriteFileAsync(
                 _storageContainerName,
                 agentReference.Filename,

--- a/src/dotnet/Authorization/ResourceProviders/AuthorizationResourceProviderService.cs
+++ b/src/dotnet/Authorization/ResourceProviders/AuthorizationResourceProviderService.cs
@@ -91,7 +91,8 @@ namespace FoundationaLLM.Authorization.ResourceProviders
                     PrincipalId = roleAssignment.PrincipalId,
                     PrincipalType = roleAssignment.PrincipalType,
                     RoleDefinitionId = roleAssignment.RoleDefinitionId,
-                    Scope = roleAssignment.Scope
+                    Scope = roleAssignment.Scope,
+                    CreatedBy = userIdentity.UPN
                 });
 
             if (roleAssignmentResult.Success)

--- a/src/dotnet/Authorization/Services/AuthorizationCore.cs
+++ b/src/dotnet/Authorization/Services/AuthorizationCore.cs
@@ -225,6 +225,7 @@ namespace FoundationaLLM.Authorization.Services
                             PrincipalType = roleAssignmentRequest.PrincipalType,
                             RoleDefinitionId = roleAssignmentRequest.RoleDefinitionId,
                             Scope = roleAssignmentRequest.Scope,
+                            CreatedBy = roleAssignmentRequest.CreatedBy
                         };
 
                         roleAssignmentStore.RoleAssignments.Add(roleAssignment);

--- a/src/dotnet/Common/Models/Authorization/RoleAssignmentRequest.cs
+++ b/src/dotnet/Common/Models/Authorization/RoleAssignmentRequest.cs
@@ -50,5 +50,12 @@ namespace FoundationaLLM.Common.Models.Authorization
         /// </summary>
         [JsonPropertyName("scope")]
         public required string Scope { get; set; }
+
+        /// <summary>
+        /// The entity who created the role assignment request.
+        /// </summary>
+        [JsonPropertyName("created_by")]
+        [JsonPropertyOrder(502)]
+        public string? CreatedBy { get; set; }
     }
 }


### PR DESCRIPTION
# Resource provider should set fields created_by and updated_by

## The issue or feature being addressed

Fixes #17830

## Details on the issue fix or feature implementation

Resource provider should set created_by and updated_by fields to UPN

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
