### PR TITLE
Adding Cognitive Services User role to Gatekeeper API

### DIFF
--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -627,6 +627,23 @@ module openAiRoles './shared/roleAssignments.bicep' = [
   }
 ]
 
+var contentSafetyTargets = [
+  'gatekeeper-api'
+]
+
+module contentSafetyRoles './shared/roleAssignments.bicep' = [
+  for target in contentSafetyTargets: {
+    scope: rg
+    name: '${target}-openai-roles-${timestamp}'
+    params: {
+      principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
+      roleDefinitionNames: [
+        'Cognitive Services User'
+      ]
+    }
+  }
+]
+
 output AZURE_APP_CONFIG_NAME string = appConfig.outputs.name
 output AZURE_AUTHORIZATION_STORAGE_ACCOUNT_NAME string = authStore.outputs.name
 output AZURE_COGNITIVE_SEARCH_ENDPOINT string = cogSearch.outputs.endpoint

--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -634,7 +634,7 @@ var contentSafetyTargets = [
 module contentSafetyRoles './shared/roleAssignments.bicep' = [
   for target in contentSafetyTargets: {
     scope: rg
-    name: '${target}-openai-roles-${timestamp}'
+    name: '${target}-cs-roles-${timestamp}'
     params: {
       principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
       roleDefinitionNames: [

--- a/deploy/quick-start/infra/shared/roleAssignments.bicep
+++ b/deploy/quick-start/infra/shared/roleAssignments.bicep
@@ -10,6 +10,7 @@ var selectedRoleDefinitions = filter(items(roleDefinitions), (item) => contains(
 var roleDefinitions = {
   'App Configuration Data Reader':  '516239f1-63e1-4d78-a4de-a74fb236a071'
   'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+  'Cognitive Services User':        'a97b65f3-24c7-4388-baec-2e87135dc908'
   'Contributor':                    'b24988ac-6180-42a0-ab88-20f7382dd24c'
   'EventGrid Contributor':          '1e241071-0855-49ea-94dc-649edcd759de'
   'Key Vault Certificate User':     'db79e9a7-68ee-4b58-9aeb-b90e7c24fcba'


### PR DESCRIPTION
# Adding Cognitive Services User role to Gatekeeper API

## The issue or feature being addressed

Fixes #18099

## Details on the issue fix or feature implementation

Adding Cognitive Services User role to Gatekeeper API to allow access to the Content Safety service.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

