### PR TITLE
Fixes app config settings associated with App Insights in Python APIs

### DIFF
--- a/src/dotnet/Common/Constants/Configuration/KeyVaultSecretNames.cs
+++ b/src/dotnet/Common/Constants/Configuration/KeyVaultSecretNames.cs
@@ -30,10 +30,16 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "foundationallm-apiendpoints-gatekeeperapi-apikey";
 
         /// <summary>
+        /// The name of the Azure Key Vault secret holding the connection string for the App Insights service used by the Gatekeeper API.
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_GatekeeperAPI_AppInsightsConnectionString =
+            "foundationallm-appinsights-connectionstring";
+
+        /// <summary>
         /// The name of the Azure Key Vault secret holding the API key for the Gatekeeper Integration API.
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_GatekeeperIntegrationAPI_APIKey =
-            "foundationallm-apiendpoints-gatekeeperintergrationapi-apikey";
+            "foundationallm-apiendpoints-gatekeeperintegrationapi-apikey";
 
         /// <summary>
         /// The name of the Azure Key Vault secret holding the connection string for the App Insights service used by the Gatekeeper Integration API.
@@ -135,7 +141,7 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// The name of the Azure Key Vault secret holding the API key for the State API.
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_StateAPI_APIKey =
-            "foundationallm-apinedpoints-stateapi-apikey";
+            "foundationallm-apiendpoints-stateapi-apikey";
 
         /// <summary>
         /// The name of the Azure Key Vault secret holding the connection string for the App Insights service used by the State API.

--- a/src/python/AgentHubAPI/app/main.py
+++ b/src/python/AgentHubAPI/app/main.py
@@ -13,7 +13,7 @@ from foundationallm.telemetry import Telemetry
 # Open a connection to the app configuration
 config = get_config()
 # Start collecting telemetry
-Telemetry.configure_monitoring(config, f'FoundationaLLM:APIs:{API_NAME}:AppInsightsConnectionString')
+Telemetry.configure_monitoring(config, f'FoundationaLLM:APIEndpoints:{API_NAME}:AppInsightsConnectionString')
 
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',

--- a/src/python/DataSourceHubAPI/app/main.py
+++ b/src/python/DataSourceHubAPI/app/main.py
@@ -13,7 +13,7 @@ from foundationallm.telemetry import Telemetry
 # Open a connection to the app configuration
 config = get_config()
 # Start collecting telemetry
-Telemetry.configure_monitoring(config, f'FoundationaLLM:APIs:{API_NAME}:AppInsightsConnectionString')
+Telemetry.configure_monitoring(config, f'FoundationaLLM:APIEndpoints:{API_NAME}:AppInsightsConnectionString')
 
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',

--- a/src/python/LangChainAPI/app/main.py
+++ b/src/python/LangChainAPI/app/main.py
@@ -14,7 +14,7 @@ from foundationallm.telemetry import Telemetry
 # Open a connection to the app configuration
 config = get_config()
 # Start collecting telemetry
-Telemetry.configure_monitoring(config, f'FoundationaLLM:APIs:{API_NAME}:AppInsightsConnectionString')
+Telemetry.configure_monitoring(config, f'FoundationaLLM:APIEndpoints:{API_NAME}:AppInsightsConnectionString')
 
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',

--- a/src/python/PromptHubAPI/app/main.py
+++ b/src/python/PromptHubAPI/app/main.py
@@ -13,7 +13,7 @@ from foundationallm.telemetry import Telemetry
 # Open a connection to the app configuration
 config = get_config()
 # Start collecting telemetry
-Telemetry.configure_monitoring(config, f'FoundationaLLM:APIs:{API_NAME}:AppInsightsConnectionString')
+Telemetry.configure_monitoring(config, f'FoundationaLLM:APIEndpoints:{API_NAME}:AppInsightsConnectionString')
 
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',


### PR DESCRIPTION
# Fixes app config settings associated with App Insights in Python APIs

## The issue or feature being addressed

Corrects the app config keys associated with Application Insights telemetry collection in the Python APIs.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
