### PR TITLE
Added Backup Script for Quickstart

### DIFF
--- a/deploy/quick-start/scripts/New-Backup.ps1
+++ b/deploy/quick-start/scripts/New-Backup.ps1
@@ -15,9 +15,6 @@ function Get-SearchServiceIndexes {
         [Parameter(Mandatory = $true)][string]$pathPrefix
     )
 
-    # Credit: https://daron.blog/2021/backup-and-restore-azure-cognitive-search-indexes-with-powershell/
-    # Updated script to use Entra tokens for authentication
-
     $serviceUri = "https://$searchServiceName.search.windows.net"
     $uri = $serviceUri + "/indexes?api-version=2020-06-30&`$select=name"
     $token = $(az account get-access-token --query accessToken --output tsv --scope "https://search.azure.com/.default")

--- a/deploy/quick-start/scripts/New-Backup.ps1
+++ b/deploy/quick-start/scripts/New-Backup.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+
+Param(
+    [Parameter(Mandatory = $true)][string]$resourceGroup
+)
+
+Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+function Get-AbsolutePath {
+    <#
+    .SYNOPSIS
+    Get the absolute path of a file or directory. Relative path does not need to exist.
+    #>
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [string]$RelatviePath
+    )
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RelatviePath)
+}
+
+function Invoke-CLICommand {
+    <#
+    .SYNOPSIS
+    Invoke a CLI Command and allow all output to print to the terminal.  Does not check for return values or pass the output to the caller.
+    #>
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Message,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [ScriptBlock]$ScriptBlock
+    )
+
+    Write-Host "${message}..." -ForegroundColor Blue
+    & $ScriptBlock
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed ${message} (code: ${LASTEXITCODE})"
+    }
+}
+
+# Navigate to the script directory so that we can use relative paths.
+Push-Location $($MyInvocation.InvocationName | Split-Path)
+try {
+    $testDataPath = "../data/backup/$resourceGroup" | Get-AbsolutePath
+    Write-Host "Writing environment files to: $testDataPath" -ForegroundColor Yellow
+    # Create test data path if it doesn't already exist
+    if (-not (Test-Path $testDataPath)) {
+        New-Item -ItemType Directory -Path $testDataPath
+    }
+
+    # Invoke-CLICommand "Copy vectorization-input data from the storage account: ${storageAccountName}" {
+    #     azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/vectorization-input" $testDataPath --recursive
+    # }
+
+    # Write-Host "Writing index-backup data to: $testDataPath" -ForegroundColor Yellow
+    # Invoke-CLICommand "Copy index-backup data from the storage account: ${storageAccountName}" {
+    #     azcopy copy "https://$($storageAccountName).blob.core.windows.net/e2e/index-backup" $testDataPath --recursive
+    # }
+}
+catch {
+    $logFile = Get-ChildItem -Path "$env:HOME/.azcopy" -Filter "*.log" | `
+        Where-Object { $_.Name -notlike "*-scanning*" } | `
+        Sort-Object LastWriteTime -Descending | `
+        Select-Object -First 1
+    $logFileContent = Get-Content -Raw -Path $logFile.FullName
+    Write-Host $logFileContent
+}
+finally {
+    Pop-Location
+    Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+}
+
+# Copy the storage account contents
+# Copy the indexes


### PR DESCRIPTION
# Added Backup Script for Quickstart

## The issue or feature being addressed

Currently, there is no functionality to back up the resource provider storage containers and the indexes for QS deployments.

## Details on the issue fix or feature implementation

This PR adds a versatile script to back up deployments.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
