### PR TITLE
Add ingress to Vectorization Worker

### DIFF
--- a/deploy/quick-start/config/appconfig.template.json
+++ b/deploy/quick-start/config/appconfig.template.json
@@ -352,7 +352,7 @@
     },
     {
       "key": "FoundationaLLM:APIs:VectorizationWorker:APIUrl",
-      "value": "WHYDOESTHISEXIST",
+      "value": "${env:SERVICE_VECTORIZATION_JOB_ENDPOINT_URL}",
       "label": null,
       "content_type": null,
       "tags": {}

--- a/deploy/quick-start/infra/main.parameters.json
+++ b/deploy/quick-start/infra/main.parameters.json
@@ -276,7 +276,7 @@
           {
             "name": "vectorization-job",
             "useEndpoint": false,
-            "hasIngress": false,
+            "hasIngress": true,
             "image": "${SERVICE_VECTORIZATIONJOB_IMAGE=cropseastus2svinternal.azurecr.io/vectorization-job:${FLLM_VERSION}}",
             "appConfigEnvironmentVarName": "FoundationaLLM_AppConfig_ConnectionString",
             "apiKeySecretName": "foundationallm-apis-vectorizationworker-apikey",

--- a/src/dotnet/VectorizationWorker/Controllers/StatusController.cs
+++ b/src/dotnet/VectorizationWorker/Controllers/StatusController.cs
@@ -1,27 +1,40 @@
-﻿using Asp.Versioning;
-using FoundationaLLM.Common.Authentication;
-using FoundationaLLM.Vectorization.Models;
+﻿using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Constants.Configuration;
+using FoundationaLLM.Common.Models.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FoundationaLLM.Vectorization.Worker.Controllers
 {
     /// <summary>
-    /// Methods for managing vectorization requests.
+    /// Provides methods for checking the status of the service.
     /// </summary>
     [ApiController]
-    [APIKeyAuthentication]
     [Route("[controller]")]
     public class StatusController : ControllerBase
     {
         /// <summary>
-        /// Gets the status of the vectorization worker.
+        /// Returns the status of the Vectorization Worker service.
         /// </summary>
-        /// <returns></returns>
-        [HttpGet]
-        public async Task<bool> GetWorkerStatus()
+        [HttpGet(Name = "GetServiceStatus")]
+        public IActionResult Get() => new OkObjectResult(new ServiceStatusInfo
         {
-            await Task.CompletedTask;
-            return true;
+            Name = ServiceNames.VectorizationWorker,
+            Instance = ValidatedEnvironment.MachineName,
+            Version = Environment.GetEnvironmentVariable(EnvironmentVariables.FoundationaLLM_Version),
+            Status = ServiceStatuses.Ready
+        });
+
+        private static readonly string[] MethodNames = ["GET", "OPTIONS"];
+
+        /// <summary>
+        /// Returns the allowed HTTP methods for the Vectorization Worker service.
+        /// </summary>
+        [HttpOptions]
+        public IActionResult Options()
+        {
+            HttpContext.Response.Headers.Append("Allow", MethodNames);
+
+            return Ok();
         }
     }
 }


### PR DESCRIPTION
# Add ingress to Vectorization Worker

## The issue or feature being addressed

Currently, ingress is disabled for Vectorization Worker, so its status does not appear in the Management UI.

## Details on the issue fix or feature implementation

This PR enables ingress for the Vectorization Worker. It also updates the Vectorization Worker Status controller, so that it returns a result when the Management UI calls the `/status` endpoint.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
