### PR TITLE
Moving peering creation to the postprovision hook

### DIFF
--- a/deploy/standard/infra/main.bicep
+++ b/deploy/standard/infra/main.bicep
@@ -245,6 +245,10 @@ output FLLM_MGMT_PORTAL_HOSTNAME string = managementPortalHostname
 output FLLM_CORE_API_HOSTNAME string = coreApiHostname
 output FLLM_MGMT_API_HOSTNAME string = managementApiHostname
 
+output FOUNDATIONALLM_VNET_NAME string = networking.outputs.vnetName
+output FOUNDATIONALLM_VNET_ID string = networking.outputs.vnetId
+output FOUNDATIONALLM_HUB_VNET_NAME string = networking.outputs.hubVnetId
+
 output SERVICE_GATEKEEPER_API_ENDPOINT_URL string = 'http://gatekeeper-api/gatekeeper/'
 output SERVICE_GATEKEEPER_INTEGRATION_API_ENDPOINT_URL string = 'http://gatekeeper-integration-api/gatekeeperintegration'
 output SERVICE_GATEWAY_ADAPTER_API_ENDPOINT_URL string = 'http://gateway-adapter-api/gatewayadapter'

--- a/deploy/standard/infra/networking-rg.bicep
+++ b/deploy/standard/infra/networking-rg.bicep
@@ -606,30 +606,4 @@ resource hub 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
   scope: resourceGroup(hubSubscriptionId, hubResourceGroup)
 }
 
-module srcToDest './modules/vnet-peering.bicep' = {
-  dependsOn: [ hub ]
-  name: 'srcToDest-${timestamp}'
-  scope: resourceGroup()
-  params: {
-    vnetName: main.name
-    destVnetId: hub.id
-    allowVirtualNetworkAccess: true
-    allowForwardedTraffic: true
-    allowGatewayTransit: false
-    useRemoteGateways: true
-  }
-}
-
-module destToSrc './modules/vnet-peering.bicep' = {
-  dependsOn: [ hub ]
-  name: 'destToSrc-${timestamp}'
-  scope: resourceGroup(hubSubscriptionId, hubResourceGroup)
-  params: {
-    vnetName: hub.name
-    destVnetId: main.id
-    allowVirtualNetworkAccess: true
-    allowForwardedTraffic: true
-    allowGatewayTransit: true
-    useRemoteGateways: false
-  }
-}
+output hubVnetId string = hub.id


### PR DESCRIPTION
# Moving peering creation to the postprovision hook

## Details on the issue fix or feature implementation

Moving peering creation to the postprovision hook instead of provisioning in bicep.  Provisioning these peerings in bicep results in the hub resource group being torn down during `azd down` when it should not be.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
