### PR TITLE
AccessToken security group retrieval strategy

### DIFF
--- a/src/dotnet/Common/Constants/Authentication/EntraUserClaimConstants.cs
+++ b/src/dotnet/Common/Constants/Authentication/EntraUserClaimConstants.cs
@@ -1,0 +1,13 @@
+﻿namespace FoundationaLLM.Common.Constants.Authentication
+{
+    /// <summary>
+    /// Additional claim constants that are not included in <see cref="Microsoft.Identity.Web.ClaimConstants"></see>.
+    /// </summary>
+    public static class EntraUserClaimConstants
+    {
+        /// <summary>
+        /// Groups claim.
+        /// </summary>
+        public const string Groups = "groups";
+    }
+}

--- a/src/dotnet/Common/Constants/Instance/SecurityGroupRetrievalStrategies.cs
+++ b/src/dotnet/Common/Constants/Instance/SecurityGroupRetrievalStrategies.cs
@@ -14,5 +14,10 @@
         /// Identity management service.
         /// </summary>
         public const string IdentityManagementService = "IdentityManagementService";
+
+        /// <summary>
+        /// Access token groups claim.
+        /// </summary>
+        public const string AccessToken = "AccessToken";
     }
 }

--- a/src/dotnet/Common/Interfaces/IUserClaimsProviderService.cs
+++ b/src/dotnet/Common/Interfaces/IUserClaimsProviderService.cs
@@ -28,5 +28,14 @@ namespace FoundationaLLM.Common.Interfaces
         /// </summary>
         /// <param name="userPrincipal">The <see cref="ClaimsPrincipal"/> object providing details about the security principal.</param>
         bool IsServicePrincipal(ClaimsPrincipal userPrincipal);
+
+        /// <summary>
+        /// Returns a list of security group identifiers from the provided
+        /// <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="userPrincipal">The principal that provides multiple
+        /// claims-based identities.</param>
+        /// <returns></returns>
+        List<string>? GetSecurityGroupIds(ClaimsPrincipal? userPrincipal);
     }
 }

--- a/src/dotnet/Common/Services/Security/EntraUserClaimsProviderService.cs
+++ b/src/dotnet/Common/Services/Security/EntraUserClaimsProviderService.cs
@@ -1,4 +1,5 @@
-﻿using FoundationaLLM.Common.Interfaces;
+﻿using FoundationaLLM.Common.Constants.Authentication;
+using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using Microsoft.Identity.Web;
 using System.Security.Claims;
@@ -25,6 +26,16 @@ namespace FoundationaLLM.Common.Services.Security
                 UPN = ResolveUsername(userPrincipal),
                 UserId = userPrincipal.FindFirstValue(ClaimConstants.Oid) ?? userPrincipal.FindFirstValue(ClaimConstants.ObjectId)
             };
+        }
+
+        /// <inheritdoc/>
+        public List<string>? GetSecurityGroupIds(ClaimsPrincipal? userPrincipal)
+        {
+            if (userPrincipal == null)
+            {
+                return null;
+            }
+            return userPrincipal.Claims.Where(c => c.Type == EntraUserClaimConstants.Groups).Select(x => x?.Value).ToList()!;
         }
 
         /// <inheritdoc/>

--- a/src/dotnet/Common/Services/Security/NoOpUserClaimsProviderService.cs
+++ b/src/dotnet/Common/Services/Security/NoOpUserClaimsProviderService.cs
@@ -1,11 +1,6 @@
 ﻿using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FoundationaLLM.Common.Services.Security
 {
@@ -17,6 +12,9 @@ namespace FoundationaLLM.Common.Services.Security
     {
         /// <inheritdoc/>
         public UnifiedUserIdentity? GetUserIdentity(ClaimsPrincipal? userPrincipal) => null;
+
+        /// <inheritdoc/>
+        public List<string>? GetSecurityGroupIds(ClaimsPrincipal? userPrincipal) => null;
 
         /// <inheritdoc/>
         public bool IsServicePrincipal(ClaimsPrincipal userPrincipal) => false;


### PR DESCRIPTION
# AccessToken security group retrieval strategy

## The issue or feature being addressed

Currently, security groups are only retrieved using an identity management service.

## Details on the issue fix or feature implementation

Adds support for retrieving security groups from access token groups claims.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
