### PR TITLE
Aligning AZD env names in Standard with those in QS

### DIFF
--- a/deploy/standard/azd-hooks/predeploy.ps1
+++ b/deploy/standard/azd-hooks/predeploy.ps1
@@ -80,11 +80,11 @@ try {
     }
 
     $entraClientIds = @{
-        authorization = $env:FLLM_AUTHORIZATION_CLIENT_ID
-        chat          = $env:FLLM_USER_PORTAL_CLIENT_ID
-        core          = $env:FLLM_CORE_API_CLIENT_ID
-        managementapi = $env:FLLM_MANAGEMENT_API_CLIENT_ID
-        managementui  = $env:FLLM_MANAGEMENT_PORTAL_CLIENT_ID
+        authorization = $env:ENTRA_AUTH_API_CLIENT_ID
+        chat          = $env:ENTRA_CHAT_UI_CLIENT_ID
+        core          = $env:ENTRA_CORE_API_CLIENT_ID
+        managementapi = $env:ENTRA_MANAGEMENT_API_CLIENT_ID
+        managementui  = $env:ENTRA_MANAGEMENT_UI_CLIENT_ID
     }
 
     $entraScopes = @{

--- a/deploy/standard/infra/main.parameters.json
+++ b/deploy/standard/infra/main.parameters.json
@@ -6,7 +6,7 @@
         "value": "${FLLM_ALLOWED_CIDR=192.168.101.0/28}"
       },
       "authAppRegistrationClientId": {
-        "value": "${FLLM_AUTHORIZATION_CLIENT_ID}"
+        "value": "${ENTRA_AUTH_API_CLIENT_ID}"
       },
       "authAppRegistrationInstance": {
         "value": "${ENTRA_AUTH_API_INSTANCE=https://login.microsoftonline.com}"
@@ -45,7 +45,7 @@
         "value": "${FOUNDATIONALLM_HUB_TENANT_ID}"
       },
       "hubVnetName": {
-        "value": "${FOUNDATIONALL_HUB_VNET_NAME}"
+        "value": "${FOUNDATIONALLM_HUB_VNET_NAME}"
       },
       "instanceId": {
         "value": "${FOUNDATIONALLM_INSTANCE_ID=''}"


### PR DESCRIPTION
# Aligning AZD env names in Standard with those in QS

## Details on the issue fix or feature implementation

Aligning AZD env names in Standard with those in QS so we can use the same toolkit scripts to fetch the app registration and group metadata for both environments.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

