### PR TITLE
Polling:  Add LongRunning flag on agent and OperationState class and OperationStatus enum

### DIFF
--- a/src/dotnet/Common/Models/Orchestration/OperationState.cs
+++ b/src/dotnet/Common/Models/Orchestration/OperationState.cs
@@ -1,0 +1,23 @@
+﻿namespace FoundationaLLM.Common.Models.Orchestration
+{
+    /// <summary>
+    /// Represents the current state of a long running operation.
+    /// </summary>
+    public class OperationState
+    {
+        /// <summary>
+        /// The identifier of the long running operation.
+        /// </summary>
+        public required string OperationId { get; set; }
+
+        /// <summary>
+        /// The status of the long running operation.
+        /// </summary>
+        public required OperationStatus Status { get; set; }
+
+        /// <summary>
+        /// The message describing the current state of the operation.
+        /// </summary>
+        public string? Message { get; set; }
+    }
+}

--- a/src/dotnet/Common/Models/Orchestration/OperationStatus.cs
+++ b/src/dotnet/Common/Models/Orchestration/OperationStatus.cs
@@ -1,0 +1,28 @@
+﻿namespace FoundationaLLM.Common.Models.Orchestration
+{
+    /// <summary>
+    /// Represents the status of a long running operation.
+    /// </summary>
+    public enum OperationStatus
+    {
+        /// <summary>
+        /// Operation is new and Pending processing.
+        /// </summary>
+        Pending,
+
+        /// <summary>
+        /// Operation is in progress.
+        /// </summary>
+        InProgress,
+
+        /// <summary>
+        /// Operation has been completed.
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// Operation has completed in a failed state
+        /// </summary>
+        Failed
+    }
+}

--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentBase.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentBase.cs
@@ -44,6 +44,12 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent
         public string? PromptObjectId { get; set; }
 
         /// <summary>
+        /// Indicates whether the agent is long running and should use the polling pattern.
+        /// </summary>
+        [JsonPropertyName("long_running")]
+        public bool LongRunning { get; set; } = false;
+
+        /// <summary>
         /// The object type of the agent.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
# Polling:  Add LongRunning flag on agent and OperationState class and OperationStatus enum

## Details on the issue fix or feature implementation

Add LongRunning flag on agent and OperationState class and OperationStatus enum

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

