### PR TITLE
(0.8.0) User Portal: Render files

### DIFF
--- a/src/dotnet/Common/Constants/Chat/MessageContentTypes.cs
+++ b/src/dotnet/Common/Constants/Chat/MessageContentTypes.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FoundationaLLM.Common.Constants.Chat
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class MessageContentTypes
+    {
+        /// <summary>
+        /// Plaintext and formatted text, such as markdown.
+        /// </summary>
+        public const string Text = "text";
+
+        /// <summary>
+        /// Image file link.
+        /// </summary>
+        public const string Image = "image";
+
+        /// <summary>
+        /// General file link.
+        /// </summary>
+        public const string File = "file";
+
+        /// <summary>
+        /// HTML file link.
+        /// </summary>
+        public const string Html = "html";
+    }
+}

--- a/src/dotnet/Common/Models/Chat/MessageContent.cs
+++ b/src/dotnet/Common/Models/Chat/MessageContent.cs
@@ -16,7 +16,7 @@ namespace FoundationaLLM.Common.Models.Chat
         /// <summary>
         /// The file name related to the Value, if applicable.
         /// </summary>
-        [JsonPropertyName("file_name")]
+        [JsonPropertyName("fileName")]
         public string? FileName { get; set; }
 
         /// <summary>

--- a/src/dotnet/Common/Models/Chat/MessageContent.cs
+++ b/src/dotnet/Common/Models/Chat/MessageContent.cs
@@ -14,6 +14,12 @@ namespace FoundationaLLM.Common.Models.Chat
         public string? Type { get; set; }
 
         /// <summary>
+        /// The file name related to the Value, if applicable.
+        /// </summary>
+        [JsonPropertyName("file_name")]
+        public string? FileName { get; set; }
+
+        /// <summary>
         /// The value of the message content.
         /// </summary>
         [JsonPropertyName("value")]

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -55,6 +55,9 @@
 							<div v-else-if="content.type === 'html'">
 								<iframe :src="content.value" frameborder="0"></iframe>
 							</div>
+							<div v-else-if="content.type === 'file'">
+								Download <a :href="content.value" target="_blank">{{ content.fileName ?? content.value }}</a>
+							</div>
 						</div>
 					</template>
 				</div>

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -40,8 +40,23 @@
 						<i class="pi pi-spin pi-spinner"></i>
 					</template>
 
-					<!-- Render the html content and any vue components within -->
-					<component :is="compiledMarkdownComponent"></component>
+					<template v-if="!message.content">
+						<div v-html="compiledVueTemplate"></div>
+					</template>
+					<template v-else>
+						<!-- Render the html content and any vue components within -->
+						<div v-for="content in message.content" :key="content.file_name" class="message-content">
+							<div v-if="content.type === 'text'">
+								<component :is="renderMarkdownComponent(content.value)"></component>
+							</div>
+							<div v-else-if="content.type === 'image'">
+								<img :src="content.value" :alt="content.file_name" />
+							</div>
+							<div v-else-if="content.type === 'html'">
+								<iframe :src="content.value" frameborder="0"></iframe>
+							</div>
+						</div>
+					</template>
 				</div>
 
 				<div v-if="message.sender !== 'User'" class="message__footer">
@@ -229,6 +244,16 @@ export default {
 	},
 
 	methods: {
+		renderMarkdownComponent(contentValue: string) {
+      		const sanitizedContent = DOMPurify.sanitize(marked(contentValue));
+			return {
+				template: `<div>${sanitizedContent}</div>`,
+				components: {
+				CodeBlockHeader,
+				},
+			};
+		},
+
 		displayWordByWord() {
 			const words = this.compiledMarkdown.split(/\s+/);
 			if (this.currentWordIndex >= words.length) {
@@ -429,6 +454,23 @@ export default {
 	background-color: var(--primary-button-bg) !important;
 	border-color: var(--primary-button-bg) !important;
 	color: var(--primary-button-text) !important;
+}
+
+.message-content {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+iframe {
+  width: 100%;
+  height: 600px;
+  border-radius: 8px;
 }
 </style>
 

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -39,7 +39,7 @@ export interface Message {
 
 export interface MessageContent {
 	type: string;
-	file_name: string;
+	fileName: string;
 	value: string;
 }
 

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -34,6 +34,13 @@ export interface Message {
 	vector: Array<Number>;
 	completionPromptId: string | null;
 	citations: Array<Citation>;
+	content: Array<MessageContent>;
+}
+
+export interface MessageContent {
+	type: string;
+	file_name: string;
+	value: string;
 }
 
 export interface Session {


### PR DESCRIPTION
# (0.8.0) User Portal: Render files

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Updates the User Portal to use the new `content` collection in the `message` objects to handle rendering multiple parts of an agent response. For example, if an agent generates images, HTML (such as for interactive graphs), or other files along with pieces of text for context, the User Portal now renders these components accordingly.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
