### PR TITLE
Improve scheme detection when constructing the root URL

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -570,13 +570,20 @@ public partial class CoreService(
 
     private string GetRootUrl()
     {
-        const string token = "{{fllm_base_url}}";
         var request = _httpContextAccessor.HttpContext?.Request;
+
+        if (request == null)
+        {
+            throw new InvalidOperationException("Request cannot be null.");
+        }
+
+        var scheme = request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? request.Scheme;
+
         var uriBuilder = new UriBuilder
         {
-            Scheme = request.Scheme,
+            Scheme = scheme,
             Host = request.Host.Host,
-            Port = request.Host.Port ?? (request.IsHttps ? 443 : 80)
+            Port = request.Host.Port ?? (scheme == "https" ? 443 : 80)
         };
 
         return uriBuilder.ToString();

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -13,6 +13,7 @@ using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Core.Models.Configuration;
 using FoundationaLLM.Core.Services;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
 using Microsoft.Extensions.Options;
@@ -248,6 +249,12 @@ namespace FoundationaLLM.Core.API
             app.UseExceptionHandler(exceptionHandlerApp
                     => exceptionHandlerApp.Run(async context
                         => await Results.Problem().ExecuteAsync(context)));
+
+            var forwardedHeadersOptions = new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            };
+            app.UseForwardedHeaders(forwardedHeadersOptions);
 
             // Configure the HTTP request pipeline.
             app.UseSwagger();


### PR DESCRIPTION
# Improve scheme detection when constructing the root URL

## The issue or feature being addressed

Fixes issue where the deployed Core API service would not detect the correct scheme (https) when generating the root URL.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
