### PR TITLE
(0.8.0) Detect file mime types

### DIFF
--- a/src/dotnet/Common/Common.csproj
+++ b/src/dotnet/Common/Common.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageReference Include="Microsoft.Graph" Version="5.48.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.17.4" />
+    <PackageReference Include="Mime-Detective" Version="24.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />

--- a/src/dotnet/Common/Utils/FileMethods.cs
+++ b/src/dotnet/Common/Utils/FileMethods.cs
@@ -1,0 +1,62 @@
+﻿using FoundationaLLM.Common.Constants.Orchestration;
+using MimeDetective;
+
+namespace FoundationaLLM.Common.Utils
+{
+    /// <summary>
+    /// Contains methods for working with files.
+    /// </summary>
+    public class FileMethods
+    {
+        private static readonly Dictionary<string, string> FileTypeMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { ".jpg", MessageContentItemTypes.ImageFile },
+            { ".jpeg", MessageContentItemTypes.ImageFile },
+            { ".png", MessageContentItemTypes.ImageFile },
+            { ".gif", MessageContentItemTypes.ImageFile },
+            { ".bmp", MessageContentItemTypes.ImageFile },
+            { ".svg", MessageContentItemTypes.ImageFile },
+            { ".webp", MessageContentItemTypes.ImageFile },
+            { ".html", MessageContentItemTypes.HTML },
+            { ".htm", MessageContentItemTypes.HTML }
+        };
+
+        /// <summary>
+        /// Returns the type of the message content based on the file name.
+        /// </summary>
+        /// <param name="fileName">The file name to evaluate.</param>
+        /// <param name="fallbackValue">If populated, defines the fallback type value
+        /// if a mapping cannot be determined from the passed in file name. Otherwise,
+        /// the default value is <see cref="MessageContentItemTypes.FilePath"/>.</param>
+        /// <returns></returns>
+        public static string GetMessageContentFileType(string? fileName, string? fallbackValue)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return fallbackValue ?? MessageContentItemTypes.FilePath;
+            }
+            var extension = Path.GetExtension(fileName);
+
+            return FileTypeMappings.GetValueOrDefault(extension, fallbackValue ?? MessageContentItemTypes.FilePath);
+        }
+
+        /// <summary>
+        /// Returns the mime type of the file data.
+        /// </summary>
+        /// <param name="fileData">The byte array for the file to inspect.</param>
+        /// <returns></returns>
+        public static string GetMimeType(byte[] fileData)
+        {
+            // Detect the mime type from the file data using Mime-Detective.
+            var Inspector = new ContentInspectorBuilder()
+            {
+                Definitions = MimeDetective.Definitions.Default.All()
+            }.Build();
+
+            var results = Inspector.Inspect(fileData);
+            var mimeType = results.FirstOrDefault()?.Definition.File.MimeType;
+
+            return mimeType ?? "application/octet-stream";
+        }
+    }
+}

--- a/src/dotnet/CoreAPI/Controllers/FilesController.cs
+++ b/src/dotnet/CoreAPI/Controllers/FilesController.cs
@@ -2,6 +2,7 @@
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
+using FoundationaLLM.Common.Utils;
 using FoundationaLLM.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -100,7 +101,7 @@ namespace FoundationaLLM.Core.API.Controllers
 
             return attachment == null
                 ? NotFound()
-                : File(attachment.Content!, attachment.ContentType!, attachment.OriginalFileName);
+                : File(attachment.Content!, FileMethods.GetMimeType(attachment.Content!), attachment.OriginalFileName);
         }
 
         /// <summary>

--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -196,7 +196,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             {
                 FoundationaLLMObjectId = $"/instances/{_instanceId}/providers/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{AzureOpenAIResourceTypeNames.FileUserContexts}/{_fileUserContextName}/{AzureOpenAIResourceTypeNames.FilesContent}/{openAIImageFile.FileId}",
                 OriginalFileName = openAIImageFile.FileId!,
-                ContentType = "image",
+                ContentType = "image/png",
                 OpenAIFileId = openAIImageFile.FileId!,
                 Generated = true,
                 OpenAIFileGeneratedOn = DateTimeOffset.UtcNow
@@ -211,7 +211,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             {
                 FoundationaLLMObjectId = $"/instances/{_instanceId}/providers/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{AzureOpenAIResourceTypeNames.FileUserContexts}/{_fileUserContextName}/{AzureOpenAIResourceTypeNames.FilesContent}/{openAIFilePath.FileId}",
                 OriginalFileName = openAIFilePath.FileId!,
-                ContentType = "generic",
+                ContentType = "application/octet-stream",
                 OpenAIFileId = openAIFilePath.FileId!,
                 Generated = true,
                 OpenAIFileGeneratedOn = DateTimeOffset.UtcNow

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -257,7 +257,7 @@ export default {
 			currentWordIndex: 0,
 			primaryButtonBg: this.$appConfigStore.primaryButtonBg,
 			primaryButtonText: this.$appConfigStore.primaryButtonText,
-			messageContent: JSON.parse(JSON.stringify(this.message.content)),
+			messageContent: this.message.content ? JSON.parse(JSON.stringify(this.message.content)) : null,
 		};
 	},
 


### PR DESCRIPTION
# (0.8.0) Detect file mime types

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Detects the mime type from a byte array and sets the mime type of the file downloaded through the Core API files controller.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
