### PR TITLE
Added AIModel Resource Provider Storage Account Details & Updated Default Agent

### DIFF
--- a/deploy/quick-start/config/appconfig.template.json
+++ b/deploy/quick-start/config/appconfig.template.json
@@ -22,6 +22,20 @@
       "tags": {}
     },
     {
+      "key": "FoundationaLLM:AIModel:ResourceProviderService:Storage:AccountName",
+      "value": "${env:AZURE_STORAGE_ACCOUNT_NAME}",
+      "label": null,
+      "content_type": "",
+      "tags": {}
+    },
+    {
+      "key": "FoundationaLLM:AIModel:ResourceProviderService:Storage:AuthenticationType",
+      "value": "AzureIdentity",
+      "label": null,
+      "content_type": "",
+      "tags": {}
+    },
+    {
       "key": "FoundationaLLM:APIs:AgentHubAPI:APIKey",
       "value": "{\"uri\":\"${env:AZURE_KEY_VAULT_ENDPOINT}secrets/foundationallm-apis-agenthubapi-apikey\"}",
       "label": null,

--- a/deploy/quick-start/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
+++ b/deploy/quick-start/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
@@ -15,18 +15,8 @@
   },
   "orchestration_settings": {
     "orchestrator": "LangChain",
-    "agent_parameters": null,
-    "endpoint_configuration": {
-      "auth_type": "key",
-      "provider": "microsoft",
-      "endpoint": "${env:AZURE_OPENAI_ENDPOINT}",
-      "api_key": "FoundationaLLM:AzureOpenAI:API:Key",
-      "api_version": "2023-05-15"
-    },
-    "model_parameters": {
-      "temperature": 0,
-      "deployment_name": "completions"
-    }
+    "agent_parameters": null
   },
+  "ai_model_object_id": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.AIModel/aiModels/DefaultCompletionAIModel",
   "prompt_object_id": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.Prompt/prompts/FoundationaLLM"
 }

--- a/deploy/standard/config/appconfig.template.json
+++ b/deploy/standard/config/appconfig.template.json
@@ -22,6 +22,20 @@
         "tags": {}
       },
       {
+        "key": "FoundationaLLM:AIModel:ResourceProviderService:Storage:AccountName",
+        "value": "{{storageAccountAdlsName}}",
+        "label": null,
+        "content_type": "",
+        "tags": {}
+      },
+      {
+        "key": "FoundationaLLM:AIModel:ResourceProviderService:Storage:AuthenticationType",
+        "value": "AzureIdentity",
+        "label": null,
+        "content_type": "",
+        "tags": {}
+      },
+      {
         "key": "FoundationaLLM:APIs:AgentHubAPI:APIKey",
         "value": "{\"uri\":\"{{keyvaultUri}}secrets/foundationallm-apis-agenthubapi-apikey\"}",
         "label": null,


### PR DESCRIPTION
# Added AIModel Resource Provider Storage Account Details & Updated Default Agent

## The issue or feature being addressed

Currently, App Configuration entries are missing for the `AIModel` Resource Provider. Additionally, the current FoundationaLLM agent schema is incorrect.

## Details on the issue fix or feature implementation

This PR adds both missing App Configuration entries for QS and Standard. Additionally, it updates the default agent schema.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
