### PR TITLE
Resolving issue where private DNS zone VNET link names collide

### DIFF
--- a/deploy/standard/infra/modules/dns.bicep
+++ b/deploy/standard/infra/modules/dns.bicep
@@ -1,6 +1,7 @@
 param key string
 param tags object
 param vnetId string
+param vnetName string
 param zone string
 
 output id string = main.id
@@ -21,7 +22,7 @@ resource main 'Microsoft.Network/privateDnsZones@2018-09-01' existing = {
 */
 resource link 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
   parent: main
-  name: 'foundationallm'
+  name: vnetName
   location: 'global'
   tags: tags
 

--- a/deploy/standard/infra/networking-rg.bicep
+++ b/deploy/standard/infra/networking-rg.bicep
@@ -565,6 +565,7 @@ module dns './modules/dns.bicep' = [for zone in items(privateDnsZone): {
   params: {
     key: zone.key
     vnetId: main.id
+    vnetName: main.name
     zone: zone.value
 
     tags: {


### PR DESCRIPTION
# Resolving issue where private DNS zone VNET link names collide

## Details on the issue fix or feature implementation

Resolving issue where private DNS zone VNET link names collide.  The original dns.bicep template was setting a default name of `foundationallm` for the Standard deployment VNET link association resources instead of something unique to the deployment VNET.  These changes resolve that issue.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
