### PR TITLE
ApiEndpoints route fix when calling from ManagementPortal

### DIFF
--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -577,7 +577,7 @@ export default {
 
 	async getExternalOrchestrationServices(resolveApiKey: boolean = false): Promise<ResourceProviderGetResult<ExternalOrchestrationService>[]> {
 		const data = await this.fetch(
-			`/instances/${this.instanceId}/providers/FoundationaLLM.Configuration/externalOrchestrationServices?api-version=${this.apiVersion}`,
+			`/instances/${this.instanceId}/providers/FoundationaLLM.Configuration/apiEndpoints?api-version=${this.apiVersion}`,
 		) as ResourceProviderGetResult<ExternalOrchestrationService>[];
 		
 		// Retrieve all the app config values for the external orchestration services..


### PR DESCRIPTION
# ApiEndpoints route fix when calling from ManagementPortal

## Details on the issue fix or feature implementation

The url should be with /apiEndpoints now.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
