### PR TITLE
AzCopy Installation Fix (Standard)

### DIFF
--- a/deploy/standard/scripts/pre-provision/Get-AzCopy.ps1
+++ b/deploy/standard/scripts/pre-provision/Get-AzCopy.ps1
@@ -29,15 +29,15 @@ $env:AZCOPY_AUTO_LOGIN_TYPE = "AZCLI"
 
 # Determine OS and set the download URL and file extension accordingly
 if ($IsWindows) {
-	$url = "https://aka.ms/downloadazcopy-v10-windows"
+	$url = "https://azcopyvnext.azureedge.net/releases/release-10.25.0-20240522/azcopy_windows_amd64_10.25.0.zip"
 	$os = "windows"
 	$ext = "zip"
 }elseif ($IsMacOS) {
-	$url = "https://aka.ms/downloadazcopy-v10-mac"
+	$url = "https://azcopyvnext.azureedge.net/releases/release-10.25.0-20240522/azcopy_darwin_amd64_10.25.0.zip"
 	$os = "darwin"
 	$ext = "zip"
 }elseif ($IsLinux) {
-	$url = "https://aka.ms/downloadazcopy-v10-linux"
+	$url = "https://azcopyvnext.azureedge.net/releases/release-10.25.0-20240522/azcopy_linux_amd64_10.25.0.tar.gz"
 	$os = "linux"
 	$ext = "tar.gz"
 }
@@ -45,18 +45,27 @@ if ($IsWindows) {
 # Define paths for download and extraction
 $outputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools/azcopy.${ext}")
 $destinationPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools")
-$toolPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools/azcopy_${os}_amd64_${AZCOPY_VERSION}/azcopy")
+$extractedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools/azcopy_${os}_amd64_${AZCOPY_VERSION}")
+$renamedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools/azcopy")
+$toolPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("../../tools/azcopy/azcopy")
 
 # Check if AzCopy already exists, download and extract if not
-if (Test-Path -Path "../../tools/azcopy_${os}_amd64_${AZCOPY_VERSION}") {
-	Write-Host "azcopy_${os}_amd64_${AZCOPY_VERSION} already exists."
+if (Test-Path -Path "../../tools/azcopy") {
+	Write-Host "azcopy already exists."
 }
 else {
 	Invoke-WebRequest -Uri $url -OutFile $outputPath
+	
 	if ($IsLinux) {
-		tar -xvzf $outputPath -C $destinationPath
+		tar -xvzf $outputPath -C $
 	}
 	else {
 		Expand-Archive -Path $outputPath -DestinationPath $destinationPath
+	}
+
+	Move-Item -Path $extractedPath -Destination $renamedPath
+
+	if ($IsLinux) {
+		chmod +x $toolPath
 	}
 }

--- a/deploy/standard/scripts/pre-provision/Get-AzCopy.ps1
+++ b/deploy/standard/scripts/pre-provision/Get-AzCopy.ps1
@@ -57,7 +57,7 @@ else {
 	Invoke-WebRequest -Uri $url -OutFile $outputPath
 	
 	if ($IsLinux) {
-		tar -xvzf $outputPath -C $
+		tar -xvzf $outputPath -C $destinationPath
 	}
 	else {
 		Expand-Archive -Path $outputPath -DestinationPath $destinationPath


### PR DESCRIPTION
# AzCopy Installation Fix

## The issue or feature being addressed

This PR fixes the AzCopy installation script in Standard, pinning the download to a specific version and putting it in a path that is version- and OS-independent.

## Details on the issue fix or feature implementation

This PR updates the `Get-AzCopy.ps1` script and all scripts that call it.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
