### PR TITLE
Increase timeout for vectorize e2e example 10

### DIFF
--- a/tests/dotnet/Core.Examples/Example0010_VectorizationAsyncDune.cs
+++ b/tests/dotnet/Core.Examples/Example0010_VectorizationAsyncDune.cs
@@ -129,9 +129,9 @@ namespace FoundationaLLM.Core.Examples
             VectorizationRequest resource = await _vectorizationTestService.GetVectorizationRequest(request);
 
             // The finalized state of the vectorization request is either "Completed" or "Failed"
-            // Give it a max of 10 minutes to complete, then exit loop and fail the test.
+            // Give it a max of 15 minutes to complete, then exit loop and fail the test.
             WriteLine($"Polling the processing state of the async vectorization request: {id} by retrieving the request from the Management API");
-            int timeRemainingMilliseconds = 600000;
+            int timeRemainingMilliseconds = 900000;
             var pollDurationMilliseconds = 30000; //poll duration of 30 seconds
             while (resource.ProcessingState != VectorizationProcessingState.Completed && resource.ProcessingState != VectorizationProcessingState.Failed && timeRemainingMilliseconds > 0)
             {                


### PR DESCRIPTION
# Increase timeout for vectorize e2e example 10

## Details on the issue fix or feature implementation

The e2e test was failing due to a timeout exception. The timeout is now set to 15 minutes instead of 10.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
