### PR TITLE
Fix circular DI reference that results in DI deadlock

### DIFF
--- a/src/dotnet/Common/Services/DependencyInjection.cs
+++ b/src/dotnet/Common/Services/DependencyInjection.cs
@@ -150,6 +150,7 @@ namespace FoundationaLLM
         {
             builder.Services.AddHttpClient();
             builder.Services.AddSingleton<IHttpClientFactoryService, HttpClientFactoryService>();
+            builder.Services.ActivateSingleton<IHttpClientFactoryService>();
         }
 
         /// <summary>


### PR DESCRIPTION
# Fix circular DI reference that results in DI deadlock

## The issue or feature being addressed

All APIs using the new `HttpClientFactoryService` implementation hang on startup.

## Details on the issue fix or feature implementation

The new `HttpClientFactoryService` implementation introduced a circular DI reference (it needs resource provider services and resource provider services need it). 

.NET has a known issue where the main DI container will just hang when a circular DI reference exists (as opposed to throwing an error and stopping). The problem is known for years (https://github.com/dotnet/runtime/issues/36458) yet it was not addressed yet.

The solution was to remove the circular reference by injecting `IServiceProvider` into `HttpClientFactoryService` instead of the specific `IResourceProviderService` references, thus breaking the circular reference.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
