### PR TITLE
Update to E2E Pipeline to use "well-known" App Registrations

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -337,11 +337,11 @@ jobs:
             -tenantId $($info.tenantId) `
             -principalType ServicePrincipal `
             -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176 `
-            -fllmApiName FoundationaLLM-Core `
-            -fllmClientName FoundationaLLM-Core `
-            -fllmMgmtApiName FoundationaLLM-Management `
-            -fllmMgmtClientName FoundationaLLM-Management-Client `
-            -fllmAuthApiName FoundationaLLM-Authorization `
+            -fllmApiName FoundationaLLM-Core-API `
+            -fllmClientName FoundationaLLM-Core-Portal `
+            -fllmMgmtApiName FoundationaLLM-Management-API `
+            -fllmMgmtClientName FoundationaLLM-Management-Portal `
+            -fllmAuthApiName FoundationaLLM-Authorization-API `
             -fllmAdminGroupName FLLM-E2E-Admins-${{ needs.generate_matrix.outputs.unique_id }}
           Pop-Location
         shell: pwsh
@@ -376,8 +376,8 @@ jobs:
           Write-Host "Update App Registration OAuth Callbacks"
           Push-Location ./deploy/quick-start
           pwsh -File ../../tests/scripts/Update-OAuthCallbackUris.ps1 `
-            -fllmChatUiName FoundationaLLM-Core-Client `
-            -fllmMgmtUiName FoundationaLLM-Management-Client
+            -fllmChatUiName FoundationaLLM-Core-Portal `
+            -fllmMgmtUiName FoundationaLLM-Management-Portal
           Pop-Location
         shell: pwsh
 
@@ -645,7 +645,7 @@ jobs:
             --username "$($info.clientId)" `
             --password "$($info.clientSecret)" `
             --tenant "$($info.tenantId)" `
-            --scope api://FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }}/.default
+            --scope api://FoundationaLLM-Core/.default
         shell: pwsh
 
       - name: Running End to End Tests

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -248,20 +248,6 @@ jobs:
             --tenant-id "$($info.tenantId)"
         shell: pwsh
 
-      - name: Provision App Registrations
-        id: provision-app-registrations
-        run: |
-          Write-Host "Provision App Registrations"
-          Push-Location ./tests/scripts
-          ./Create-FllmEntraIdApps.ps1 `
-            -authAppName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -coreAppName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -coreClientAppName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -mgmtAppName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -mgmtClientAppName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }}
-          Pop-Location
-        shell: pwsh
-
       - name: Provision Admin Group
         id: provision-admin-group
         run: |
@@ -351,11 +337,11 @@ jobs:
             -tenantId $($info.tenantId) `
             -principalType ServicePrincipal `
             -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176 `
-            -fllmApiName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -fllmClientName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -fllmMgmtApiName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -fllmMgmtClientName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -fllmAuthApiName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
+            -fllmApiName FoundationaLLM-Core `
+            -fllmClientName FoundationaLLM-Core `
+            -fllmMgmtApiName FoundationaLLM-Management `
+            -fllmMgmtClientName FoundationaLLM-Management-Client `
+            -fllmAuthApiName FoundationaLLM-Authorization `
             -fllmAdminGroupName FLLM-E2E-Admins-${{ needs.generate_matrix.outputs.unique_id }}
           Pop-Location
         shell: pwsh
@@ -390,8 +376,8 @@ jobs:
           Write-Host "Update App Registration OAuth Callbacks"
           Push-Location ./deploy/quick-start
           pwsh -File ../../tests/scripts/Update-OAuthCallbackUris.ps1 `
-            -fllmChatUiName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -fllmMgmtUiName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }}
+            -fllmChatUiName FoundationaLLM-Core-Client `
+            -fllmMgmtUiName FoundationaLLM-Management-Client
           Pop-Location
         shell: pwsh
 
@@ -848,17 +834,6 @@ jobs:
 
           Write-Host "Remove Admin Group"
           az ad group delete --group FLLM-E2E-Admins-${{ needs.generate_matrix.outputs.unique_id }} --output json
-
-          Write-Host "Tear down App Registrations"
-          Push-Location ./tests/scripts
-          ./Remove-EntraIdApps.ps1 `
-            -authAppName FoundationaLLM-Authorization-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -coreAppName FoundationaLLM-Core-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -coreClientAppName FoundationaLLM-Core-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -mgmtAppName FoundationaLLM-Management-E2E-${{ needs.generate_matrix.outputs.unique_id }} `
-            -mgmtClientAppName FoundationaLLM-Management-E2E-Client-${{ needs.generate_matrix.outputs.unique_id }} `
-            -interactiveMode $false
-          Pop-Location
         shell: pwsh
 
       - name: Get E2E Test Results

--- a/deploy/common/scripts/Set-TestData.ps1
+++ b/deploy/common/scripts/Set-TestData.ps1
@@ -138,7 +138,7 @@ try {
     $testDataPath = "../data/test/vectorization-input" | Get-AbsolutePath | join-path -ChildPath "*"
     Write-Host "Reading vectorization-input data from: $testDataPath" -ForegroundColor Yellow
     Invoke-CLICommand "Copy vectorization-input data to the storage account ${storageAccountName}" {
-        azcopy copy $testDataPath "https://$($storageAccountName).blob.core.windows.net/vectorization-input" --recursive
+        azcopy copy "$testDataPath" "https://$($storageAccountName).blob.core.windows.net/vectorization-input" --recursive
     }
 }
 catch {


### PR DESCRIPTION
# Update to E2E Pipeline to use "well-known" App Registrations

## The issue or feature being addressed

Fixes #18077 and #18081

## Details on the issue fix or feature implementation

Updated the E2E pipeline to no longer create app registrations for each deployment, but instead use pre-existing "well-known" App Registrations.  Also corrected an issue with AzCopy in the test data upload stage.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
