### PR TITLE
Fix data source internal resolution logic

### DIFF
--- a/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
+++ b/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
@@ -444,14 +444,14 @@ namespace FoundationaLLM.DataSource.ResourceProviders
 
             if (typeof(T) != typeof(DataSourceBase))
                 throw new ResourceProviderException($"The type of requested resource ({typeof(T)}) does not match the resource type specified in the path ({resourcePath.ResourceTypeInstances[0].ResourceType}).");
-
+                     
             _dataSourceReferences.TryGetValue(resourcePath.ResourceTypeInstances[0].ResourceId!, out var dataSourceReference);
-            if (dataSourceReference == null || dataSourceReference.Deleted)
-                throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId!} of type {resourcePath.ResourceTypeInstances[0].ResourceType} was not found.");
+            if (dataSourceReference is not null && dataSourceReference.Deleted)
+                throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId} of type {resourcePath.ResourceTypeInstances[0].ResourceType} has been soft deleted.");
 
-            var dataSource = LoadDataSource(dataSourceReference).Result;
+            var dataSource = LoadDataSource(dataSourceReference, resourcePath.ResourceTypeInstances[0].ResourceId).Result;
             return dataSource as T
-                ?? throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId!} of type {resourcePath.ResourceTypeInstances[0].ResourceType} was not found.");
+                ?? throw new ResourceProviderException($"The resource {resourcePath.ResourceTypeInstances[0].ResourceId} of type {resourcePath.ResourceTypeInstances[0].ResourceType} was not found.");
         }
         
 


### PR DESCRIPTION
# Fix data source internal resolution logic


## Details on the issue fix or feature implementation

When running end-to-end tests the data source may not be loaded and a hot reload is required. The existing logic would fail the retrieval of a datasource if the reference did not exist prior to the hot reload. Modified the logic so that the data source reference can be null and passing in the resource id for hot reload support.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable