### PR TITLE
Polling support in Orchestration API

### DIFF
--- a/src/dotnet/Common/Clients/PollingHttpClient`2.cs
+++ b/src/dotnet/Common/Clients/PollingHttpClient`2.cs
@@ -1,0 +1,121 @@
+﻿using FoundationaLLM.Common.Settings;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Common.Clients
+{
+    /// <summary>
+    /// Provides a generic HTTP client that can be used to poll for a response.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the payload to send to start the operation.</typeparam>
+    /// <typeparam name="TResponse">The type of the response received when the operation is completed.</typeparam>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for the requests.</param>
+    /// <param name="request">The <typeparamref name="TRequest"/> request to send to the service.</param>
+    /// <param name="operationStarterPath">The path to send the request to (will be appended to the base path of the HTTP client.</param>
+    /// <param name="pollingInterval">The <see cref="TimeSpan"/> interval to poll for the response.</param>
+    /// <param name="maxWaitTime">The <see cref="TimeSpan"/> maximum time to wait for the response.</param>
+    /// <param name="logger">The logger used for logging.</param>
+    public class PollingHttpClient<TRequest, TResponse>(
+        HttpClient httpClient,
+        TRequest request,
+        string operationStarterPath,
+        TimeSpan pollingInterval,
+        TimeSpan maxWaitTime,
+        ILogger logger)
+    {
+        private readonly HttpClient _httpClient = httpClient;
+        private readonly TRequest _request = request;
+        private readonly string _operationStarterPath = operationStarterPath;
+        private readonly TimeSpan _pollingInterval = pollingInterval;
+        private readonly TimeSpan _maxWaitTime = maxWaitTime;
+        private readonly ILogger _logger = logger;
+        private readonly JsonSerializerOptions _jsonSerializerOptions = CommonJsonSerializerOptions.GetJsonSerializerOptions(
+            options => {
+                options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+                return options;
+            });
+
+        /// <summary>
+        /// <para>Retrieves the response from the service using a polling mechanism.
+        /// The polling mechanis is based on the following assumptions:</para>
+        /// - The {operationStarterPath} endpoint will accept a POST with a <typeparamref name="TRequest"/> object as payload and will return a 202 Accepted status code when the operation is started.<br/>
+        /// - The returned response will contain a RunningOperation object with the operation id.<br/>
+        /// - The polling enpoint is available at {operationStarterPath}/{operationId}.<br/>
+        /// - The polling endpoint will return a 204 No Content status code when the operation is in progress.<br/>
+        /// - The polling endpoint will return a 200 OK status code when the operation is completed and the reponse will contain a TResult object.<br/>
+        /// - The polling endpoint will return a 404 Not Found status code when the operation is not found.<br/>
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> indicating the need to cancel the process.</param>
+        /// <returns>The <typeparamref name="TResponse"/> object containing the response.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public async Task<TResponse?> GetResponseAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var body = JsonSerializer.Serialize(_request, _jsonSerializerOptions);
+                var responseMessage = await _httpClient.PostAsync(
+                    _operationStarterPath,
+                    new StringContent(
+                        body,
+                        Encoding.UTF8, "application/json"),
+                    cancellationToken);
+
+                if (responseMessage.StatusCode != HttpStatusCode.Accepted)
+                {
+                    _logger.LogError("The operation could not be started. The response status code was {StatusCode}.", responseMessage.StatusCode);
+                    return default;
+                }
+
+                var responseContent = await responseMessage.Content.ReadAsStringAsync();
+                var runningOperation = JsonSerializer.Deserialize<RunningOperation>(responseContent, _jsonSerializerOptions)!;
+
+                _logger.LogInformation("The operation was started successfully. The operation id is {OperationId}.", runningOperation.OperationId);
+                var operationResultPath = $"{_operationStarterPath}/{runningOperation.OperationId}";
+
+                var pollingStartTime = DateTime.UtcNow;
+
+                while (true)
+                {
+                    await Task.Delay(_pollingInterval, cancellationToken);
+
+                    _logger.LogInformation("Polling for the response on operation id {Operationid}...", runningOperation.OperationId);
+
+                    responseMessage = await _httpClient.GetAsync(
+                        operationResultPath,
+                        cancellationToken);
+
+                    switch (responseMessage.StatusCode)
+                    {
+                        case HttpStatusCode.NoContent:
+                            var totalPollingTime = DateTime.UtcNow - pollingStartTime;
+                            if (totalPollingTime > _maxWaitTime)
+                            {
+                                _logger.LogWarning("Total polling time ({TotalTime} seconds) exceeded to maximum allowed ({MaxTime} seconds).",
+                                    totalPollingTime.TotalSeconds,
+                                    _maxWaitTime.TotalSeconds);
+                                return default;
+                            }
+                            continue;
+                        case HttpStatusCode.OK:
+                            responseContent = await responseMessage.Content.ReadAsStringAsync();
+                            return JsonSerializer.Deserialize<TResponse>(responseContent, _jsonSerializerOptions);
+                        case HttpStatusCode.NotFound:
+                            _logger.LogError("The operation was not found. The operation id was {OperationId}.", runningOperation.OperationId);
+                            return default;
+                        default:
+                            _logger.LogError("An error occurred while polling for the response. The response status code was {StatusCode}.", responseMessage.StatusCode);
+                            return default;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while polling for the response.");
+                return default;
+            }
+        }
+    }
+}

--- a/src/dotnet/Common/Clients/RunningOperation.cs
+++ b/src/dotnet/Common/Clients/RunningOperation.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Common.Clients
+{
+    /// <summary>
+    /// Provides details about an LLM operation that is in progress.
+    /// </summary>
+    public class RunningOperation
+    {
+        /// <summary>
+        /// The unique identifier for the operation.
+        /// </summary>
+        [JsonPropertyName("operation_id")]
+        public required string OperationId { get; set; } = string.Empty;
+    }
+}

--- a/src/dotnet/Common/Settings/CommonJsonSerializerOptions.cs
+++ b/src/dotnet/Common/Settings/CommonJsonSerializerOptions.cs
@@ -16,5 +16,17 @@ namespace FoundationaLLM.Common.Settings
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
+
+        /// <summary>
+        /// Configures the System.Text.Json JSON serializer settings.
+        /// </summary>
+        /// <param name="customizer">A function that customizes the default settings.</param>
+        /// <returns></returns>
+        public static JsonSerializerOptions GetJsonSerializerOptions(
+            Func<JsonSerializerOptions, JsonSerializerOptions> customizer)
+        {
+            var options = GetJsonSerializerOptions();
+            return customizer(options);
+        }
     }
 }


### PR DESCRIPTION
# Polling support in Orchestration API

## The issue or feature being addressed

Adds support for interacting with external orchestration services using a polling pattern.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
