### PR TITLE
Fix Test Settings Loading for E2E

### DIFF
--- a/.github/workflows/e2e-daily-testing.yml
+++ b/.github/workflows/e2e-daily-testing.yml
@@ -18,5 +18,5 @@ jobs:
       enableTeardown: true
       bypassAndTeardown: false
       target: e2e
-      deployAMLResources: true
+      deployAMLResources: false
     secrets: inherit

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -604,6 +604,7 @@ jobs:
 
       - name: Pull Build Artifacts
         run: |
+          $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Push-Location ./deploy/common/scripts
           $env:AZCOPY_SPA_CLIENT_SECRET="$($info.clientSecret)"
           azcopy login `

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -578,6 +578,40 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.x
+
+      - name: Sets Credentials for Source (SBX)
+        run: |
+          {
+            echo 'AZURE_CREDENTIALS_SRC<<EOF'
+            echo "$FLLM_SBX_AZURE_CREDENTIALS"
+            echo EOF
+          } >> "$GITHUB_ENV"
+        env:
+          FLLM_SBX_AZURE_CREDENTIALS: |
+            ${{ secrets.FLLM_SBX_AZURE_CREDENTIALS }}
+
+      - name: Sets Credentials for Target (E2E)
+        run: |
+          {
+            echo 'AZURE_CREDENTIALS<<EOF'
+            echo "$FLLM_E2E_AZURE_CREDENTIALS"
+            echo EOF
+          } >> "$GITHUB_ENV"
+        if: inputs.target == 'e2e'
+        env:
+          FLLM_E2E_AZURE_CREDENTIALS: |
+            ${{ secrets.FLLM_E2E_AZURE_CREDENTIALS }}
+
+      - name: Pull Build Artifacts
+        run: |
+          Push-Location ./deploy/common/scripts
+          $env:AZCOPY_SPA_CLIENT_SECRET="$($info.clientSecret)"
+          azcopy login `
+            --login-type=SPN `
+            --application-id "$($info.clientId)" `
+            --tenant-id "$($info.tenantId)"
+          ./Get-TestSettings.ps1 -storageAccountName foundationallmdata
+          Pop-Location
       
       - name: Build Tests
         shell: pwsh
@@ -675,15 +709,6 @@ jobs:
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
-
-          Push-Location ./deploy/common/scripts
-          $env:AZCOPY_SPA_CLIENT_SECRET="$($info.clientSecret)"
-          azcopy login `
-            --login-type=SPN `
-            --application-id "$($info.clientId)" `
-            --tenant-id "$($info.tenantId)"
-          ./Get-TestSettings.ps1 -storageAccountName foundationallmdata
-          Pop-Location
 
           Write-Host "Create new AZD Environment"
           Push-Location ./deploy/quick-start

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -677,7 +677,7 @@ jobs:
           Write-Host "::add-mask::$($info.clientSecret)"
 
           Push-Location ./deploy/common/scripts
-          Get-TestSettings.ps1 -storageAccountName foundationallmdata
+          ./Get-TestSettings.ps1 -storageAccountName foundationallmdata
           Pop-Location
 
           Write-Host "Create new AZD Environment"

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -612,6 +612,7 @@ jobs:
             --tenant-id "$($info.tenantId)"
           ./Get-TestSettings.ps1 -storageAccountName foundationallmdata
           Pop-Location
+        shell: pwsh
       
       - name: Build Tests
         shell: pwsh

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -676,6 +676,10 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
+          Push-Location ./deploy/common/scripts
+          Get-TestSettings.ps1 -storageAccountName foundationallmdata
+          Pop-Location
+
           Write-Host "Create new AZD Environment"
           Push-Location ./deploy/quick-start
           azd env new ${{ inputs.environment }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -677,6 +677,11 @@ jobs:
           Write-Host "::add-mask::$($info.clientSecret)"
 
           Push-Location ./deploy/common/scripts
+          $env:AZCOPY_SPA_CLIENT_SECRET="$($info.clientSecret)"
+          azcopy login `
+            --login-type=SPN `
+            --application-id "$($info.clientId)" `
+            --tenant-id "$($info.tenantId)"
           ./Get-TestSettings.ps1 -storageAccountName foundationallmdata
           Pop-Location
 

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -582,7 +582,7 @@ jobs:
       - name: Sets Credentials for Source (SBX)
         run: |
           {
-            echo 'AZURE_CREDENTIALS_SRC<<EOF'
+            echo 'AZURE_CREDENTIALS<<EOF'
             echo "$FLLM_SBX_AZURE_CREDENTIALS"
             echo EOF
           } >> "$GITHUB_ENV"

--- a/deploy/common/scripts/Get-TestData.ps1
+++ b/deploy/common/scripts/Get-TestData.ps1
@@ -55,12 +55,6 @@ try {
     Invoke-CLICommand "Copy index-backup data from the storage account: ${storageAccountName}" {
         azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/index-backup" $testDataPath --recursive
     }
-
-    $testSettingsPath = "../../../tests/dotnet/Core.Examples/testsettings.json" | Get-AbsolutePath
-    Write-Host "Writing testsettings.json data to: $testSettingsPath" -ForegroundColor Yellow
-    Invoke-CLICommand "Copy testsettings.json data from the storage account: ${storageAccountName}" {
-        azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/testsettings.json" $testSettingsPath
-    }
 }
 catch {
     $logFile = Get-ChildItem -Path "$env:HOME/.azcopy" -Filter "*.log" | `

--- a/deploy/common/scripts/Get-TestSettings.ps1
+++ b/deploy/common/scripts/Get-TestSettings.ps1
@@ -1,0 +1,49 @@
+#! /usr/bin/pwsh
+
+Param(
+    [parameter(Mandatory = $true)][string]$storageAccountName
+)
+
+Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+function Invoke-CLICommand {
+    <#
+    .SYNOPSIS
+    Invoke a CLI Command and allow all output to print to the terminal.  Does not check for return values or pass the output to the caller.
+    #>
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Message,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [ScriptBlock]$ScriptBlock
+    )
+
+    Write-Host "${message}..." -ForegroundColor Blue
+    & $ScriptBlock
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed ${message} (code: ${LASTEXITCODE})"
+    }
+}
+
+function Get-AbsolutePath {
+    <#
+    .SYNOPSIS
+    Get the absolute path of a file or directory. Relative path does not need to exist.
+    #>
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [string]$RelatviePath
+    )
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RelatviePath)
+}
+
+$testSettingsPath = "../../../tests/dotnet/Core.Examples/testsettings.json" | Get-AbsolutePath
+Write-Host "Writing testsettings.json data to: $testSettingsPath" -ForegroundColor Yellow
+Invoke-CLICommand "Copy testsettings.json data from the storage account: ${storageAccountName}" {
+    azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/testsettings.json" $testSettingsPath
+}

--- a/deploy/common/scripts/Get-TestSettings.ps1
+++ b/deploy/common/scripts/Get-TestSettings.ps1
@@ -42,8 +42,8 @@ function Get-AbsolutePath {
     return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RelatviePath)
 }
 
-$testSettingsPath = "../../../tests/dotnet/Core.Examples/testsettings.json" | Get-AbsolutePath
-Write-Host "Writing testsettings.json data to: $testSettingsPath" -ForegroundColor Yellow
-Invoke-CLICommand "Copy testsettings.json data from the storage account: ${storageAccountName}" {
-    azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/testsettings.json" $testSettingsPath
+$testSettingsPath = "../../../tests/dotnet/Core.Examples/testsettings.e2e.json" | Get-AbsolutePath
+Write-Host "Writing testsettings.e2e.json data to: $testSettingsPath" -ForegroundColor Yellow
+Invoke-CLICommand "Copy testsettings.e2e.json data from the storage account: ${storageAccountName}" {
+    azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/testsettings.e2e.json" $testSettingsPath
 }

--- a/tests/dotnet/Core.Examples/Core.Examples.csproj
+++ b/tests/dotnet/Core.Examples/Core.Examples.csproj
@@ -51,6 +51,9 @@
     <None Update="testsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="testsettings.e2e.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/dotnet/Core.Examples/Setup/TestFixture.cs
+++ b/tests/dotnet/Core.Examples/Setup/TestFixture.cs
@@ -20,6 +20,7 @@ namespace FoundationaLLM.Core.Examples.Setup
 
             var configRoot = new ConfigurationBuilder()
 				.AddJsonFile("testsettings.json", true)
+				.AddJsonFile("testsettings.e2e.json", true)
 				.AddEnvironmentVariables()
 				.AddUserSecrets<Environment>()
 				.AddAzureAppConfiguration(options =>


### PR DESCRIPTION
# Fix Test Settings Loading for E2E

## The issue or feature being addressed

Currently, the test settings file is not part of the .NET build, so any tests that reference it fail.

## Details on the issue fix or feature implementation

This PR breaks the download of the test settings file into a separate script that is called by the build process.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
