### PR TITLE
(0.8.0) Client library updates and E2E test fixes

### DIFF
--- a/src/dotnet/CoreClient/Clients/RESTClients/AttachmentRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/AttachmentRESTClient.cs
@@ -9,8 +9,11 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
     /// </summary>
     internal class AttachmentRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), IAttachmentRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), IAttachmentRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+
         /// <inheritdoc/>
         public async Task<string> UploadAttachmentAsync(Stream fileStream, string fileName, string contentType)
         {
@@ -26,7 +29,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
                 }, "file", fileName }
             };
 
-            var responseMessage = await coreClient.PostAsync("attachments/upload", content);
+            var responseMessage = await coreClient.PostAsync($"instances/{_instanceId}/attachments/upload", content);
 
             if (!responseMessage.IsSuccessStatusCode)
             {

--- a/src/dotnet/CoreClient/Clients/RESTClients/BrandingRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/BrandingRESTClient.cs
@@ -10,13 +10,16 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
     /// </summary>
     internal class BrandingRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), IBrandingRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), IBrandingRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+
         /// <inheritdoc/>
         public async Task<ClientBrandingConfiguration> GetBrandingAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync("branding");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/branding");
 
             if (responseMessage.IsSuccessStatusCode)
             {

--- a/src/dotnet/CoreClient/Clients/RESTClients/CompletionRestClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/CompletionRestClient.cs
@@ -14,8 +14,11 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
     /// </summary>
     internal class CompletionRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), ICompletionRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), ICompletionRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+
         /// <inheritdoc/>
         public async Task<Completion> GetChatCompletionAsync(CompletionRequest completionRequest)
         {

--- a/src/dotnet/CoreClient/Clients/RESTClients/CompletionRestClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/CompletionRestClient.cs
@@ -25,7 +25,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
             var coreClient = await GetCoreClientAsync();
             var serializedRequest = JsonSerializer.Serialize(completionRequest, SerializerOptions);
 
-            var responseMessage = await coreClient.PostAsync("completions",
+            var responseMessage = await coreClient.PostAsync($"instances/{_instanceId}/completions",
                 new StringContent(
                     serializedRequest,
                     Encoding.UTF8, "application/json"));
@@ -45,7 +45,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<IEnumerable<ResourceProviderGetResult<AgentBase>>> GetAgentsAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync("completions/agents");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/completions/agents");
 
             if (responseMessage.IsSuccessStatusCode)
             {

--- a/src/dotnet/CoreClient/Clients/RESTClients/SessionRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/SessionRESTClient.cs
@@ -11,13 +11,16 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
     /// </summary>
     internal class SessionRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), ISessionRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), ISessionRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+
         /// <inheritdoc/>
         public async Task<string> CreateSessionAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var responseSession = await coreClient.PostAsync("sessions", null);
+            var responseSession = await coreClient.PostAsync($"instances/{_instanceId}/sessions", null);
 
             if (responseSession.IsSuccessStatusCode)
             {
@@ -36,7 +39,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<string> RenameChatSession(string sessionId, string sessionName)
         {
             var coreClient = await GetCoreClientAsync();
-            var response = await coreClient.PostAsync($"sessions/{sessionId}/rename?newChatSessionName={UrlEncoder.Default.Encode(sessionName)}", null);
+            var response = await coreClient.PostAsync($"instances/{_instanceId}/sessions/{sessionId}/rename?newChatSessionName={UrlEncoder.Default.Encode(sessionName)}", null);
 
             if (response.IsSuccessStatusCode)
             {
@@ -50,7 +53,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<CompletionPrompt> GetCompletionPromptAsync(string sessionId, string completionPromptId)
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync($"sessions/{sessionId}/completionprompts/{completionPromptId}");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/sessions/{sessionId}/completionprompts/{completionPromptId}");
 
             if (responseMessage.IsSuccessStatusCode)
             {
@@ -67,7 +70,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<IEnumerable<Message>> GetChatSessionMessagesAsync(string sessionId)
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync($"sessions/{sessionId}/messages");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/sessions/{sessionId}/messages");
 
             if (responseMessage.IsSuccessStatusCode)
             {
@@ -83,7 +86,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<IEnumerable<Session>> GetAllChatSessionsAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync("sessions");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/sessions");
 
             if (responseMessage.IsSuccessStatusCode)
             {
@@ -99,7 +102,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task RateMessageAsync(string sessionId, string messageId, bool rating)
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.PostAsync($"sessions/{sessionId}/message/{messageId}/rate?rating={rating}", null);
+            var responseMessage = await coreClient.PostAsync($"instances/{_instanceId}/sessions/{sessionId}/message/{messageId}/rate?rating={rating}", null);
 
             if (!responseMessage.IsSuccessStatusCode)
             {
@@ -111,7 +114,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task DeleteSessionAsync(string sessionId)
         {
             var coreClient = await GetCoreClientAsync();
-            await coreClient.DeleteAsync($"sessions/{sessionId}");
+            await coreClient.DeleteAsync($"instances/{_instanceId}/sessions/{sessionId}");
         }
     }
 }

--- a/src/dotnet/CoreClient/Clients/RESTClients/StatusRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/StatusRESTClient.cs
@@ -8,15 +8,17 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
 {
     internal class StatusRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), IStatusRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), IStatusRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
         private readonly JsonSerializerOptions _jsonSerializerOptions = CommonJsonSerializerOptions.GetJsonSerializerOptions();
 
         /// <inheritdoc/>
         public async Task<ServiceStatusInfo> GetServiceStatusAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var response = await coreClient.GetAsync("status");
+            var response = await coreClient.GetAsync($"instances/{_instanceId}/status");
 
             if (response.IsSuccessStatusCode)
             {
@@ -31,7 +33,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         public async Task<bool> IsAuthenticatedAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var response = await coreClient.GetAsync("status/auth");
+            var response = await coreClient.GetAsync($"instances/{_instanceId}/status/auth");
 
             return response.IsSuccessStatusCode;
         }

--- a/src/dotnet/CoreClient/Clients/RESTClients/UserProfileRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/UserProfileRESTClient.cs
@@ -10,13 +10,16 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
     /// </summary>
     internal class UserProfileRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : CoreRESTClientBase(httpClientFactory, credential), IUserProfileRESTClient
+        TokenCredential credential,
+        string instanceId) : CoreRESTClientBase(httpClientFactory, credential), IUserProfileRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+
         /// <inheritdoc/>
         public async Task<IEnumerable<UserProfile>> GetUserProfilesAsync()
         {
             var coreClient = await GetCoreClientAsync();
-            var responseMessage = await coreClient.GetAsync("userprofiles");
+            var responseMessage = await coreClient.GetAsync($"instances/{_instanceId}/userprofiles");
 
             if (responseMessage.IsSuccessStatusCode)
             {

--- a/src/dotnet/CoreClient/CoreClient.cs
+++ b/src/dotnet/CoreClient/CoreClient.cs
@@ -26,8 +26,14 @@ namespace FoundationaLLM.Client.Core
         /// <param name="coreUri">The base URI of the Core API.</param>
         /// <param name="credential">A <see cref="TokenCredential"/> of an authenticated
         /// user or service principle from which the client library can generate auth tokens.</param>
-        public CoreClient(string coreUri, TokenCredential credential)
-            : this(coreUri, credential, new APIClientSettings()) { }
+        /// <param name="instanceId">The unique (GUID) ID for the FoundationaLLM deployment.
+        /// Locate this value in the FoundationaLLM Management Portal or in Azure App Config
+        /// (FoundationaLLM:Instance:Id key)</param>
+        public CoreClient(
+            string coreUri,
+            TokenCredential credential,
+            string instanceId)
+            : this(coreUri, credential, instanceId,  new APIClientSettings()) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CoreClient"/> class with
@@ -36,9 +42,16 @@ namespace FoundationaLLM.Client.Core
         /// <param name="coreUri">The base URI of the Core API.</param>
         /// <param name="credential">A <see cref="TokenCredential"/> of an authenticated
         /// user or service principle from which the client library can generate auth tokens.</param>
+        /// <param name="instanceId">The unique (GUID) ID for the FoundationaLLM deployment.
+        /// Locate this value in the FoundationaLLM Management Portal or in Azure App Config
+        /// (FoundationaLLM:Instance:Id key)</param>
         /// <param name="options">Additional options to configure the HTTP Client.</param>
-        public CoreClient(string coreUri, TokenCredential credential, APIClientSettings options) =>
-            _coreRestClient = new CoreRESTClient(coreUri, credential, options);
+        public CoreClient(
+            string coreUri,
+            TokenCredential credential,
+            string instanceId,
+            APIClientSettings options) =>
+            _coreRestClient = new CoreRESTClient(coreUri, credential, instanceId, options);
 
         /// <inheritdoc/>
         public async Task<string> CreateChatSessionAsync(string? sessionName)

--- a/src/dotnet/CoreClient/CoreRESTClient.cs
+++ b/src/dotnet/CoreClient/CoreRESTClient.cs
@@ -12,6 +12,7 @@ namespace FoundationaLLM.Client.Core
     public class CoreRESTClient : ICoreRESTClient
     {
         private readonly string _coreUri;
+        private readonly string _instanceId;
         private readonly TokenCredential _credential;
         private readonly APIClientSettings _options;
 
@@ -21,6 +22,7 @@ namespace FoundationaLLM.Client.Core
         public CoreRESTClient()
         {
             _coreUri = null!;
+            _instanceId = null!;
             _options = null!;
             _credential = null!;
         }
@@ -33,8 +35,14 @@ namespace FoundationaLLM.Client.Core
         /// <param name="coreUri">The base URI of the Core API.</param>
         /// <param name="credential">A <see cref="TokenCredential"/> of an authenticated
         /// user or service principle from which the client library can generate auth tokens.</param>
-        public CoreRESTClient(string coreUri, TokenCredential credential)
-            : this(coreUri, credential, new APIClientSettings()) { }
+        /// <param name="instanceId">The unique (GUID) ID for the FoundationaLLM deployment.
+        /// Locate this value in the FoundationaLLM Management Portal or in Azure App Config
+        /// (FoundationaLLM:Instance:Id key)</param>
+        public CoreRESTClient(
+            string coreUri,
+            TokenCredential credential,
+            string instanceId)
+            : this(coreUri, credential, instanceId, new APIClientSettings()) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CoreRESTClient"/> class and
@@ -45,11 +53,19 @@ namespace FoundationaLLM.Client.Core
         /// <param name="coreUri">The base URI of the Core API.</param>
         /// <param name="credential">A <see cref="TokenCredential"/> of an authenticated
         /// user or service principle from which the client library can generate auth tokens.</param>
+        /// <param name="instanceId">The unique (GUID) ID for the FoundationaLLM deployment.
+        /// Locate this value in the FoundationaLLM Management Portal or in Azure App Config
+        /// (FoundationaLLM:Instance:Id key)</param>
         /// <param name="options">Additional options to configure the HTTP Client.</param>
-        public CoreRESTClient(string coreUri, TokenCredential credential, APIClientSettings options)
+        public CoreRESTClient(
+            string coreUri,
+            TokenCredential credential,
+            string instanceId,
+            APIClientSettings options)
         {
             _coreUri = coreUri ?? throw new ArgumentNullException(nameof(coreUri));
             _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+            _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
             _options = options ?? throw new ArgumentNullException(nameof(options));
 
             var services = new ServiceCollection();
@@ -86,12 +102,12 @@ namespace FoundationaLLM.Client.Core
 
         private void InitializeClients(IHttpClientFactory httpClientFactory)
         {
-            Sessions = new SessionRESTClient(httpClientFactory, _credential);
-            Attachments = new AttachmentRESTClient(httpClientFactory, _credential);
-            Branding = new BrandingRESTClient(httpClientFactory, _credential);
-            Completions = new CompletionRESTClient(httpClientFactory, _credential);
-            Status = new StatusRESTClient(httpClientFactory, _credential);
-            UserProfiles = new UserProfileRESTClient(httpClientFactory, _credential);
+            Sessions = new SessionRESTClient(httpClientFactory, _credential, _instanceId);
+            Attachments = new AttachmentRESTClient(httpClientFactory, _credential, _instanceId);
+            Branding = new BrandingRESTClient(httpClientFactory, _credential, _instanceId);
+            Completions = new CompletionRESTClient(httpClientFactory, _credential, _instanceId);
+            Status = new StatusRESTClient(httpClientFactory, _credential, _instanceId);
+            UserProfiles = new UserProfileRESTClient(httpClientFactory, _credential, _instanceId);
         }
     }
 }

--- a/src/dotnet/CoreClient/DependencyInjection.cs
+++ b/src/dotnet/CoreClient/DependencyInjection.cs
@@ -1,14 +1,8 @@
 ﻿using Azure.Core;
 using FoundationaLLM.Client.Core;
 using FoundationaLLM.Client.Core.Interfaces;
-using FoundationaLLM.Common.Constants;
-using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Models.Configuration.API;
-using FoundationaLLM.Common.Settings;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace FoundationaLLM
 {
@@ -24,17 +18,21 @@ namespace FoundationaLLM
         /// <param name="coreUri">The base URI of the Core API.</param>
         /// <param name="credential">A <see cref="TokenCredential"/> of an authenticated
         /// user or service principle from which the client library can generate auth tokens.</param>
+        /// <param name="instanceId">The unique (GUID) ID for the FoundationaLLM deployment.
+        /// Locate this value in the FoundationaLLM Management Portal or in Azure App Config
+        /// (FoundationaLLM:Instance:Id key)</param>
         /// <param name="options">Additional options to configure the HTTP Client.</param>
         public static void AddCoreClient(
             this IServiceCollection services,
             string coreUri,
             TokenCredential credential,
+            string instanceId,
             APIClientSettings? options = null)
         {
             options ??= new APIClientSettings();
 
-            services.AddSingleton<ICoreRESTClient>(serviceProvider => new CoreRESTClient(coreUri, credential, options));
-            services.AddSingleton<ICoreClient>(serviceProvider => new CoreClient(coreUri, credential, options));
+            services.AddSingleton<ICoreRESTClient>(serviceProvider => new CoreRESTClient(coreUri, credential, instanceId, options));
+            services.AddSingleton<ICoreClient>(serviceProvider => new CoreClient(coreUri, credential, instanceId,options));
         }
     }
 }

--- a/src/dotnet/ManagementClient/Clients/RESTClients/IdentityRESTClient.cs
+++ b/src/dotnet/ManagementClient/Clients/RESTClients/IdentityRESTClient.cs
@@ -10,17 +10,22 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
 {
     internal class IdentityRESTClient : ManagementRESTClientBase, IIdentityRESTClient
     {
+        private readonly string _instanceId;
         private readonly JsonSerializerOptions _jsonSerializerOptions = CommonJsonSerializerOptions.GetJsonSerializerOptions();
 
-        public IdentityRESTClient(IHttpClientFactory httpClientFactory, TokenCredential credential)
-            : base(httpClientFactory, credential) { }
+        internal IdentityRESTClient(
+            IHttpClientFactory httpClientFactory,
+            TokenCredential credential,
+            string instanceId)
+            : base(httpClientFactory, credential) =>
+            _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
 
         /// <inheritdoc/>
         public async Task<IEnumerable<Group>> RetrieveGroupsAsync(ObjectQueryParameters parameters)
         {
             var managementClient = await GetManagementClientAsync();
             var content = new StringContent(JsonSerializer.Serialize(parameters), Encoding.UTF8, "application/json");
-            var response = await managementClient.PostAsync("groups/retrieve", content);
+            var response = await managementClient.PostAsync($"instances/{_instanceId}/groups/retrieve", content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -35,7 +40,7 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
         public async Task<Group> GetGroupAsync(string groupId)
         {
             var managementClient = await GetManagementClientAsync();
-            var response = await managementClient.GetAsync($"groups/{groupId}");
+            var response = await managementClient.GetAsync($"instances/{_instanceId}/groups/{groupId}");
 
             if (response.IsSuccessStatusCode)
             {
@@ -51,7 +56,7 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
         {
             var managementClient = await GetManagementClientAsync();
             var content = new StringContent(JsonSerializer.Serialize(parameters), Encoding.UTF8, "application/json");
-            var response = await managementClient.PostAsync("users/retrieve", content);
+            var response = await managementClient.PostAsync($"instances/{_instanceId}/users/retrieve", content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -66,7 +71,7 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
         public async Task<User> GetUserAsync(string userId)
         {
             var managementClient = await GetManagementClientAsync();
-            var response = await managementClient.GetAsync($"users/{userId}");
+            var response = await managementClient.GetAsync($"instances/{_instanceId}/users/{userId}");
 
             if (response.IsSuccessStatusCode)
             {
@@ -82,7 +87,7 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
         {
             var managementClient = await GetManagementClientAsync();
             var content = new StringContent(JsonSerializer.Serialize(parameters), Encoding.UTF8, "application/json");
-            var response = await managementClient.PostAsync("objects/retrievebyids", content);
+            var response = await managementClient.PostAsync($"instances/{_instanceId}/objects/retrievebyids", content);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/dotnet/ManagementClient/Clients/RESTClients/StatusRESTClient.cs
+++ b/src/dotnet/ManagementClient/Clients/RESTClients/StatusRESTClient.cs
@@ -8,15 +8,17 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
 {
     internal class StatusRESTClient(
         IHttpClientFactory httpClientFactory,
-        TokenCredential credential) : ManagementRESTClientBase(httpClientFactory, credential), IStatusRESTClient
+        TokenCredential credential,
+        string instanceId) : ManagementRESTClientBase(httpClientFactory, credential), IStatusRESTClient
     {
+        private readonly string _instanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
         private readonly JsonSerializerOptions _jsonSerializerOptions = CommonJsonSerializerOptions.GetJsonSerializerOptions();
 
         /// <inheritdoc/>
         public async Task<ServiceStatusInfo> GetServiceStatusAsync()
         {
             var managementClient = await GetManagementClientAsync();
-            var response = await managementClient.GetAsync("status");
+            var response = await managementClient.GetAsync($"instances/{_instanceId}/status");
 
             if (response.IsSuccessStatusCode)
             {
@@ -31,7 +33,7 @@ namespace FoundationaLLM.Client.Management.Clients.RESTClients
         public async Task<bool> IsAuthenticatedAsync()
         {
             var managementClient = await GetManagementClientAsync();
-            var response = await managementClient.GetAsync("status/auth");
+            var response = await managementClient.GetAsync($"instances/{_instanceId}/status/auth");
 
             return response.IsSuccessStatusCode;
         }

--- a/src/dotnet/ManagementClient/Clients/Resources/AIModelManagementClient.cs
+++ b/src/dotnet/ManagementClient/Clients/Resources/AIModelManagementClient.cs
@@ -8,6 +8,31 @@ namespace FoundationaLLM.Client.Management.Clients.Resources
     internal class AIModelManagementClient(IManagementRESTClient managementRestClient) : IAIModelManagementClient
     {
         /// <inheritdoc/>
+        public async Task<List<ResourceProviderGetResult<AIModelBase>>> GetAIModelsAsync() =>
+            await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<AIModelBase>>>(
+                ResourceProviderNames.FoundationaLLM_AIModel,
+                AIModelResourceTypeNames.AIModels
+            );
+
+        /// <inheritdoc/>
+        public async Task<ResourceProviderGetResult<AIModelBase>> GetAIModelAsync(string aiModelName)
+        {
+            var result = await managementRestClient.Resources.GetResourcesAsync<List<ResourceProviderGetResult<AIModelBase>>>(
+                ResourceProviderNames.FoundationaLLM_AIModel,
+                $"{AIModelResourceTypeNames.AIModels}/{aiModelName}"
+            );
+
+            if (result == null || result.Count == 0)
+            {
+                throw new Exception($"AI Model '{aiModelName}' not found.");
+            }
+
+            var agent = result[0];
+
+            return agent;
+        }
+
+        /// <inheritdoc/>
         public async Task<ResourceProviderUpsertResult> UpsertAIModel(AIModelBase aiModel) =>
             await managementRestClient.Resources.UpsertResourceAsync(
                 ResourceProviderNames.FoundationaLLM_AIModel,

--- a/src/dotnet/ManagementClient/Interfaces/IAIModelManagementClient.cs
+++ b/src/dotnet/ManagementClient/Interfaces/IAIModelManagementClient.cs
@@ -9,10 +9,23 @@ namespace FoundationaLLM.Client.Management.Interfaces
     public interface IAIModelManagementClient
     {
         /// <summary>
-        /// Upserts an ai model resource. If an ai model does not exist, it will be created.
-        /// If an ai model configuration does exist, it will be updated.
+        /// Retrieves all AI model resources.
         /// </summary>
-        /// <param name="aiModel">The api endpoint configuration resource to create or update.</param>
+        /// <returns>All AI model resources to which the caller has access and which have not been marked as deleted.</returns>
+        Task<List<ResourceProviderGetResult<AIModelBase>>> GetAIModelsAsync();
+
+        /// <summary>
+        /// Retrieves a specific AI model by name.
+        /// </summary>
+        /// <param name="aiModelName">The name of the AI model to retrieve.</param>
+        /// <returns></returns>
+        Task<ResourceProviderGetResult<AIModelBase>> GetAIModelAsync(string aiModelName);
+
+        /// <summary>
+        /// Upserts an AI model resource. If an AI model does not exist, it will be created.
+        /// If an AI model configuration does exist, it will be updated.
+        /// </summary>
+        /// <param name="aiModel">The API endpoint configuration resource to create or update.</param>
         /// <returns>Returns a <see cref="ResourceProviderUpsertResult"/>, which contains the
         /// Object ID of the resource.</returns>
         Task<ResourceProviderUpsertResult> UpsertAIModel(AIModelBase aiModel);

--- a/src/dotnet/ManagementClient/ManagementRESTClient.cs
+++ b/src/dotnet/ManagementClient/ManagementRESTClient.cs
@@ -101,9 +101,9 @@ namespace FoundationaLLM.Client.Management
 
         private void InitializeClients(IHttpClientFactory httpClientFactory)
         {
-            Identity = new IdentityRESTClient(httpClientFactory, _credential);
+            Identity = new IdentityRESTClient(httpClientFactory, _credential, _instanceId);
             Resources = new ResourceRESTClient(httpClientFactory, _credential, _instanceId);
-            Status = new StatusRESTClient(httpClientFactory, _credential);
+            Status = new StatusRESTClient(httpClientFactory, _credential, _instanceId);
         }
     }
 }

--- a/tests/dotnet/Core.Examples/Catalogs/AgentCatalog.cs
+++ b/tests/dotnet/Core.Examples/Catalogs/AgentCatalog.cs
@@ -1,10 +1,5 @@
 ﻿using FoundationaLLM.Common.Constants;
-using FoundationaLLM.Common.Constants.Authentication;
-using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
-using FoundationaLLM.Common.Models.ResourceProviders.AIModel;
-using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
-using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
 using FoundationaLLM.Core.Examples.Constants;
 
 namespace FoundationaLLM.Core.Examples.Catalogs
@@ -47,7 +42,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.LangChain
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -74,7 +69,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel,
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -102,7 +97,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -130,7 +125,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.LangChain
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -157,7 +152,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -184,7 +179,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.LangChain
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -238,7 +233,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -265,7 +260,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -292,7 +287,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.SemanticKernel
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
             new KnowledgeManagementAgent
             {
@@ -319,7 +314,7 @@ namespace FoundationaLLM.Core.Examples.Catalogs
                 {
                     Orchestrator = LLMOrchestrationServiceNames.LangChain
                 },
-                AIModelObjectId = TestAIModelNames.Completions_Default
+                AIModelObjectId = TestAIModelNames.Completions_Deployed_Default
             },
 
         ];

--- a/tests/dotnet/Core.Examples/Constants/TestAIModelNames.cs
+++ b/tests/dotnet/Core.Examples/Constants/TestAIModelNames.cs
@@ -14,5 +14,10 @@
         /// The name of the GPT-4-32K completions AI model.
         /// </summary>
         public const string Completions_GPT4_32K = "completions-gpt-4-32k";
+
+        /// <summary>
+        /// The name of the default completions AI model deployed in new FoundationaLLM environments.
+        /// </summary>
+        public const string Completions_Deployed_Default = "DefaultCompletionAIModel";
     }
 }

--- a/tests/dotnet/Core.Examples/Example0002_KnowledgeManagementInlineContextAgentWithSemanticKernel.cs
+++ b/tests/dotnet/Core.Examples/Example0002_KnowledgeManagementInlineContextAgentWithSemanticKernel.cs
@@ -58,6 +58,11 @@ namespace FoundationaLLM.Core.Examples
                 }
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0003_KnowledgeManagementInlineContextAgentWithLangChain.cs
+++ b/tests/dotnet/Core.Examples/Example0003_KnowledgeManagementInlineContextAgentWithLangChain.cs
@@ -58,6 +58,11 @@ namespace FoundationaLLM.Core.Examples
                 }
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0004_SynchronousVectorizationOfPDFFromDataLake.cs
+++ b/tests/dotnet/Core.Examples/Example0004_SynchronousVectorizationOfPDFFromDataLake.cs
@@ -166,6 +166,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch(Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the App Configuration key {accountNameAppConfigKey}");

--- a/tests/dotnet/Core.Examples/Example0005_AsynchronousVectorizationOfPDFFromDataLake.cs
+++ b/tests/dotnet/Core.Examples/Example0005_AsynchronousVectorizationOfPDFFromDataLake.cs
@@ -185,6 +185,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the App Configuration key {accountNameAppConfigKey}");

--- a/tests/dotnet/Core.Examples/Example0006_SynchronousVectorizationOfPDFFromOneLake.cs
+++ b/tests/dotnet/Core.Examples/Example0006_SynchronousVectorizationOfPDFFromOneLake.cs
@@ -130,6 +130,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the data source: {dataSourceName} via the Management API");

--- a/tests/dotnet/Core.Examples/Example0007_AsynchronousVectorizationOfPDFFromOneLake.cs
+++ b/tests/dotnet/Core.Examples/Example0007_AsynchronousVectorizationOfPDFFromOneLake.cs
@@ -152,6 +152,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the data source: {dataSourceName} via the Management API");

--- a/tests/dotnet/Core.Examples/Example0008_SynchronousVectorizationOfPDFFromSharePoint.cs
+++ b/tests/dotnet/Core.Examples/Example0008_SynchronousVectorizationOfPDFFromSharePoint.cs
@@ -132,6 +132,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the data source: {dataSourceName} via the Management API");

--- a/tests/dotnet/Core.Examples/Example0009_AsynchronousVectorizationOfPDFFromSharePoint.cs
+++ b/tests/dotnet/Core.Examples/Example0009_AsynchronousVectorizationOfPDFFromSharePoint.cs
@@ -154,6 +154,11 @@ namespace FoundationaLLM.Core.Examples
                 if (result.VectorResults.TotalCount != 27)
                     throw new Exception($"Query did not return the expected number of vector results. Expected: 27, Retrieved: {result.VectorResults.TotalCount}");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 WriteLine($"Delete the data source: {dataSourceName} via the Management API");

--- a/tests/dotnet/Core.Examples/Example0011_KnowledgeManagementAgentWithSemanticKernel.cs
+++ b/tests/dotnet/Core.Examples/Example0011_KnowledgeManagementAgentWithSemanticKernel.cs
@@ -69,6 +69,11 @@ namespace FoundationaLLM.Core.Examples
 
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0012_KnowledgeManagementAgentWithLangChain.cs
+++ b/tests/dotnet/Core.Examples/Example0012_KnowledgeManagementAgentWithLangChain.cs
@@ -69,6 +69,11 @@ namespace FoundationaLLM.Core.Examples
 
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0013_KnowledgeManagementSemanticKernelWithLargeIndex.cs
+++ b/tests/dotnet/Core.Examples/Example0013_KnowledgeManagementSemanticKernelWithLargeIndex.cs
@@ -68,6 +68,11 @@ namespace FoundationaLLM.Core.Examples
 
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0014_KnowledgeManagementLangChainWithLargeIndex.cs
+++ b/tests/dotnet/Core.Examples/Example0014_KnowledgeManagementLangChainWithLargeIndex.cs
@@ -68,6 +68,11 @@ namespace FoundationaLLM.Core.Examples
 
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(agentName);

--- a/tests/dotnet/Core.Examples/Example0015_AgentToAgentConversations.cs
+++ b/tests/dotnet/Core.Examples/Example0015_AgentToAgentConversations.cs
@@ -71,6 +71,11 @@ namespace FoundationaLLM.Core.Examples
 
                 Assert.True(invalidAgentResponsesFound == 0, $"{invalidAgentResponsesFound} invalid agent responses found.");
             }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception: {ex.Message}");
+                throw;
+            }
             finally
             {
                 await _managementAPITestManager.DeleteAgent(TestAgentNames.Dune01);

--- a/tests/dotnet/Core.Examples/Interfaces/IDownstreamAPISettings.cs
+++ b/tests/dotnet/Core.Examples/Interfaces/IDownstreamAPISettings.cs
@@ -1,0 +1,15 @@
+﻿using FoundationaLLM.Core.Examples.Models;
+
+namespace FoundationaLLM.Core.Examples.Interfaces
+{
+    /// <summary>
+    /// One or more downstream APIs with a base URL and API key for authentication.
+    /// </summary>
+    public interface IDownstreamAPISettings
+    {
+        /// <summary>
+        /// A dictionary of downstream APIs with a base URL and API key for authentication.
+        /// </summary>
+        Dictionary<string, DownstreamAPIKeySettings> DownstreamAPIs { get; }
+    }
+}

--- a/tests/dotnet/Core.Examples/Models/DownstreamAPISettings.cs
+++ b/tests/dotnet/Core.Examples/Models/DownstreamAPISettings.cs
@@ -1,0 +1,25 @@
+﻿using FoundationaLLM.Core.Examples.Interfaces;
+
+namespace FoundationaLLM.Core.Examples.Models
+{
+    public record DownstreamAPISettings : IDownstreamAPISettings
+    {
+        /// <inheritdoc/>
+        public required Dictionary<string, DownstreamAPIKeySettings> DownstreamAPIs { get; init; }
+    }
+
+    /// <summary>
+    /// Represents settings for downstream API key authentication.
+    /// </summary>
+    public record DownstreamAPIKeySettings
+    {
+        /// <summary>
+        /// The URL of the downstream API.
+        /// </summary>
+        public required string APIUrl { get; init; }
+        /// <summary>
+        /// The value of the API key.
+        /// </summary>
+        public required string APIKey { get; init; }
+    }
+}

--- a/tests/dotnet/Core.Examples/Services/AgentConversationTestService.cs
+++ b/tests/dotnet/Core.Examples/Services/AgentConversationTestService.cs
@@ -62,12 +62,6 @@ namespace FoundationaLLM.Core.Examples.Services
                 await coreClient.DeleteSessionAsync(sessionId);
             }
 
-            if (createAgent)
-            {
-                // Delete the agent and its dependencies.
-                await managementAPITestManager.DeleteAgent(agentName);
-            }
-
             return messages;
         }
 


### PR DESCRIPTION
# (0.8.0) Client library updates and E2E test fixes

## The issue or feature being addressed

Fixes failing E2E tests.

## Details on the issue fix or feature implementation

Updates the `CoreClient` and `ManagementClient` client libraries to use FLLM instance paths, add missing methods, and implement recent changes to the backend services they expose.

Fixes `Core.Examples` test configuration and updates E2E tests so they can successfully run in 0.8.0 and beyond.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
