### PR TITLE
Refactoring E2E Tests to build .NET Tests independently of test runs

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -571,9 +571,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.x
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
       
       - name: Build Tests
         shell: pwsh
@@ -633,6 +630,12 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./dist
 
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -576,13 +576,13 @@ jobs:
         shell: pwsh
         run: |
           dotnet restore ./src/FoundationaLLM.sln --output ./dist
-          dotnet build ./tests/dotnet/Common.Tests.csproj --output ./dist
-          dotnet build ./tests/dotnet/Core.Examples.csproj --output ./dist
-          dotnet build ./tests/dotnet/Core.Tests.csproj --output ./dist
-          dotnet build ./tests/dotnet/Gatekeeper.Tests.csproj --output ./dist
-          dotnet build ./tests/dotnet/Orchestration.Tests.csproj --output ./dist
-          dotnet build ./tests/dotnet/SemanticKernel.Tests.csproj --output ./dist
-          dotnet build ./tests/dotnet/Vectorization.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Common.Tests/Common.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Core.Examples/Core.Examples.csproj --output ./dist
+          dotnet build ./tests/dotnet/Core.Test/Core.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Gatekeeper.Tests/Gatekeeper.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Orchestration.Tests/Orchestration.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/SemanticKernel.Tests/SemanticKernel.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Vectorization.Tests/Vectorization.Tests.csproj --output ./dist
 
       - name: Publish Build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -634,12 +634,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download Build
-        uses: actions/download-artifact@v4
-        with:
-          name: build
-          path: ./dist
-
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0
         with:

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -571,6 +571,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
       
       - name: Build Tests
         shell: pwsh

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -559,6 +559,29 @@ jobs:
             -storageAccountName $env:AZURE_STORAGE_ACCOUNT_NAME `
             -aiSearchName $env:AZURE_COGNITIVE_SEARCH_NAME
 
+  build_e2e_tests:
+    name: Build End to End Tests
+    if: ${{ !inputs.bypassAndTeardown }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.x
+      
+      - name: Build Tests
+        shell: pwsh
+        run: dotnet build ./src/FoundationaLLM.sln --output ./dist
+
+      - name: Publish Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ./dist
+
   run_e2e_tests:
     name: Run End to End Tests
     if: ${{ !inputs.bypassAndTeardown }}
@@ -567,7 +590,7 @@ jobs:
     env:
       AZURE_ENV_NAME: ${{ inputs.environment }}
       AZURE_LOCATION: ${{ inputs.location }}
-    needs: [generate_matrix, deploy_quickstart, add_test_data]
+    needs: [generate_matrix, deploy_quickstart, add_test_data, build_e2e_tests]
     strategy:
       fail-fast: false
       matrix:
@@ -599,6 +622,12 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./dist
 
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0
@@ -661,6 +690,9 @@ jobs:
 
           echo "Running End to End Test: ${{ matrix.object.name }}"
           dotnet test `
+            ./src/FoundationaLLM.sln `
+            --output ./dist `
+            --no-build `
             --filter "FullyQualifiedName=${{ matrix.object.namespace }}.${{ matrix.object.task_name }}" `
             --logger:"html;verbosity=detailed;LogFileName=${{ github.workspace }}/${{ matrix.object.name }}.html" `
             ${{ matrix.object.target }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -577,7 +577,15 @@ jobs:
       
       - name: Build Tests
         shell: pwsh
-        run: dotnet build ./src/FoundationaLLM.sln --output ./dist
+        run: |
+          dotnet restore ./src/FoundationaLLM.sln --output ./dist
+          dotnet build ./tests/dotnet/Common.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Core.Examples.csproj --output ./dist
+          dotnet build ./tests/dotnet/Core.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Gatekeeper.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Orchestration.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/SemanticKernel.Tests.csproj --output ./dist
+          dotnet build ./tests/dotnet/Vectorization.Tests.csproj --output ./dist
 
       - name: Publish Build
         uses: actions/upload-artifact@v4
@@ -693,7 +701,6 @@ jobs:
 
           echo "Running End to End Test: ${{ matrix.object.name }}"
           dotnet test `
-            ./src/FoundationaLLM.sln `
             --output ./dist `
             --no-build `
             --filter "FullyQualifiedName=${{ matrix.object.namespace }}.${{ matrix.object.task_name }}" `

--- a/.gitignore
+++ b/.gitignore
@@ -394,3 +394,4 @@ deploy/quick-start/.env
 .sonarqube/
 
 *.lutconfig
+dist


### PR DESCRIPTION
# Refactoring E2E Tests to build .NET Tests independently of test runs

## The issue or feature being addressed

Fixes #17916 

## Details on the issue fix or feature implementation

Moved the build operation to a previous Github job and published the build as an artifact that the test steps then download and execute tests against.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

