### PR TITLE
Exposing HUB and VPN Client Pool CIDRs as configurable parameters

### DIFF
--- a/deploy/standard-hub/infra/core/networking/vpnGateway.bicep
+++ b/deploy/standard-hub/infra/core/networking/vpnGateway.bicep
@@ -5,7 +5,7 @@ param location string
 param project string
 param subnetId string
 param tags object
-param vpnClientAddressPool string = '192.168.101.0/28'
+param vpnClientAddressPool string
 
 @allowed([
   'VpnGw1'

--- a/deploy/standard-hub/infra/main.bicep
+++ b/deploy/standard-hub/infra/main.bicep
@@ -6,6 +6,7 @@ param environmentName string
 param location string
 param project string
 param timestamp string = utcNow()
+param vpnClientAddressPool string
 
 // Locals
 var abbrs = loadJsonContent('./abbreviations.json')
@@ -130,6 +131,7 @@ module vpn './core/networking/vpnGateway.bicep' = {
     project: project
     subnetId: '${vnet.outputs.vnetId}/subnets/GatewaySubnet'
     tags: tags
+    vpnClientAddressPool: vpnClientAddressPool
   }
   scope: rg
 }

--- a/deploy/standard-hub/infra/main.parameters.json
+++ b/deploy/standard-hub/infra/main.parameters.json
@@ -2,11 +2,17 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+      "cidrVnet": {
+        "value": "${FLLM_HUB_CIDR_VNET=192.168.100.0/24}"
+      },
       "environmentName": {
         "value": "${AZURE_ENV_NAME}"
       },
       "location": {
         "value": "${AZURE_LOCATION}"
+      },
+      "vpnClientAddressPool": {
+        "value": "${VPN_CLIENT_ADDRESS_POOL=192.168.101.0/24}"
       }
     }
 }


### PR DESCRIPTION
# Exposing HUB and VPN Client Pool CIDRs as configurable parameters

## Details on the issue fix or feature implementation

Exposing HUB and VPN Client Pool CIDRs as configurable parameters so that different CIDRs can be specified for the HUB VNET or the VPN Client Address Pool.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

