### PR TITLE
Fix the use of APIEndpoint instead of ExternalOrchestrationService

### DIFF
--- a/src/dotnet/ManagementClient/Clients/Resources/ConfigurationManagementClient.cs
+++ b/src/dotnet/ManagementClient/Clients/Resources/ConfigurationManagementClient.cs
@@ -22,18 +22,18 @@ namespace FoundationaLLM.Client.Management.Clients.Resources
             );
 
         /// <inheritdoc/>
-        public async Task<List<ResourceProviderGetResult<ExternalOrchestrationService>>> GetExternalOrchestrationServicesAsync() =>
-            await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<ExternalOrchestrationService>>>(
+        public async Task<List<ResourceProviderGetResult<APIEndpoint>>> GetExternalOrchestrationServicesAsync() =>
+            await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<APIEndpoint>>>(
                 ResourceProviderNames.FoundationaLLM_Configuration,
-                ConfigurationResourceTypeNames.ExternalOrchestrationServices
+                ConfigurationResourceTypeNames.APIEndpoints
             );
 
         /// <inheritdoc/>
-        public async Task<ResourceProviderGetResult<ExternalOrchestrationService>> GetExternalOrchestrationServiceAsync(string externalOrchestrationServiceName)
+        public async Task<ResourceProviderGetResult<APIEndpoint>> GetExternalOrchestrationServiceAsync(string externalOrchestrationServiceName)
         {
-            var result = await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<ExternalOrchestrationService>>>(
+            var result = await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<APIEndpoint>>>(
                 ResourceProviderNames.FoundationaLLM_Configuration,
-                $"{ConfigurationResourceTypeNames.ExternalOrchestrationServices}/{externalOrchestrationServiceName}"
+                $"{ConfigurationResourceTypeNames.APIEndpoints}/{externalOrchestrationServiceName}"
             );
 
             if (result == null || result.Count == 0)

--- a/src/dotnet/ManagementClient/Interfaces/IConfigurationManagementClient.cs
+++ b/src/dotnet/ManagementClient/Interfaces/IConfigurationManagementClient.cs
@@ -28,7 +28,7 @@ namespace FoundationaLLM.Client.Management.Interfaces
         /// Retrieves all external orchestration services.
         /// </summary>
         /// <returns></returns>
-        Task<List<ResourceProviderGetResult<ExternalOrchestrationService>>> GetExternalOrchestrationServicesAsync();
+        Task<List<ResourceProviderGetResult<APIEndpoint>>> GetExternalOrchestrationServicesAsync();
 
         /// <summary>
         /// Returns a specific external orchestration service by name.
@@ -36,7 +36,7 @@ namespace FoundationaLLM.Client.Management.Interfaces
         /// <param name="externalOrchestrationServiceName">The name of the external orchestration
         /// service to retrieve.</param>
         /// <returns></returns>
-        Task<ResourceProviderGetResult<ExternalOrchestrationService>> GetExternalOrchestrationServiceAsync(string externalOrchestrationServiceName);
+        Task<ResourceProviderGetResult<APIEndpoint>> GetExternalOrchestrationServiceAsync(string externalOrchestrationServiceName);
 
         /// <summary>
         /// Upserts an app configuration value. If the value does not exist, it will be created.


### PR DESCRIPTION
# Fix the use of APIEndpoint instead of ExternalOrchestrationService

## Details on the issue fix or feature implementation

ManagementClient should use the new APIEndpoint resource.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
