### PR TITLE
Fix attachment provider name in Python - Cherry-pick

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -89,7 +89,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
         if self.prompt.suffix is not None:
             prompt_builder += f'\n\n{self.prompt.suffix}'
 
-        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENTS and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
+        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
         if self.has_retriever or len(image_attachments) > 0:
             # Insert the user prompt into the template.
             prompt_builder += "\n\nQuestion: {question}"
@@ -217,7 +217,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
         agent = request.agent
 
         image_analysis_results = None
-        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENTS and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
+        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
         if len(image_attachments) > 0:
             image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=False)
             image_analysis_svc = ImageAnalysisService(client=image_analysis_client, deployment_model=self.ai_model.deployment_name)
@@ -341,7 +341,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
 
         image_analysis_results = None
         # Get image attachments that are images with URL file paths.
-        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENTS and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
+        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
         if len(image_attachments) > 0:
             image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=True)
             image_analysis_svc = ImageAnalysisService(client=image_analysis_client, deployment_model=self.ai_model.deployment_name)

--- a/src/python/PythonSDK/foundationallm/models/attachments/attachment_providers.py
+++ b/src/python/PythonSDK/foundationallm/models/attachments/attachment_providers.py
@@ -2,5 +2,5 @@ from enum import Enum
 
 class AttachmentProviders(str, Enum):
     """Enumerator of the Attachment Providers."""
-    FOUNDATIONALLM_ATTACHMENTS = "FoundationaLLM.Attachments"
+    FOUNDATIONALLM_ATTACHMENT = "FoundationaLLM.Attachment"
     FOUNDATIONALLM_AZURE_OPENAI = "FoundationaLLM.AzureOpenAI"


### PR DESCRIPTION
# Fix attachment provider name in Python

## The issue or feature being addressed

Fixes incorrect provider name for attachments in Python SDK.

## Details on the issue fix or feature implementation

{Detail}

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
