### PR TITLE
Gatekeeper API : Pin numpy package to version 1.26.4

### DIFF
--- a/src/python/GatekeeperIntegrationAPI/requirements.txt
+++ b/src/python/GatekeeperIntegrationAPI/requirements.txt
@@ -3,6 +3,7 @@ azure-identity==1.16.0
 azure-keyvault-secrets==4.7.0
 azure-monitor-opentelemetry==1.2.0
 fastapi==0.110.1
+numpy==1.26.4
 presidio-analyzer==2.2.351
 presidio-anonymizer==2.2.351
 pylint==3.0.2

--- a/src/python/IntegrationSDK/requirements.txt
+++ b/src/python/IntegrationSDK/requirements.txt
@@ -1,6 +1,7 @@
 azure-appconfiguration-provider==1.0.0
 azure-identity==1.16.0
 azure-keyvault-secrets==4.7.0
+numpy==1.26.4
 pydantic==2.5.2
 presidio-analyzer==2.2.351
 presidio-anonymizer==2.2.351


### PR DESCRIPTION
# Gatekeeper API : Pin numpy package to version 1.26.4


## Details on the issue fix or feature implementation

An update to numpy to v. 2 created a downstream package incompatibility with the Thinc package (breaking Presidio). Pinning version to 1.26.4 fixes this issue until the downstream problems are rectified.

Ref: 
https://github.com/microsoft/presidio/issues/1400
https://github.com/explosion/thinc/issues/939

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
