### PR TITLE
Updated E2E to publish and use AZD Environment as an artifact

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -391,6 +391,12 @@ jobs:
           Pop-Location
         shell: pwsh
 
+      - name: Publish AZD Environment
+        uses: actions/upload-artifact@v4
+        with:
+          name: azd-env
+          path: ./deploy/quick-start/.azure
+
       - name: Update App Registration OAuth Callbacks
         id: update-app-reg-oauth
         run: |

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -493,6 +493,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download AZD Environment
+        uses: actions/download-artifact@v4
+        with:
+          name: azd-env
+          path: ./deploy/quick-start/.azure
+
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0
         with:
@@ -526,21 +532,7 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
-          Write-Host "Create new AZD Environment"
           Push-Location ./deploy/quick-start
-          azd env new ${{ inputs.environment }}
-          azd env set AZURE_SUBSCRIPTION_ID $($info.subscriptionId)
-          azd env set PIPELINE_DEPLOY "$true"
-          Pop-Location
-
-          Push-Location ./deploy/quick-start
-          ../../tests/scripts/Set-AzdEnv.ps1 `
-            -tenantId $($info.tenantId) `
-            -principalType ServicePrincipal `
-            -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176
-
-          azd env refresh --no-prompt
-
           (azd env get-values) | foreach {
               $name, $value = $_.split('=')
               $value = $value.Trim('"')

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -675,6 +675,12 @@ jobs:
           name: build
           path: ./dist
 
+      - name: Download AZD Environment
+        uses: actions/download-artifact@v4
+        with:
+          name: azd-env
+          path: ./deploy/quick-start/.azure
+
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0
         with:
@@ -706,21 +712,7 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
-          Write-Host "Create new AZD Environment"
           Push-Location ./deploy/quick-start
-          azd env new ${{ inputs.environment }}
-          azd env set AZURE_SUBSCRIPTION_ID $($info.subscriptionId)
-          azd env set PIPELINE_DEPLOY "$true"
-          Pop-Location
-
-          Push-Location ./deploy/quick-start
-          ../../tests/scripts/Set-AzdEnv.ps1 `
-            -tenantId $($info.tenantId) `
-            -principalType ServicePrincipal `
-            -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176
-
-          azd env refresh --no-prompt
-
           (azd env get-values) | foreach {
               $name, $value = $_.split('=')
               set-content env:\$name $value
@@ -838,6 +830,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download AZD Environment
+        uses: actions/download-artifact@v4
+        with:
+          name: azd-env
+          path: ./deploy/quick-start/.azure
+
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0
         with:
@@ -882,20 +880,7 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
-          Write-Host "Create new AZD Environment"
           Push-Location ./deploy/quick-start
-          azd env new ${{ inputs.environment }}
-          azd env set AZURE_SUBSCRIPTION_ID $($info.subscriptionId)
-          azd env set PIPELINE_DEPLOY "$true"
-          Pop-Location
-
-          Push-Location ./deploy/quick-start
-          ../../tests/scripts/Set-AzdEnv.ps1 `
-            -tenantId $($info.tenantId) `
-            -principalType ServicePrincipal `
-            -instanceId 6fa496ce-d5c0-4e02-9223-06a98c9c0176
-
-          azd env refresh --no-prompt
           Write-Host "Removing App Registration OAuth Callbacks"
           pwsh -File ../common/scripts/Remove-OAuthCallbackUris.ps1 `
             -fllmChatUiName FoundationaLLM-Core-Portal `


### PR DESCRIPTION
# Updated E2E to publish and use AZD Environment as an artifact

## Details on the issue fix or feature implementation

Updated E2E to publish and use AZD Environment as an artifact so that later pipeline stages do not have to recreate an appropriate AZD environment to perform tasks.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

