### PR TITLE
Dynamic footer text

### DIFF
--- a/src/ui/ManagementPortal/layouts/default.vue
+++ b/src/ui/ManagementPortal/layouts/default.vue
@@ -3,7 +3,9 @@
 		<Sidebar />
 		<div class="page">
 			<!-- Page to render -->
-			<slot />
+			<div class="page-content">
+				<slot />
+			</div>
 
 			<!-- Session expired dialog -->
 			<Dialog
@@ -17,6 +19,10 @@
 					<Button label="Log in" primary @click="handleRefreshLogin" />
 				</template>
 			</Dialog>
+
+			<Footer v-if="$appConfigStore.footerText">
+				<FooterItem v-html="$appConfigStore.footerText"></FooterItem>
+			</Footer>
 		</div>
 	</div>
 </template>
@@ -31,3 +37,22 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.page {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+}
+
+.page-content {
+	flex: 1;
+}
+
+footer {
+	text-align: right;
+	font-size: 0.85rem;
+    margin-top: 24px;
+	padding-right: 24px;
+}
+</style>

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -37,6 +37,10 @@
 		<div class="chat-thread__input">
 			<ChatInput :disabled="isLoading || isMessagePending" @send="handleSend" />
 		</div>
+
+		<Footer v-if="$appConfigStore.footerText">
+			<FooterItem v-html="$appConfigStore.footerText"></FooterItem>
+		</Footer>
 	</div>
 </template>
 
@@ -130,7 +134,7 @@ export default {
 
 .chat-thread__input {
 	display: flex;
-	margin: 0px 24px 24px 24px;
+	margin: 0px 24px 8px 24px;
 	// box-shadow: 0 -5px 10px 0 rgba(27, 29, 33, 0.1);
 }
 
@@ -160,5 +164,11 @@ export default {
 	font-size: 1.2rem;
 	font-weight: 300;
 	font-style: italic;
+}
+
+footer {
+	text-align: right;
+	font-size: 0.85rem;
+    padding-right: 24px;
 }
 </style>


### PR DESCRIPTION
# Dynamic footer text

## Details on the issue fix or feature implementation

Displays dynamic footer text if the `FoundationaLLM:Branding:FooterText` App Config setting contains content.

Here is an example in the User Portal where `FooterText` contains the following content: `<a href="https://foundationallm.ai" target="_blank">Home</a> | Copyright FoundationaLLM. All rights reserved.`

![image](https://github.com/solliancenet/foundationallm/assets/5950304/a806ba75-e004-4fe7-ad7a-3cef11938d21)

Here's an example in the Management Portal:

![image](https://github.com/solliancenet/foundationallm/assets/5950304/f6bdefea-d64e-4306-8e77-2d069c7ea087)


## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
