### PR TITLE
Adding script to remove OAuth callback URIs from client app registrations

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -828,6 +828,13 @@ jobs:
             -principalType ServicePrincipal `
             -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176
 
+          Write-Host "Removing App Registration OAuth Callbacks"
+          Push-Location ./deploy/quick-start
+          pwsh -File ../../tests/scripts/Remove-OAuthCallbackUris.ps1 `
+            -fllmChatUiName FoundationaLLM-Core-Portal `
+            -fllmMgmtUiName FoundationaLLM-Management-Portal
+          Pop-Location
+
           azd env refresh --no-prompt
           azd down --force --purge --no-prompt
           Pop-Location

--- a/tests/scripts/Remove-OAuthCallbackUris.ps1
+++ b/tests/scripts/Remove-OAuthCallbackUris.ps1
@@ -1,15 +1,17 @@
 #!/usr/bin/pwsh
 <#
 .SYNOPSIS
-    Updates the OAuth callback URIs of the Chat UI and Management UI app registrations. This script is best 
+    Removes the OAuth callback URIs of the Chat UI and Management UI app registrations. This script is best 
     used after running the ./deploy/common/scripts/entraid/Create-FllmEntraApps.ps1 script to create your FLLM EntraID apps
-    and deploying the appropriate Chat UI and Management UI infrastructure and services.
+    and deploying the appropriate Chat UI and Management UI infrastructure and services and Update-OAuthCallbackUris.ps1
+    to create the OAuth callback URIs to be removed.
 
 .DESCRIPTION
-    This script updates the app registration OAuth callback URIs required for the Starter deployment.
+    This script removes the app registration OAuth callback URIs required for the Starter deployment.
     It retrieves the endpoint URIs of the User Portal and Management Portal, constructs the callback URIs from
-    these endpoint URIs, and adds them to the Authentication configuration of the EntraID Apps required for the 
-    FLLM application. This script must be run after running azd provision in the ./deploy/quick-start folder.
+    these endpoint URIs, and removes them if they exist from the Authentication configuration of the EntraID Apps
+    required for the FLLM application. This script must be run after running azd provision in the 
+    ./deploy/quick-start folder and Update-OAuthCallbackUris.ps1 from the ./tests/scripts folder.
 
     For more information on seting up the FLLM EntraID apps: : https://docs.foundationallm.ai/deployment/authentication/index.html
     
@@ -24,13 +26,13 @@ Optional parameters:
     - fllmMgmtUiName: The name of the FLLM Management UI.
     
 .EXAMPLE
-If you have run the Create-FllmEntraApps.ps1 script, then you can run the Update-OAuthCallbackUris.ps1 script with no parameters:
-    ./Update-OAuthCallbackUris.ps1
+If you have run the Update-OAuthCallbackUris.ps1 script, then you can run the Remove-OAuthCallbackUris.ps1 script with no parameters:
+    ./Remove-OAuthCallbackUris.ps1
 
 If you have not run the Create-FllmEntraApps.ps1 script, then you can run the Set-AzdEnv.ps1 script with the tenant ID and the names of the apps.
 You will need to update the app names with those you created manually in the EntraID portal.
-    ./Set-AzdEnv.ps1 -fllmChatUiNAme "FoundationaLLM" `
-                     -fllmMgmtUiName "FoundationaLLM-Management"
+    ./Set-AzdEnv.ps1 -fllmChatUiNAme "FoundationaLLM-Core-Portal" `
+                     -fllmMgmtUiName "FoundationaLLM-Management-Portal"
 
 #>
 
@@ -76,25 +78,21 @@ foreach ($uri in $uris.GetEnumerator()) {
 
     $redirect = ($uri.Value.endpoint | ConvertFrom-Json) + "/signin-oidc"
 
-    if ($redirects -eq $null)
-    {
-        $redirects = @( $redirect )
-    } else {
-        if (-not $redirects.Contains($redirect)) {
-            $redirects += $redirect
-        }
+
+    if ($redirects.Contains($redirect)) {
+        $redirects -= $redirect
+
+        $body = @{
+            spa = @{
+                redirectUris = $redirects
+            }
+        } | ConvertTo-Json -Compress
+
+        Set-Content -Path "$($uri.Key)`.json" $body
+        az rest `
+            --method "patch" `
+            --uri $applicationUri `
+            --headers "{'Content-Type': 'application/json'}" `
+            --body "@$($uri.Key)`.json"
     }
-
-    $body = @{
-        spa = @{
-            redirectUris = $redirects
-        }
-    } | ConvertTo-Json -Compress
-
-    Set-Content -Path "$($uri.Key)`.json" $body
-    az rest `
-        --method "patch" `
-        --uri $applicationUri `
-        --headers "{'Content-Type': 'application/json'}" `
-        --body "@$($uri.Key)`.json"
 }


### PR DESCRIPTION
# Adding script to remove OAuth callback URIs from client app registrations

## The issue or feature being addressed

Fixes #18078

## Details on the issue fix or feature implementation

Adding script to remove OAuth callback URIs from client app registrations and updated the E2E pipeline to appropriately call it on teardown.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

