### PR TITLE
Fix vectorization infinite loop in Excel Extraction

### DIFF
--- a/src/dotnet/Vectorization/DataFormats/Office/XLSXTextExtractor.cs
+++ b/src/dotnet/Vectorization/DataFormats/Office/XLSXTextExtractor.cs
@@ -90,15 +90,15 @@ namespace FoundationaLLM.Vectorization.DataFormats.Office
                         {
                             IXLCell? cell = cells[i];
 
-                            if (this._withQuotes && cell is { Value.IsText: true })
+                            if (this._withQuotes && cell is { CachedValue.IsText: true })
                             {
                                 sb.Append('"')
-                                    .Append(cell.Value.GetText().Replace("\"", "\"\"", StringComparison.Ordinal))
+                                    .Append(cell.CachedValue.GetText().Replace("\"", "\"\"", StringComparison.Ordinal))
                                     .Append('"');
                             }
                             else
                             {
-                                sb.Append(cell.Value);
+                                sb.Append(cell.CachedValue);
                             }
 
                             if (i < cells.Count - 1)

--- a/src/dotnet/Vectorization/Vectorization.csproj
+++ b/src/dotnet/Vectorization/Vectorization.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.17.1" />
-    <PackageReference Include="ClosedXML" Version="0.104.0-preview2" />
+    <PackageReference Include="ClosedXML" Version="0.102.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
# Fix vectorization infinite loop in Excel Extraction

## The issue or feature being addressed

Fixes #17966

## Details on the issue fix or feature implementation

Downgraded to the latest stable version of ClosedXML. 
We encountered a cast exception when using cell.Value. To resolve this, we can use CachedValue instead of Value.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
