### PR TITLE
(0.8.0) Ensure rendering of entire response for longer results

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -230,9 +230,14 @@ export default {
 
 	methods: {
 		displayWordByWord() {
-			if (this.currentWordIndex >= this.compiledMarkdown.split(/\s+/).length) return;
+			const words = this.compiledMarkdown.split(/\s+/);
+			if (this.currentWordIndex >= words.length) {
+				this.compiledVueTemplate = addCodeHeaderComponents(this.compiledMarkdown);
+				return;
+			}
 
 			this.currentWordIndex += 1;
+
 			const htmlString = truncate(this.compiledMarkdown, this.currentWordIndex, {
 				byWords: true,
 				stripTags: false,


### PR DESCRIPTION
# (0.8.0) Ensure rendering of entire response for longer results

## The issue or feature being addressed

Fixes an issue causing the dynamic agent response to cut off the final part of a long text result.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
