### PR TITLE
Fix deletions for non-existent Prompts & Vectorization Profiles

### DIFF
--- a/src/dotnet/Prompt/ResourceProviders/PromptResourceProviderService.cs
+++ b/src/dotnet/Prompt/ResourceProviders/PromptResourceProviderService.cs
@@ -344,7 +344,7 @@ namespace FoundationaLLM.Prompt.ResourceProviders
         private async Task DeletePrompt(List<ResourceTypeInstance> instances)
         {
             if (_promptReferences.TryGetValue(instances.Last().ResourceId!, out var promptReference)
-                || promptReference!.Deleted)
+                && !promptReference.Deleted)
             {
                 promptReference.Deleted = true;
 

--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
@@ -551,7 +551,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
             where TBase : ResourceBase
         {
             if (resourceStore.TryGetValue(resourcePath.ResourceTypeInstances[0].ResourceId!, out var resource)
-                || resource!.Deleted)
+                && !resource.Deleted)
             {
                 resource.Deleted = true;
 


### PR DESCRIPTION
# Fix deletions for non-existent Prompts & Vectorization Profiles

## The issue or feature being addressed

Currently, whenever a Prompt or Vectorization Profile that does not exist is deleted, a null reference exception is thrown. Thus, the user sees a 500 internal server error, rather than a 404.

## Details on the issue fix or feature implementation

This PR fixes the logical evaluation in the Prompt & Vectorization resource providers so that the logical condition is evaluated correctly.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable