### PR TITLE
Send storage path for image attachments

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -123,18 +123,26 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
 
             List<AttachmentProperties> result = [];
             await foreach (var attachment in attachments)
+            {
+                var useAttachmentPath =
+                    string.IsNullOrWhiteSpace(attachment.SecondaryProvider)
+                    || (attachment.ContentType ?? string.Empty).StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
                 result.Add(new AttachmentProperties
                 {
                     OriginalFileName = attachment.OriginalFileName,
                     ContentType = attachment.ContentType!,
-                    Provider = attachment.SecondaryProvider ?? ResourceProviderNames.FoundationaLLM_Attachment,
-                    ProviderFileName = string.IsNullOrWhiteSpace(attachment.SecondaryProvider)
+                    Provider = useAttachmentPath
+                        ? ResourceProviderNames.FoundationaLLM_Attachment
+                        : attachment.SecondaryProvider!,
+                    ProviderFileName = useAttachmentPath
                         ? attachment.Path
                         : fileUserContext.Files[attachment.ObjectId!].OpenAIFileId!,
-                    ProviderStorageAccountName = string.IsNullOrWhiteSpace(attachment.SecondaryProvider)
+                    ProviderStorageAccountName = useAttachmentPath
                         ? _attachmentResourceProvider.StorageAccountName
                         : null
                 });
+            }
 
             return result;
         }


### PR DESCRIPTION
# Send storage path for image attachments

## The issue or feature being addressed

Sends storage path instead of Assistants file id for image attachments.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
