### PR TITLE
Add null check in configuration filter

### DIFF
--- a/src/dotnet/Orchestration/Services/LLMOrchestrationServiceManager.cs
+++ b/src/dotnet/Orchestration/Services/LLMOrchestrationServiceManager.cs
@@ -67,7 +67,7 @@ namespace FoundationaLLM.Orchestration.Core.Services
                     DefaultAuthentication.ServiceIdentity!);
 
                 _externalOrchestrationServiceSettings = apiEndpoint
-                    .Where(eos =>  eos.APIKeyConfigurationName.StartsWith(AppConfigurationKeySections.FoundationaLLM_ExternalAPIs))
+                    .Where(eos => eos.APIKeyConfigurationName is not null &&  eos.APIKeyConfigurationName.StartsWith(AppConfigurationKeySections.FoundationaLLM_ExternalAPIs))
                     .ToDictionary(
                         eos => eos.Name,
                         eos => new APISettingsBase


### PR DESCRIPTION
# Add null check in configuration filter


## Details on the issue fix or feature implementation

When filtering the API Endpoint list for external apis, the APIKeyConfigurationName is expected to have a value. In some cases this property is null, added a null check to avoid exceptions.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
