### PR TITLE
Fix Build Failures in E2E Pipeline

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -590,18 +590,6 @@ jobs:
           FLLM_SBX_AZURE_CREDENTIALS: |
             ${{ secrets.FLLM_SBX_AZURE_CREDENTIALS }}
 
-      - name: Sets Credentials for Target (E2E)
-        run: |
-          {
-            echo 'AZURE_CREDENTIALS<<EOF'
-            echo "$FLLM_E2E_AZURE_CREDENTIALS"
-            echo EOF
-          } >> "$GITHUB_ENV"
-        if: inputs.target == 'e2e'
-        env:
-          FLLM_E2E_AZURE_CREDENTIALS: |
-            ${{ secrets.FLLM_E2E_AZURE_CREDENTIALS }}
-
       - name: Pull Build Artifacts
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;

--- a/tests/dotnet/Core.Examples/Setup/TestFixture.cs
+++ b/tests/dotnet/Core.Examples/Setup/TestFixture.cs
@@ -30,22 +30,22 @@ namespace FoundationaLLM.Core.Examples.Setup
 					{
 						throw new InvalidOperationException("Azure App Configuration connection string is not set.");
 					}
-					options.Connect(connectionString)
-						.ConfigureKeyVault(kv =>
+                    options.Connect(connectionString)
+                        .ConfigureKeyVault(kv =>
                         {
                             kv.SetCredential(DefaultAuthentication.AzureCredential);
                         })
                         // Select the configuration sections to load:
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_Instance)
-						.Select(AppConfigurationKeyFilters.FoundationaLLM_APIs)
+                        .Select(AppConfigurationKeyFilters.FoundationaLLM_APIs)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_Chat_Entra)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_Management_Entra)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_CosmosDB)
-						.Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio)
+                        .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_APIs_VectorizationAPI)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization)
-						.Select(AppConfigurationKeyFilters.FoundationaLLM_DataSources)
-                        .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio_BlobStorageServiceSettings);
+                        .Select(AppConfigurationKeyFilters.FoundationaLLM_DataSources);
+                        // .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio_BlobStorageServiceSettings);
 				})
 				.Build();
 

--- a/tests/dotnet/Core.Examples/Setup/TestFixture.cs
+++ b/tests/dotnet/Core.Examples/Setup/TestFixture.cs
@@ -44,8 +44,8 @@ namespace FoundationaLLM.Core.Examples.Setup
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_APIs_VectorizationAPI)
                         .Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization)
-                        .Select(AppConfigurationKeyFilters.FoundationaLLM_DataSources);
-                        // .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio_BlobStorageServiceSettings);
+                        .Select(AppConfigurationKeyFilters.FoundationaLLM_DataSources)
+                        .Select(AppConfigurationKeyFilters.FoundationaLLM_AzureAIStudio_BlobStorageServiceSettings);
 				})
 				.Build();
 


### PR DESCRIPTION
# Fix Build Failures in E2E Pipeline

## The issue or feature being addressed

Currently, the daily E2E pipeline is failing because the build fails. This is because AzCopy, acting with E2E credentials, does not have permission to pull the `testsettings.e2e.json` file from Sandbox.

## Details on the issue fix or feature implementation

This PR uses the Sandbox credential, instead of E2E.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
