### PR TITLE
Support for deleting App Config keys

### DIFF
--- a/src/dotnet/Common/Interfaces/IAzureAppConfigurationService.cs
+++ b/src/dotnet/Common/Interfaces/IAzureAppConfigurationService.cs
@@ -48,5 +48,19 @@
         /// </summary>
         /// <returns></returns>
         Task<Dictionary<string, bool>> CheckAppConfigurationSettingsExistAsync();
+
+        /// <summary>
+        /// Check if an individual Azure App Configuration key exists.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        Task<bool> CheckAppConfigurationSettingExistsAsync(string key);
+
+        /// <summary>
+        /// Deletes an Azure App Configuration setting and its associated Azure Key Vault secret.
+        /// </summary>
+        /// <param name="key">The App Configuration setting key.</param>
+        /// <returns></returns>
+        Task DeleteAppConfigurationSettingAsync(string key);
     }
 }

--- a/src/dotnet/Common/Services/AzureAppConfigurationService.cs
+++ b/src/dotnet/Common/Services/AzureAppConfigurationService.cs
@@ -1,6 +1,5 @@
 ﻿using Azure;
 using Azure.Data.AppConfiguration;
-using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using FoundationaLLM.Common.Authentication;
 using Microsoft.Extensions.Logging;
@@ -136,7 +135,7 @@ namespace FoundationaLLM.Common.Services
             if (setting is SecretReferenceConfigurationSetting secretReference)
             {
                 var identifier = new KeyVaultSecretIdentifier(secretReference.SecretId);
-                _logger.LogInformation("App Configuration key {key} references Key Vault secret {identifier.Name}. Deleting and purging.", key, identifier.Name);
+                _logger.LogInformation("App Configuration key {key} references Key Vault secret {identifier.Name}. Deleting.", key, identifier.Name);
                 var secretClient = new SecretClient(identifier.VaultUri, DefaultAuthentication.AzureCredential);
                 try
                 {

--- a/src/dotnet/Common/Services/AzureAppConfigurationService.cs
+++ b/src/dotnet/Common/Services/AzureAppConfigurationService.cs
@@ -1,4 +1,8 @@
-﻿using Azure.Data.AppConfiguration;
+﻿using Azure;
+using Azure.Data.AppConfiguration;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using FoundationaLLM.Common.Authentication;
 using Microsoft.Extensions.Logging;
 using System.Net;
 
@@ -106,6 +110,47 @@ namespace FoundationaLLM.Common.Services
                 existenceMap[setting.Key] = !string.IsNullOrWhiteSpace(setting.Value);
             }
             return existenceMap;
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> CheckAppConfigurationSettingExistsAsync(string key)
+        {
+            try
+            {
+                await _configurationClient.GetConfigurationSettingAsync(key);
+            }
+            catch (RequestFailedException ex)
+            {
+                if (ex.GetRawResponse()!.Status == 404)
+                    return false;
+                throw;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteAppConfigurationSettingAsync(string key)
+        {
+            ConfigurationSetting setting = await _configurationClient.GetConfigurationSettingAsync(key);
+            
+            if (setting is SecretReferenceConfigurationSetting secretReference)
+            {
+                var identifier = new KeyVaultSecretIdentifier(secretReference.SecretId);
+                _logger.LogInformation("App Configuration key {key} references Key Vault secret {identifier.Name}. Deleting and purging.", key, identifier.Name);
+                var secretClient = new SecretClient(identifier.VaultUri, DefaultAuthentication.AzureCredential);
+                try
+                {
+                    await secretClient.StartDeleteSecretAsync(identifier.Name);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error deleting Key Vault secret {key}.", identifier.Name);
+                }
+            }
+
+            var deleteSettingResponse = await _configurationClient.DeleteConfigurationSettingAsync(key);
+            if (deleteSettingResponse.IsError)
+                throw new Exception($"Failed to delete App Configuration setting {key}: {deleteSettingResponse.ReasonPhrase}");
         }
     }
 }

--- a/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
+++ b/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
@@ -228,6 +228,9 @@ namespace FoundationaLLM.Configuration.Services
                 case ConfigurationResourceTypeNames.APIEndpoints:
                     await DeleteAPIEndpoint(resourcePath.ResourceTypeInstances);
                     break;
+                case ConfigurationResourceTypeNames.AppConfigurations:
+                    await DeleteAppConfigurationKey(resourcePath.ResourceTypeInstances);
+                    break;
                 default:
                     throw new ResourceProviderException($"The resource type {resourcePath.ResourceTypeInstances.Last().ResourceType} is not supported by the {_name} resource provider.",
                     StatusCodes.Status400BadRequest);
@@ -353,6 +356,15 @@ namespace FoundationaLLM.Configuration.Services
             else
                 throw new ResourceProviderException($"Could not locate the {instances.Last().ResourceId} api endpoint resource.",
                             StatusCodes.Status404NotFound);
+        }
+
+        private async Task DeleteAppConfigurationKey(List<ResourceTypeInstance> instances)
+        {
+            string key = instances.Last().ResourceId!.Split("/").Last();
+            if (!await _appConfigurationService.CheckAppConfigurationSettingExistsAsync(key))
+                throw new ResourceProviderException($"Could not locate the {key} App Configuration key.",
+                                StatusCodes.Status404NotFound);
+            await _appConfigurationService.DeleteAppConfigurationSettingAsync(key);
         }
         #endregion
 


### PR DESCRIPTION
# Support for deleting App Config keys

## The issue or feature being addressed

Currently, Management API does not provide facilities to delete App Config keys.

## Details on the issue fix or feature implementation

This PR updates the Configuration Resource Provider and the Azure App Configuration Service to delete App Config keys and associated Key Vault secrets.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
