### PR TITLE
Allowing completion to be nullable

### DIFF
--- a/src/dotnet/Common/Models/Orchestration/Response/CompletionResponseBase.cs
+++ b/src/dotnet/Common/Models/Orchestration/Response/CompletionResponseBase.cs
@@ -17,7 +17,7 @@ namespace FoundationaLLM.Common.Models.Orchestration.Response
         /// The completion response from the language model.
         /// </summary>
         [JsonPropertyName("completion")]
-        public string Completion { get; set; }
+        public string? Completion { get; set; }
 
         /// <summary>
         /// Content returned from the Assistants API.


### PR DESCRIPTION
# Allowing completion to be nullable

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Cherry-pick of commit to allow completion to be nullable on `CompletionResponseBase` object.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
