### PR TITLE
Removing deprecated storage containers from the FLLM storage account

### DIFF
--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -394,18 +394,6 @@ module storage './shared/storage.bicep' = {
   params: {
     containers: [
       {
-        name: 'agents'
-      }
-      {
-        name: 'data-sources'
-      }
-      {
-        name: 'foundationallm-source'
-      }
-      {
-        name: 'prompts'
-      }
-      {
         name: 'resource-provider'
       }
       {

--- a/deploy/standard/bicep/storage-rg.bicep
+++ b/deploy/standard/bicep/storage-rg.bicep
@@ -76,10 +76,6 @@ module storage 'modules/storageAccount.bicep' = {
     subnetId: '${vnetId}/subnets/FLLMStorage'
     tags: tags
     containers: [
-      'agents'
-      'data-sources'
-      'foundationallm-source'
-      'prompts'
       'resource-provider'
       'vectorization-input'
       'vectorization-state'


### PR DESCRIPTION
# Removing deprecated storage containers from the FLLM storage account

## Details on the issue fix or feature implementation

Removes the agents, data-sources, foundationallm-source, and prompts containers from both the Quick Start and Standard deployments.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

