### PR TITLE
Added Search Service Contributor role assignment for Semantic Kernel

### DIFF
--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -261,6 +261,7 @@ module searchReaderRoles './shared/roleAssignments.bicep' = [
       principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
       roleDefinitionIds: {
         'Search Index Data Reader': '1407120a-92aa-4202-b7e9-c0e197c71c8f'
+        'Search Service Contributor': '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
       }
     }
   }

--- a/deploy/standard/bicep/app-rg.bicep
+++ b/deploy/standard/bicep/app-rg.bicep
@@ -498,6 +498,7 @@ module searchIndexDataReaderSemanticKernelRole 'modules/utility/roleAssignments.
     principalId: srBackend[indexOf(backendServiceNames, 'semantic-kernel-api')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Search Index Data Reader': '1407120a-92aa-4202-b7e9-c0e197c71c8f'
+      'Search Service Contributor': '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
     }
   }
 }


### PR DESCRIPTION
# Added Search Service Contributor role assignment for Semantic Kernel

## The issue or feature being addressed

Semantic Kernel is currently missing role assignments to list indexes; this means that Semantic Kernel doesn't work with Knowledge Management agents without Inline Contexts.

## Details on the issue fix or feature implementation

This PR adds the Search Service Contributor role assignment to the LangChain and Semantic Kernel managed identities.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
