### PR TITLE
PR for branch: vectorization-fixes - Change the message for request source queues

### DIFF
--- a/src/dotnet/Vectorization/Extensions/VectorizationResourceProviderServiceExtensions.cs
+++ b/src/dotnet/Vectorization/Extensions/VectorizationResourceProviderServiceExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using FoundationaLLM.Common.Constants.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders;
+using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
 using FoundationaLLM.Common.Models.Vectorization;
 using FoundationaLLM.Vectorization.ResourceProviders;
 
@@ -42,6 +43,15 @@ namespace FoundationaLLM.Vectorization.Extensions
             string slug = activate ? "activate" : "deactivate";           
             await vectorizationResourceProvider.ExecuteActionAsync($"{pipelineObjectId}/{slug}");
         }
-        
+
+        /// <summary>
+        /// Retrieves the vectorization request resource with the specified name.
+        /// </summary>
+        /// <param name="vectorizationResourceProvider">An instance of the vectorization resource provider.</param>
+        /// <param name="requestName">The name of the request to retrieve.</param>
+        /// <returns>The vectorization request.</returns>
+        public static VectorizationRequest GetVectorizationRequestResource(this VectorizationResourceProviderService vectorizationResourceProvider, string requestName)
+            => vectorizationResourceProvider.GetResource<VectorizationRequest>($"/{VectorizationResourceTypeNames.VectorizationRequests}/{requestName}");
+
     }
 }

--- a/src/dotnet/Vectorization/Models/VectorizationDequeuedRequest.cs
+++ b/src/dotnet/Vectorization/Models/VectorizationDequeuedRequest.cs
@@ -10,7 +10,7 @@ namespace FoundationaLLM.Vectorization.Models
         /// <summary>
         /// The vectorization request.
         /// </summary>
-        public required VectorizationRequest Request { get; set;}
+        public required string RequestName { get; set;}
 
         /// <summary>
         /// The queue message identifier.

--- a/src/dotnet/Vectorization/Models/VectorizationRequestProcessingContext.cs
+++ b/src/dotnet/Vectorization/Models/VectorizationRequestProcessingContext.cs
@@ -1,0 +1,21 @@
+﻿using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
+
+namespace FoundationaLLM.Vectorization.Models
+{
+    /// <summary>
+    /// Represents a vectorization request processing context.
+    /// This class associates a dequeued request with the corresponding vectorization request resource.
+    /// </summary>
+    public class VectorizationRequestProcessingContext
+    {
+        /// <summary>
+        /// The message that was dequeued.
+        /// </summary>
+        public required VectorizationDequeuedRequest DequeuedRequest { get; set; }
+
+        /// <summary>
+        /// The vectorization request resource.
+        /// </summary>
+        public required VectorizationRequest Request { get; set; }
+    }
+}

--- a/src/dotnet/Vectorization/Services/Pipelines/PipelineExecutionService.cs
+++ b/src/dotnet/Vectorization/Services/Pipelines/PipelineExecutionService.cs
@@ -257,6 +257,7 @@ namespace FoundationaLLM.Vectorization.Services.Pipelines
                                             PipelineExecutionId = pipelineExecutionId,
                                             PipelineObjectId = activePipeline.ObjectId!,
                                             PipelineName = activePipeline.Name,
+                                            CostCenter = activePipeline.CostCenter,
                                             ContentIdentifier = new ContentIdentifier()
                                             {
                                                 DataSourceObjectId = dataSource.ObjectId!,

--- a/src/dotnet/Vectorization/Services/RequestSources/MemoryRequestSourceService.cs
+++ b/src/dotnet/Vectorization/Services/RequestSources/MemoryRequestSourceService.cs
@@ -41,7 +41,7 @@ namespace FoundationaLLM.Vectorization.Services.RequestSources
             {
                 if (_requests.TryDequeue(out var request))                    
                     result.Add(new VectorizationDequeuedRequest(){
-                        Request = request,
+                        RequestName = request.Name,
                         MessageId = string.Empty,
                         PopReceipt = string.Empty,
                         DequeueCount = 0

--- a/src/dotnet/Vectorization/Services/RequestSources/StorageQueueRequestSourceService.cs
+++ b/src/dotnet/Vectorization/Services/RequestSources/StorageQueueRequestSourceService.cs
@@ -71,7 +71,7 @@ namespace FoundationaLLM.Vectorization.Services.RequestSources
 
                         result.Add(new VectorizationDequeuedRequest()
                         {
-                            Request = vectorizationRequest!,
+                            RequestName = vectorizationRequest!.Name,
                             MessageId = m.MessageId,
                             PopReceipt = m.PopReceipt!,
                             DequeueCount = m.DequeueCount

--- a/src/dotnet/Vectorization/Services/VectorizationStates/BlobStorageVectorizationStateService.cs
+++ b/src/dotnet/Vectorization/Services/VectorizationStates/BlobStorageVectorizationStateService.cs
@@ -34,6 +34,8 @@ namespace FoundationaLLM.Vectorization.Services.VectorizationStates
         private const string EXECUTION_STATE_DIRECTORY = "execution-state";
         private const string PIPELINE_STATE_DIRECTORY = "pipeline-state";
 
+        private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
         /// <inheritdoc/>
         public async Task<bool> HasState(VectorizationRequest request) =>
             await _storageService.FileExistsAsync(
@@ -265,12 +267,22 @@ namespace FoundationaLLM.Vectorization.Services.VectorizationStates
             //vectorization-state/pipeline-state/pipeline-name/pipeline-name-pipeline-execution-id.json
             var pipelineStatePath = $"{PIPELINE_STATE_DIRECTORY}/{pipelineName}/{pipelineName}-{state.ExecutionId}.json";
             var content = JsonSerializer.Serialize(state);
-            await _storageService.WriteFileAsync(
-                BLOB_STORAGE_CONTAINER_NAME,
-                pipelineStatePath,
-                content,
-                default,
-                default);            
+
+            // add SemaphoreSlim async lock to avoid pipeline file contention - allows for a lock with an await in the body
+            await _semaphore.WaitAsync();
+            try
+            {
+                await _storageService.WriteFileAsync(
+                    BLOB_STORAGE_CONTAINER_NAME,
+                    pipelineStatePath,
+                    content,
+                    default,
+                    default);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }           
         }
 
         /// <inheritdoc/>

--- a/tests/dotnet/Vectorization.Tests/Services/RequestSources/StorageQueueRequestSourceServiceTests.cs
+++ b/tests/dotnet/Vectorization.Tests/Services/RequestSources/StorageQueueRequestSourceServiceTests.cs
@@ -72,7 +72,7 @@ namespace Vectorization.Tests.Services.RequestSources
             // Correct Deserialization
             Assert.Equal(
                 "d4669c9c-e330-450a-a41c-a4d6649abdef",
-                vectorizationRequestQueueMessage.Request.Name
+                vectorizationRequestQueueMessage!.RequestName
             );
 
             // Message ID & Pop Receipt must be retained for deletion


### PR DESCRIPTION
# PR for branch: vectorization-fixes : Change the message for request source queues

## Details on the issue fix or feature implementation

Include just the request name (id) instead of the actual object.

Introduce vectorization request processing context that associates the dequeued message (message id, pop receipt) with the hydrated request from the vectorization resource provider.

a couple other small fixes

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
