### PR TITLE
User Portal: Select the last agent used in a chat session

### DIFF
--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -43,7 +43,6 @@
 
 			<!-- Right side content -->
 			<div class="navbar__content__right">
-				<!-- <template v-if="currentSession && $appConfigStore.allowAgentHint"> -->
 				<template v-if="currentSession">
 					<span class="header__dropdown">
 						<img
@@ -108,12 +107,15 @@ export default {
 
 	watch: {
 		currentSession(newSession: Session, oldSession: Session) {
-			if (newSession.id === oldSession?.id) return;
-
-			this.agentSelection =
-				this.agentOptions.find(
-					(agent) => agent.value === this.$appStore.getSessionAgent(newSession),
-				) || null;
+			if (newSession.id !== oldSession?.id) {
+				this.updateAgentSelection();
+			}
+		},
+		'$appStore.selectedAgents': {
+			handler() {
+				this.updateAgentSelection();
+			},
+			deep: true,
 		},
 	},
 
@@ -129,8 +131,6 @@ export default {
 			value: agent,
 		}));
 
-		// const publicAgentOptions = this.agentOptions.filter((agent) => !agent.my_agent);
-		// Show all agents in the first group, including "my agents".
 		const publicAgentOptions = this.agentOptions;
 		const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
 		const noAgentOptions = [{ label: 'None', value: null, disabled: true }];
@@ -149,6 +149,10 @@ export default {
 			label: 'My Agents',
 			items: privateAgentOptions.length > 0 ? privateAgentOptions : noAgentOptions,
 		});
+	},
+
+	mounted() {
+		this.updateAgentSelection();
 	},
 
 	methods: {
@@ -178,6 +182,11 @@ export default {
 
 		async handleLogout() {
 			await this.$authStore.logout();
+		},
+
+		updateAgentSelection() {
+			const agent = this.$appStore.getSessionAgent(this.currentSession);
+			this.agentSelection = this.agentOptions.find((option) => option.value.resource.object_id === agent.resource.object_id) || null;
 		},
 	},
 };

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -25,7 +25,7 @@ export const useAppStore = defineStore('app', {
 			// No need to load sessions if in kiosk mode, simply create a new one and skip.
 			if (appConfigStore.isKioskMode) {
 				const newSession = await api.addSession();
-				this.changeSession(newSession);
+				await this.changeSession(newSession);
 				return;
 			}
 
@@ -33,11 +33,16 @@ export const useAppStore = defineStore('app', {
 
 			if (this.sessions.length === 0) {
 				await this.addSession();
-				this.changeSession(this.sessions[0]);
+				await this.changeSession(this.sessions[0]);
 			} else {
 				const existingSession = this.sessions.find((session: Session) => session.id === sessionId);
-				this.changeSession(existingSession || this.sessions[0]);
+				await this.changeSession(existingSession || this.sessions[0]);
 			}
+
+			if (this.currentSession) {
+				await this.getMessages();
+				this.updateSessionAgentFromMessages(this.currentSession);
+			  }
 		},
 
 		async getSessions(session?: Session) {
@@ -98,13 +103,13 @@ export const useAppStore = defineStore('app', {
 			// Ensure there is at least always 1 session
 			if (this.sessions.length === 0) {
 				const newSession = await this.addSession();
-				this.changeSession(newSession);
+				await this.changeSession(newSession);
 				return;
 			}
 
 			const firstSession = this.sessions[0];
 			if (firstSession) {
-				this.changeSession(firstSession);
+				await this.changeSession(firstSession);
 			}
 		},
 
@@ -113,7 +118,20 @@ export const useAppStore = defineStore('app', {
 			this.currentMessages = data;
 		},
 
+		updateSessionAgentFromMessages(session: Session) {
+			const lastAssistantMessage = this.currentMessages
+			  .filter((message) => message.sender.toLowerCase() === 'assistant')
+			  .pop();
+			if (lastAssistantMessage) {
+			  const agent = this.agents.find(agent => agent.resource.name === lastAssistantMessage.senderDisplayName);
+			  if (agent) {
+				this.setSessionAgent(session, agent);
+			  }
+			}
+		  },
+
 		getSessionAgent(session: Session) {
+			if (!session) return null;
 			let selectedAgent = this.selectedAgents.get(session.id);
 			if (!selectedAgent) {
 				if (this.lastSelectedAgent) {
@@ -202,7 +220,7 @@ export const useAppStore = defineStore('app', {
 			}
 		},
 
-		changeSession(newSession: Session) {
+		async changeSession(newSession: Session) {
 			const nuxtApp = useNuxtApp();
 			const appConfigStore = useAppConfigStore();
 
@@ -214,6 +232,8 @@ export const useAppStore = defineStore('app', {
 			}
 
 			this.currentSession = newSession;
+			await this.getMessages();
+			this.updateSessionAgentFromMessages(newSession);
 		},
 
 		toggleSidebar() {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -42,7 +42,7 @@ export const useAppStore = defineStore('app', {
 			if (this.currentSession) {
 				await this.getMessages();
 				this.updateSessionAgentFromMessages(this.currentSession);
-			  }
+			}
 		},
 
 		async getSessions(session?: Session) {


### PR DESCRIPTION
# User Portal: Select the last agent used in a chat session

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Currently, when a user selects a chat session, we retrieve the message history from the Core API. In the meantime, we keep track of the last selected agent.

This PR modifies this behavior by selecting the last agent used within a given chat session. If a user creates a brand new chat session, we retain the current behavior of keeping the current agent selection in place.

We determine the last agent within a chat session by evaluating the messages within the session. The last message within a session where the sender is "Assistant" has the name of the agent within the `senderDisplayName` property. The Pinia app store keeps track of the currently selected agent and adds the ability to extract the agent from a chat session. These methods work in concert to set the selected agent in the dropdown on page load via new watch methods.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
