### PR TITLE
Fix error in User Portal on mobile displays during first page load

### DIFF
--- a/src/ui/UserPortal/pages/index/index.vue
+++ b/src/ui/UserPortal/pages/index/index.vue
@@ -28,7 +28,7 @@ export default {
 
 	mounted() {
 		if (window.innerWidth < 950) {
-			this.appStore.toggleSidebar();
+			this.$appStore.toggleSidebar();
 		}
 	},
 


### PR DESCRIPTION
# Fix error in User Portal on mobile displays during first page load

## The issue or feature being addressed

Fixes an invalid reference to the app store to toggle the sidebar.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
