### PR TITLE
Fixing analysis_results parameter name - Cherry-pick

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -266,7 +266,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
                 operation_id = request.operation_id,
                 full_prompt = self.prompt.prefix,
                 content = assistant_response.content,
-                analysis_result = assistant_response.analysis_result,
+                analysis_results = assistant_response.analysis_results,
                 completion_tokens = assistant_response.completion_tokens + image_analysis_token_usage.completion_tokens,
                 prompt_tokens = assistant_response.prompt_tokens + image_analysis_token_usage.prompt_tokens,
                 total_tokens = assistant_response.total_tokens + image_analysis_token_usage.total_tokens,
@@ -396,7 +396,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
             return CompletionResponse(
                 operation_id = request.operation_id,
                 full_prompt = self.prompt.prefix,
-                analysis_result = assistant_response.analysis_result,
+                analysis_results = assistant_response.analysis_results,
                 content = assistant_response.content,
                 completion_tokens = assistant_response.completion_tokens + image_analysis_token_usage.completion_tokens,
                 prompt_tokens = assistant_response.prompt_tokens + image_analysis_token_usage.prompt_tokens,

--- a/src/python/PythonSDK/foundationallm/models/orchestration/completion_response.py
+++ b/src/python/PythonSDK/foundationallm/models/orchestration/completion_response.py
@@ -22,7 +22,7 @@ class CompletionResponse(BaseModel):
             ]
         ]
     ] = None
-    analysis_result: Optional[List[AnalysisResult]] = []
+    analysis_results: Optional[List[AnalysisResult]] = []
     citations: Optional[List[Citation]] = []
     user_prompt_embedding: Optional[List[float]] = []
     prompt_tokens: int = 0

--- a/src/python/PythonSDK/foundationallm/models/services/openai_assistants_response.py
+++ b/src/python/PythonSDK/foundationallm/models/services/openai_assistants_response.py
@@ -24,7 +24,7 @@ class OpenAIAssistantsAPIResponse(BaseModel):
             ]
         ]
     ]
-    analysis_result: Optional[List[AnalysisResult]]
+    analysis_results: Optional[List[AnalysisResult]]
     completion_tokens: Optional[int]
     prompt_tokens: Optional[int]
     total_tokens: Optional[int]

--- a/src/python/PythonSDK/foundationallm/services/openai_assistants_api_service.py
+++ b/src/python/PythonSDK/foundationallm/services/openai_assistants_api_service.py
@@ -86,7 +86,7 @@ class OpenAIAssistantsApiService:
         run = self.client.beta.threads.runs.create_and_poll(
             thread_id = request.thread_id,
             assistant_id = request.assistant_id
-            )
+        )
         
         # Retrieve the messages in the thread after the prompt message was appended.
         messages = self.client.beta.threads.messages.list(
@@ -99,13 +99,13 @@ class OpenAIAssistantsApiService:
           run_id = run.id
         )
 
-        analysis_result = self._parse_run_steps(run_steps.data)
+        analysis_results = self._parse_run_steps(run_steps.data)
 
         content = self._parse_messages(messages)
         
         return OpenAIAssistantsAPIResponse(
             content = content,
-            analysis_result= analysis_result,
+            analysis_results = analysis_results,
             completion_tokens = run.usage.completion_tokens,
             prompt_tokens = run.usage.prompt_tokens,
             total_tokens = run.usage.total_tokens
@@ -149,7 +149,7 @@ class OpenAIAssistantsApiService:
           run_id = run.id
         )
 
-        analysis_result = await self._aparse_run_steps(run_steps.data)
+        analysis_results = await self._aparse_run_steps(run_steps.data)
 
         # Retrieve the messages in the thread after the prompt message was appended.
         messages = await self.client.beta.threads.messages.list(
@@ -160,7 +160,7 @@ class OpenAIAssistantsApiService:
 
         return OpenAIAssistantsAPIResponse(
             content = content,
-            analysis_result= analysis_result,
+            analysis_results = analysis_results,
             completion_tokens = run.usage.completion_tokens,
             prompt_tokens = run.usage.prompt_tokens,
             total_tokens = run.usage.total_tokens


### PR DESCRIPTION
# Fixing analysis_results parameter name

## The issue or feature being addressed

The `analysis_result` parameter on the `completion_response` in Python was incorrectly named. It should be the plural, `analysis_results` to align with the expectations of the calling API in .NET.

## Details on the issue fix or feature implementation

Renamed `analysis_result` to `analysis_results` in the Python `completion_response` object.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
