### PR TITLE
Added support for parameterizing resources for ACA QS

### DIFF
--- a/deploy/quick-start/infra/app/acaService.bicep
+++ b/deploy/quick-start/infra/app/acaService.bicep
@@ -2,6 +2,7 @@
 param apiKeySecretName string
 param applicationInsightsName string
 param containerAppsEnvironmentName string
+param cpu string
 param envSettings array = []
 param exists bool
 param hasIngress bool = false
@@ -9,7 +10,9 @@ param identityName string
 param imageName string
 param keyvaultName string
 param location string = resourceGroup().location
+param memory string
 param name string
+param replicaCount int
 param resourceToken string
 param secretSettings array = []
 param serviceName string
@@ -146,12 +149,15 @@ resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
             )
           )
           resources: {
-            cpu: json('1.0')
-            memory: '2.0Gi'
+            cpu: json(cpu)
+            memory: memory
           }
         }
       ]
-      scale: {
+      scale: replicaCount > 0 ? {
+        minReplicas: replicaCount
+        maxReplicas: replicaCount
+      } : {
         minReplicas: 1
         maxReplicas: 10
       }

--- a/deploy/quick-start/infra/app/authAcaService.bicep
+++ b/deploy/quick-start/infra/app/authAcaService.bicep
@@ -4,10 +4,10 @@ param tags object = {}
 param authRgName string
 param authStoreName string
 param cpu string
-param identityName string
-param keyvaultName string
 param memory string
 param replicaCount int
+param identityName string
+param keyvaultName string
 param containerAppsEnvironmentName string
 param applicationInsightsName string
 param exists bool

--- a/deploy/quick-start/infra/app/authAcaService.bicep
+++ b/deploy/quick-start/infra/app/authAcaService.bicep
@@ -3,8 +3,11 @@ param location string = resourceGroup().location
 param tags object = {}
 param authRgName string
 param authStoreName string
+param cpu string
 param identityName string
 param keyvaultName string
+param memory string
+param replicaCount int
 param containerAppsEnvironmentName string
 param applicationInsightsName string
 param exists bool
@@ -117,12 +120,15 @@ resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
             secretRef: secret.secretRef
           }))
           resources: {
-            cpu: json('1.0')
-            memory: '2.0Gi'
+            cpu: json(cpu)
+            memory: memory
           }
         }
       ]
-      scale: {
+      scale: replicaCount > 0 ? {
+        minReplicas: replicaCount
+        maxReplicas: replicaCount
+      } : {
         minReplicas: 1
         maxReplicas: 10
       }

--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -527,6 +527,9 @@ module authAcaService './app/authAcaService.bicep' = {
     keyvaultName: authKeyvault.outputs.name
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     containerAppsEnvironmentName: appsEnv.outputs.name
+    cpu: authService.cpu
+    memory: authService.memory
+    replicaCount: empty(authService.replicaCount) ? 0 : int(authService.replicaCount)
     exists: authServiceExists == 'true'
     appDefinition: serviceDefinition
     hasIngress: true
@@ -554,13 +557,16 @@ module acaServices './app/acaService.bicep' = [
       appDefinition: serviceDefinition
       applicationInsightsName: monitoring.outputs.applicationInsightsName
       containerAppsEnvironmentName: appsEnv.outputs.name
+      cpu: service.cpu
       exists: servicesExist['${service.name}'] == 'true'
       hasIngress: service.hasIngress
       identityName: '${abbrs.managedIdentityUserAssignedIdentities}${service.name}-${resourceToken}'
       imageName: service.image
       keyvaultName: keyVault.outputs.name
       location: location
+      memory: service.memory
       name: '${abbrs.appContainerApps}${service.name}'
+      replicaCount: empty(service.replicaCount) ? 0 : int(service.replicaCount)
       resourceToken: resourceToken
       serviceName: service.name
       tags: tags

--- a/deploy/quick-start/infra/main.parameters.json
+++ b/deploy/quick-start/infra/main.parameters.json
@@ -100,7 +100,10 @@
       "authService": {
         "value": {
           "name": "auth-api",
-          "image": "${SERVICE_AUTHORIZATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/authorization-api:${FLLM_VERSION}}"
+          "image": "${SERVICE_AUTHORIZATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/authorization-api:${FLLM_VERSION}}",
+          "cpu": "${SERVICE_AUTHORIZATIONAPI_CPU=1.0}",
+          "memory": "${SERVICE_AUTHORIZATIONAPI_MEMORY=2.0Gi}",
+          "replicaCount": "${SERVICE_AUTHORIZATIONAPI_REPLICAS}"
         }
       },
       "services": {
@@ -111,7 +114,10 @@
             "hasIngress": true,
             "image": "${SERVICE_AGENTHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/agent-hub-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
-            "apiKeySecretName": "foundationallm-apis-agenthubapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-agenthubapi-apikey",
+            "cpu": "${SERVICE_AGENTHUB_CPU=1.0}",
+            "memory": "${SERVICE_AGENTHUB_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_AGENTHUB_REPLICAS}"
           },
           {
             "name": "chat-ui",
@@ -119,7 +125,10 @@
             "hasIngress": true,
             "image": "${SERVICE_CHATUI_IMAGE=cropseastus2svinternal.azurecr.io/chat-ui:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "NUXT_APP_CONFIG_ENDPOINT",
-            "apiKeySecretName": "foundationallm-apis-chatui-apikey"
+            "apiKeySecretName": "foundationallm-apis-chatui-apikey",
+            "cpu": "${SERVICE_CHATUI_CPU=1.0}",
+            "memory": "${SERVICE_CHATUI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_CHATUI_REPLICAS}"
           },
           {
             "name": "core-api",
@@ -127,7 +136,10 @@
             "hasIngress": true,
             "image": "${SERVICE_COREAPI_IMAGE=cropseastus2svinternal.azurecr.io/core-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-coreapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-coreapi-apikey",
+            "cpu": "${SERVICE_COREAPI_CPU=1.0}",
+            "memory": "${SERVICE_COREAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_COREAPI_REPLICAS}"
           },
           {
             "name": "core-job",
@@ -135,7 +147,10 @@
             "hasIngress": false,
             "image": "${SERVICE_COREJOB_IMAGE=cropseastus2svinternal.azurecr.io/core-job:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-corejob-apikey"
+            "apiKeySecretName": "foundationallm-apis-corejob-apikey",
+            "cpu": "${SERVICE_COREJOB_CPU=1.0}",
+            "memory": "${SERVICE_COREJOB_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_COREJOB_REPLICAS}"
           },
           {
             "name": "data-source-hub-api",
@@ -143,7 +158,10 @@
             "hasIngress": true,
             "image": "${SERVICE_DATASOURCEHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/data-source-hub-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
-            "apiKeySecretName": "foundationallm-apis-datasourcehubapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-datasourcehubapi-apikey",
+            "cpu": "${SERVICE_DATASOURCEHUBAPI_CPU=1.0}",
+            "memory": "${SERVICE_DATASOURCEHUBAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_DATASOURCEHUBAPI_REPLICAS}"
           },
           {
             "name": "gatekeeper-api",
@@ -151,7 +169,10 @@
             "hasIngress": true,
             "image": "${SERVICE_GATEKEEPERAPI_IMAGE=cropseastus2svinternal.azurecr.io/gatekeeper-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-gatekeeperapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-gatekeeperapi-apikey",
+            "cpu": "${SERVICE_GATEKEEPERAPI_CPU=1.0}",
+            "memory": "${SERVICE_GATEKEEPERAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_GATEKEEPERAPI_REPLICAS}"
           },
           {
             "name": "gatekeeper-integration-api",
@@ -159,7 +180,10 @@
             "hasIngress": true,
             "image": "${SERVICE_GATEKEEPERINTEGRATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/gatekeeper-integration-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
-            "apiKeySecretName": "foundationallm-apis-gatekeeperintegrationapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-gatekeeperintegrationapi-apikey",
+            "cpu": "${SERVICE_GATEKEEPERINTEGRATIONAPI_CPU=1.0}",
+            "memory": "${SERVICE_GATEKEEPERINTEGRATIONAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_GATEKEEPERINTEGRATIONAPI_REPLICAS}"
           },
           {
             "name": "gateway-api",
@@ -167,7 +191,10 @@
             "hasIngress": true,
             "image": "${SERVICE_GATEWAYAPI_IMAGE=cropseastus2svinternal.azurecr.io/gateway-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-gatewayapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-gatewayapi-apikey",
+            "cpu": "${SERVICE_GATEWAYAPI_CPU=1.0}",
+            "memory": "${SERVICE_GATEWAYAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_GATEWAYAPI_REPLICAS}"
           },
           {
             "name": "langchain-api",
@@ -175,7 +202,10 @@
             "hasIngress": true,
             "image": "${SERVICE_LANGCHAINAPI_IMAGE=cropseastus2svinternal.azurecr.io/langchain-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
-            "apiKeySecretName": "foundationallm-apis-langchainapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-langchainapi-apikey",
+            "cpu": "${SERVICE_LANGCHAINAPI_CPU=1.0}",
+            "memory": "${SERVICE_LANGCHAINAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_LANGCHAINAPI_REPLICAS}"
           },
           {
             "name": "management-api",
@@ -183,7 +213,10 @@
             "hasIngress": true,
             "image": "${SERVICE_MANAGEMENTAPI_IMAGE=cropseastus2svinternal.azurecr.io/management-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-managementapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-managementapi-apikey",
+            "cpu": "${SERVICE_MANAGEMENTAPI_CPU=1.0}",
+            "memory": "${SERVICE_MANAGEMENTAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_MANAGEMENTAPI_REPLICAS}"
           },
           {
             "name": "management-ui",
@@ -191,7 +224,10 @@
             "hasIngress": true,
             "image": "${SERVICE_MANAGEMENTUI_IMAGE=cropseastus2svinternal.azurecr.io/management-ui:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "NUXT_APP_CONFIG_ENDPOINT",
-            "apiKeySecretName": "foundationallm-apis-managementui-apikey"
+            "apiKeySecretName": "foundationallm-apis-managementui-apikey",
+            "cpu": "${SERVICE_MANAGEMENTUI_CPU=1.0}",
+            "memory": "${SERVICE_MANAGEMENTUI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_MANAGEMENTUI_REPLICAS}"
           },
           {
             "name": "orchestration-api",
@@ -199,7 +235,10 @@
             "hasIngress": true,
             "image": "${SERVICE_ORCHESTRATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/orchestration-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-orchestrationapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-orchestrationapi-apikey",
+            "cpu": "${SERVICE_ORCHESTRATIONAPI_CPU=1.0}",
+            "memory": "${SERVICE_ORCHESTRATIONAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_ORCHESTRATIONAPI_REPLICAS}"
           },
           {
             "name": "prompt-hub-api",
@@ -207,7 +246,10 @@
             "hasIngress": true,
             "image": "${SERVICE_PROMPTHUBAPI_IMAGE=cropseastus2svinternal.azurecr.io/prompt-hub-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FOUNDATIONALLM_APP_CONFIGURATION_URI",
-            "apiKeySecretName": "foundationallm-apis-prompthubapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-prompthubapi-apikey",
+            "cpu": "${SERVICE_PROMPTHUBAPI_CPU=1.0}",
+            "memory": "${SERVICE_PROMPTHUBAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_PROMPTHUBAPI_REPLICAS}"
           },
           {
             "name": "semantic-kernel-api",
@@ -215,7 +257,10 @@
             "hasIngress": true,
             "image": "${SERVICE_SEMANTICKERNELAPI_IMAGE=cropseastus2svinternal.azurecr.io/semantic-kernel-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-semantickernelapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-semantickernelapi-apikey",
+            "cpu": "${SERVICE_SEMANTICKERNELAPI_CPU=1.0}",
+            "memory": "${SERVICE_SEMANTICKERNELAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_SEMANTICKERNELAPI_REPLICAS}"
           },
           {
             "name": "vectorization-api",
@@ -223,7 +268,10 @@
             "hasIngress": true,
             "image": "${SERVICE_VECTORIZATIONAPI_IMAGE=cropseastus2svinternal.azurecr.io/vectorization-api:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-vectorizationapi-apikey"
+            "apiKeySecretName": "foundationallm-apis-vectorizationapi-apikey",
+            "cpu": "${SERVICE_VECTORIZATIONAPI_CPU=1.0}",
+            "memory": "${SERVICE_VECTORIZATIONAPI_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_VECTORIZATIONAPI_REPLICAS}"
           },
           {
             "name": "vectorization-job",
@@ -231,7 +279,10 @@
             "hasIngress": false,
             "image": "${SERVICE_VECTORIZATIONJOB_IMAGE=cropseastus2svinternal.azurecr.io/vectorization-job:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
-            "apiKeySecretName": "foundationallm-apis-vectorizationworker-apikey"
+            "apiKeySecretName": "foundationallm-apis-vectorizationworker-apikey",
+            "cpu": "${SERVICE_VECTORIZATIONJOB_CPU=1.0}",
+            "memory": "${SERVICE_VECTORIZATIONJOB_MEMORY=2.0Gi}",
+            "replicaCount": "${SERVICE_VECTORIZATIONJOB_REPLICAS}"
           }
         ]
       },


### PR DESCRIPTION
# Added support for parameterizing resources for ACA QS

## The issue or feature being addressed

Currently, there is no way to specify ACA CPU and memory allocation and scaling policy. This is needed for Load Testing.

## Details on the issue fix or feature implementation

This PR adds AZD config keys with default values for scaling specific services at deploy time.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
