### PR TITLE
Fix API Endpoint Configuration action resource path, make APIKeyPrefix optional

### DIFF
--- a/src/dotnet/Common/Constants/Authorization/AuthorizableActionNames.cs
+++ b/src/dotnet/Common/Constants/Authorization/AuthorizableActionNames.cs
@@ -83,17 +83,17 @@ namespace FoundationaLLM.Common.Constants.Authorization
         /// <summary>
         /// Read API endpoints.
         /// </summary>
-        public const string FoundationaLLM_Configuration_APIEndpoints_Read = "FoundationaLLM.Configuration/apiEndpoints/read";
+        public const string FoundationaLLM_Configuration_APIEndpoints_Read = "FoundationaLLM.Configuration/apiEndpointConfigurations/read";
 
         /// <summary>
         /// Create or update API endpoints.
         /// </summary>
-        public const string FoundationaLLM_Configuration_APIEndpoints_Write = "FoundationaLLM.Configuration/apiEndpoints/write";
+        public const string FoundationaLLM_Configuration_APIEndpoints_Write = "FoundationaLLM.Configuration/apiEndpointConfigurations/write";
 
         /// <summary>
         /// Delete API endpoints.
         /// </summary>
-        public const string FoundationaLLM_Configuration_APIEndpoints_Delete = "FoundationaLLM.Configuration/apiEndpoints/delete";
+        public const string FoundationaLLM_Configuration_APIEndpoints_Delete = "FoundationaLLM.Configuration/apiEndpointConfigurations/delete";
 
         #endregion
 

--- a/src/dotnet/Common/Services/HttpClientFactoryService.cs
+++ b/src/dotnet/Common/Services/HttpClientFactoryService.cs
@@ -88,7 +88,7 @@ namespace FoundationaLLM.Common.Services
 
                     if (!endpointConfiguration.AuthenticationParameters.TryGetValue(
                         AuthenticationParametersKeys.APIKeyConfigurationName, out var apiKeyConfigurationNameObj))
-                        throw new Exception($"The {AuthenticationParametersKeys.APIKeyConfigurationName} key is missing from the enpoint's authentication parameters dictionary.");
+                        throw new Exception($"The {AuthenticationParametersKeys.APIKeyConfigurationName} key is missing from the endpoint's authentication parameters dictionary.");
 
                     apiKey = _configuration.GetValue<string>(apiKeyConfigurationNameObj?.ToString()!)!;
 

--- a/src/dotnet/Common/Services/HttpClientFactoryService.cs
+++ b/src/dotnet/Common/Services/HttpClientFactoryService.cs
@@ -98,11 +98,12 @@ namespace FoundationaLLM.Common.Services
 
                     apiKeyHeaderName = apiKeyHeaderNameObj.ToString();
 
-                    if (!endpointConfiguration.AuthenticationParameters.TryGetValue(
-                        AuthenticationParametersKeys.APIKeyPrefix, out var apiKeyPrefixObj))
-                        throw new Exception($"The {AuthenticationParametersKeys.APIKeyPrefix} key is missing from the enpoint's authentication parameters dictionary.");
+                    // APIKeyPrefix is optional, set to empty string if not found.
+                    endpointConfiguration.AuthenticationParameters.TryGetValue(
+                        AuthenticationParametersKeys.APIKeyPrefix, out var apiKeyPrefixObj);
 
-                    apiKeyPrefix = apiKeyPrefixObj.ToString();
+                    apiKeyPrefix = apiKeyPrefixObj?.ToString() ?? string.Empty;
+
 
                     if (apiKeyHeaderName == HeaderNames.Authorization)
                     {


### PR DESCRIPTION
# Fix API Endpoint Configuration action resource path, make APIKeyPrefix optional


## Details on the issue fix or feature implementation

Fix API Endpoint Configuration action resource path, make APIKeyPrefix optional

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

