### PR TITLE
Cherry pick: Multiple file uploads progress bar with real upload progress 

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -263,9 +263,12 @@ export default {
 		},
 
 		async handleUpload(event: any) {
-			const numberOfFiles = event.files.length;
+			const stallLoadPercentage = 70;
+			const totalFiles = event.files.length;
+			let filesUploaded = 0;
+
 			event.files.forEach(async (file: any, index) => {
-				this.uploadProgress = 70;
+				this.uploadProgress = stallLoadPercentage / totalFiles;
 				try {
 					const formData = new FormData();
 					formData.append('file', file);
@@ -274,14 +277,16 @@ export default {
 						formData,
 						this.$appStore.currentSession.sessionId,
 					);
+					filesUploaded += 1;
+					this.uploadProgress += stallLoadPercentage / totalFiles;
 
-					if (index === numberOfFiles - 1) {
+					if (totalFiles === filesUploaded) {
 						this.showFileUploadDialog = false;
 						this.uploadProgress = 0;
 						this.$toast.add({
 							severity: 'success',
 							summary: 'Success',
-							detail: `File${numberOfFiles > 1 ? 's' : ''} uploaded successfully.`,
+							detail: `File${totalFiles > 1 ? 's' : ''} uploaded successfully.`,
 							life: 5000,
 						});
 					}

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -280,7 +280,7 @@ export default {
 
 							let totalUploadProgress = 0;
 							filesProgress.forEach((fileProgress) => {
-								totalUploadProgress += fileProgress / 3;
+								totalUploadProgress += fileProgress / totalFiles;
 							});
 
 							this.uploadProgress = totalUploadProgress;

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -57,10 +57,13 @@
 					</template>
 
 					<template #content="{ files, removeFileCallback }">
-						<div v-if="uploadProgress !== 0">
+						<!-- Progress bar -->
+						<div v-if="isUploading">
 							<ProgressBar :value="uploadProgress" :showValue="false" style="display: flex; width: 95%; margin: 10px 2.5%;" />
 							<p style="text-align: center">Uploading...</p>
 						</div>
+
+						<!-- File list -->
 						<div v-else>
 							<div
 								v-for="(file, index) of files"
@@ -193,10 +196,7 @@ export default {
 			agents: [],
 			agentListOpen: false,
 			showFileUploadDialog: false,
-			primaryButtonBg: this.$appConfigStore.primaryButtonBg,
-			primaryButtonText: this.$appConfigStore.primaryButtonText,
-			secondaryButtonBg: this.$appConfigStore.secondaryButtonBg,
-			secondaryButtonText: this.$appConfigStore.secondaryButtonText,
+			isUploading: false,
 			uploadProgress: 0,
 		};
 	},
@@ -263,25 +263,40 @@ export default {
 		},
 
 		async handleUpload(event: any) {
-			const stallLoadPercentage = 70;
+			this.isUploading = true;
+
 			const totalFiles = event.files.length;
 			let filesUploaded = 0;
+			const filesProgress = [];
 
 			event.files.forEach(async (file: any, index) => {
-				this.uploadProgress = stallLoadPercentage / totalFiles;
 				try {
 					const formData = new FormData();
 					formData.append('file', file);
 
-					const objectId = await this.$appStore.uploadAttachment(
+					const onProgress = (event) => {
+						if (event.lengthComputable) {
+							filesProgress[index] = (event.loaded / event.total) * 100;
+
+							let totalUploadProgress = 0;
+							filesProgress.forEach((fileProgress) => {
+								totalUploadProgress += fileProgress / 3;
+							});
+
+							this.uploadProgress = totalUploadProgress;
+						}
+					}
+
+					await this.$appStore.uploadAttachment(
 						formData,
 						this.$appStore.currentSession.sessionId,
+						onProgress,
 					);
 					filesUploaded += 1;
-					this.uploadProgress += stallLoadPercentage / totalFiles;
 
 					if (totalFiles === filesUploaded) {
 						this.showFileUploadDialog = false;
+						this.isUploading = false;
 						this.uploadProgress = 0;
 						this.$toast.add({
 							severity: 'success',

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -40,6 +40,7 @@
 						v-if="message.sender === 'User'"
 						:attachments="message.attachmentDetails ?? []"
 					/>
+
 					<template v-if="message.sender === 'Assistant' && message.type === 'LoadingMessage'">
 						<i class="pi pi-spin pi-spinner"></i>
 					</template>
@@ -47,12 +48,14 @@
 					<template v-if="!messageContent || messageContent.length === 0">
 						<div v-html="compiledVueTemplate"></div>
 					</template>
+
 					<template v-else>
 						<!-- Render the html content and any vue components within -->
 						<div v-for="content in messageContent" :key="content.fileName" class="message-content">
 							<div v-if="content.type === 'text'">
 								<component :is="renderMarkdownComponent(content.value)"></component>
 							</div>
+
 							<div v-else-if="content.type === 'image_file'">
 								<template v-if="content.loading || (!content.error && !content.blobUrl)">
 									<div class="loading-image-container">
@@ -61,7 +64,6 @@
 										<span class="loading-image-text">Loading image...</span>
 									</div>
 								</template>
-
 								<img
 									v-if="content.blobUrl"
 									:src="content.blobUrl"
@@ -78,9 +80,11 @@
 									<span class="loading-image-error-text">Could not load image</span>
 								</div>
 							</div>
+
 							<div v-else-if="content.type === 'html'">
 								<iframe :src="content.blobUrl" frameborder="0"></iframe>
 							</div>
+
 							<div v-else-if="content.type === 'file_path'">
 								<a
 									:href="content.blobUrl"

--- a/src/ui/UserPortal/js/api.ts
+++ b/src/ui/UserPortal/js/api.ts
@@ -287,7 +287,7 @@ export default {
 	 * @returns The ObjectID of the uploaded attachment.
 	 */
 	async uploadAttachment(file: FormData, agentName: string, progressCallback: Function) {
-		const response: ResourceProviderUpsertResult = await new Promise(async (resolve) => {
+		const response: ResourceProviderUpsertResult = await new Promise(async (resolve, reject) => {
 			const xhr = new XMLHttpRequest();
 
 			xhr.upload.onprogress = function (event) {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -334,14 +334,14 @@ export const useAppStore = defineStore('app', {
 			return this.agents;
 		},
 
-		async uploadAttachment(file: FormData, sessionId: string) {
+		async uploadAttachment(file: FormData, sessionId: string, progressCallback: Function) {
 			const agent = this.getSessionAgent(this.currentSession!).resource;
 			// If the agent is not found, do not upload the attachment and display an error message.
 			if (!agent) {
 				throw new Error('No agent selected.');
 			}
 
-			const upsertResult = await api.uploadAttachment(file, agent.name) as ResourceProviderUpsertResult;
+			const upsertResult = await api.uploadAttachment(file, agent.name, progressCallback) as ResourceProviderUpsertResult;
 			const fileName = file.get('file')?.name;
 			const newAttachment: Attachment = { id: upsertResult.objectId, fileName, sessionId };
 


### PR DESCRIPTION
# Cherry pick: Multiple file uploads progress bar with real upload progress 

## The issue or feature being addressed
- Update the upload progress bar in the portal UI for multiple files
- Use real upload progress for progress bar rather than simulated

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.