### PR TITLE
Switching image analysis to use Assistant API vision

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -215,48 +215,21 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
         self._validate_request(request)
 
         agent = request.agent
-        image_analysis_token_usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-
-        image_analysis_results = None
-        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
-        if len(image_attachments) > 0:
-            image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=False)
-            image_analysis_svc = ImageAnalysisService(config=self.config, client=image_analysis_client, deployment_model=self.ai_model.deployment_name)
-            image_analysis_results, usage = image_analysis_svc.analyze_images(image_attachments)
-            image_analysis_token_usage.prompt_tokens += usage.prompt_tokens
-            image_analysis_token_usage.completion_tokens += usage.completion_tokens
-            image_analysis_token_usage.total_tokens += usage.total_tokens
 
         # Check for Assistants API capability
         if "OpenAI.Assistants" in agent.capabilities:
             operation_type_override = OperationTypes.ASSISTANTS_API
             # create the service
-            assistant_svc = OpenAIAssistantsApiService(azure_openai_client=self._get_language_model(override_operation_type=operation_type_override, is_async=False))
+            assistant_svc = OpenAIAssistantsApiService(client=self._get_language_model(override_operation_type=operation_type_override, is_async=False))
             
             # populate service request object
             assistant_req = OpenAIAssistantsAPIRequest(
                 assistant_id=request.objects["OpenAI.AssistantId"],
                 thread_id=request.objects["OpenAI.AssistantThreadId"],
-                attachments=[attachment.provider_file_name for attachment in request.attachments if attachment.provider == AttachmentProviders.FOUNDATIONALLM_AZURE_OPENAI],
+                attachments=[attachment for attachment in request.attachments if attachment.provider == AttachmentProviders.FOUNDATIONALLM_AZURE_OPENAI],
                 user_prompt=request.user_prompt
             )
 
-            # Add user and assistant messages related to image analysis to the Assistants API request.
-            if image_analysis_results is not None:
-                # Add user message
-                assistant_svc.add_thread_message(
-                    thread_id = assistant_req.thread_id,
-                    role = "user",
-                    content = "Analyze any attached images.",
-                    attachments = []
-                )
-                # Add assistant message
-                assistant_svc.add_thread_message(
-                    thread_id = assistant_req.thread_id,
-                    role = "assistant",
-                    content = image_analysis_svc.format_results(image_analysis_results),
-                    attachments = []
-                )
             # invoke/run the service
             assistant_response = assistant_svc.run(assistant_req)
             
@@ -266,14 +239,26 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
                 full_prompt = self.prompt.prefix,
                 content = assistant_response.content,
                 analysis_results = assistant_response.analysis_results,
-                completion_tokens = assistant_response.completion_tokens + image_analysis_token_usage.completion_tokens,
-                prompt_tokens = assistant_response.prompt_tokens + image_analysis_token_usage.prompt_tokens,
-                total_tokens = assistant_response.total_tokens + image_analysis_token_usage.total_tokens,
+                completion_tokens = assistant_response.completion_tokens,
+                prompt_tokens = assistant_response.prompt_tokens,
+                total_tokens = assistant_response.total_tokens,
                 user_prompt = request.user_prompt
                 )
 
         with get_openai_callback() as cb:
             try:
+                image_analysis_token_usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+                image_analysis_results = None
+                image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
+                if len(image_attachments) > 0:
+                    image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=False)
+                    image_analysis_svc = ImageAnalysisService(config=self.config, client=image_analysis_client, deployment_model=self.ai_model.deployment_name)
+                    image_analysis_results, usage = image_analysis_svc.analyze_images(image_attachments)
+                    image_analysis_token_usage.prompt_tokens += usage.prompt_tokens
+                    image_analysis_token_usage.completion_tokens += usage.completion_tokens
+                    image_analysis_token_usage.total_tokens += usage.total_tokens
+
                 # Get the vector document retriever, if it exists.
                 retriever = self._get_document_retriever(request, agent)
                 if retriever is not None:
@@ -343,49 +328,20 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
         self._validate_request(request)
 
         agent = request.agent
-        image_analysis_token_usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-
-        image_analysis_results = None
-        # Get image attachments that are images with URL file paths.
-        image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
-        if len(image_attachments) > 0:
-            image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=True)
-            image_analysis_svc = ImageAnalysisService(config=self.config, client=image_analysis_client, deployment_model=self.ai_model.deployment_name)
-            image_analysis_results, usage = await image_analysis_svc.aanalyze_images(image_attachments)
-            image_analysis_token_usage.prompt_tokens += usage.prompt_tokens
-            image_analysis_token_usage.completion_tokens += usage.completion_tokens
-            image_analysis_token_usage.total_tokens += usage.total_tokens
-
+        
         # Check for Assistants API capability
         if "OpenAI.Assistants" in agent.capabilities:
             operation_type_override = OperationTypes.ASSISTANTS_API
             # create the service
-            assistant_svc = OpenAIAssistantsApiService(azure_openai_client=self._get_language_model(override_operation_type=operation_type_override, is_async=True))
+            assistant_svc = OpenAIAssistantsApiService(client=self._get_language_model(override_operation_type=operation_type_override, is_async=True))
 
             # populate service request object
             assistant_req = OpenAIAssistantsAPIRequest(
                 assistant_id=request.objects["OpenAI.AssistantId"],
                 thread_id=request.objects["OpenAI.AssistantThreadId"],
-                attachments=[attachment.provider_file_name for attachment in request.attachments if attachment.provider == AttachmentProviders.FOUNDATIONALLM_AZURE_OPENAI],
+                attachments=[attachment for attachment in request.attachments if attachment.provider == AttachmentProviders.FOUNDATIONALLM_AZURE_OPENAI],
                 user_prompt=request.user_prompt
             )
-
-            # Add user and assistant messages related to image analysis to the Assistants API request.
-            if image_analysis_results is not None:
-                # Add user message
-                await assistant_svc.aadd_thread_message(
-                    thread_id = assistant_req.thread_id,
-                    role = "user",
-                    content = "Analyze any attached images.",
-                    attachments = []
-                )
-                # Add assistant message
-                await assistant_svc.aadd_thread_message(
-                    thread_id = assistant_req.thread_id,
-                    role = "assistant",
-                    content = image_analysis_svc.format_results(image_analysis_results),
-                    attachments = []
-                )
 
             # invoke/run the service
             assistant_response = await assistant_svc.arun(assistant_req)
@@ -396,14 +352,27 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
                 full_prompt = self.prompt.prefix,
                 analysis_results = assistant_response.analysis_results,
                 content = assistant_response.content,
-                completion_tokens = assistant_response.completion_tokens + image_analysis_token_usage.completion_tokens,
-                prompt_tokens = assistant_response.prompt_tokens + image_analysis_token_usage.prompt_tokens,
-                total_tokens = assistant_response.total_tokens + image_analysis_token_usage.total_tokens,
+                completion_tokens = assistant_response.completion_tokens,
+                prompt_tokens = assistant_response.prompt_tokens,
+                total_tokens = assistant_response.total_tokens,
                 user_prompt = request.user_prompt
                 )          
 
         with get_openai_callback() as cb:
             try:
+                image_analysis_token_usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+                image_analysis_results = None
+                # Get image attachments that are images with URL file paths.
+                image_attachments = [attachment for attachment in request.attachments if (attachment.provider == AttachmentProviders.FOUNDATIONALLM_ATTACHMENT and attachment.content_type.startswith('image/'))] if request.attachments is not None else []
+                if len(image_attachments) > 0:
+                    image_analysis_client = self._get_language_model(override_operation_type=OperationTypes.IMAGE_ANALYSIS, is_async=True)
+                    image_analysis_svc = ImageAnalysisService(config=self.config, client=image_analysis_client, deployment_model=self.ai_model.deployment_name)
+                    image_analysis_results, usage = await image_analysis_svc.aanalyze_images(image_attachments)
+                    image_analysis_token_usage.prompt_tokens += usage.prompt_tokens
+                    image_analysis_token_usage.completion_tokens += usage.completion_tokens
+                    image_analysis_token_usage.total_tokens += usage.total_tokens
+
                 # Get the vector document retriever, if it exists.
                 retriever = self._get_document_retriever(request, agent)
                 if retriever is not None:

--- a/src/python/PythonSDK/foundationallm/models/services/openai_assistants_request.py
+++ b/src/python/PythonSDK/foundationallm/models/services/openai_assistants_request.py
@@ -3,16 +3,18 @@ Encapsulates properties useful for calling the OpenAI Assistants API.
 """
 from typing import List, Optional
 from pydantic import BaseModel
+from foundationallm.models.attachments import AttachmentProperties
 
 class OpenAIAssistantsAPIRequest(BaseModel):
     """
     Encapsulates properties useful for calling the OpenAI Assistants API.
         assistant_id: str - The ID of the assistant to use.
         thread_id: str - The ID of the conversation thread to use.
-        attachments: Optional[List[str]] - The list of OpenAI file IDs to use.
+        attachments: Optional[List[AttachmentProperties]] - The list of OpenAI file attachments to include in the request.
         user_prompt: str - The user prompt/message to send to the assistants API.
     """
     assistant_id: str
     thread_id: str
-    attachments: Optional[List[str]] = []
+    #attachments: Optional[List[str]] = []
+    attachments: Optional[List[AttachmentProperties]] = []
     user_prompt: str

--- a/src/python/PythonSDK/foundationallm/services/image_analysis_service.py
+++ b/src/python/PythonSDK/foundationallm/services/image_analysis_service.py
@@ -87,11 +87,11 @@ class ImageAnalysisService:
         str
             The formatted image analysis results.
         """
-        formatted_results = f"You have access to the following {len(image_analyses)} images and their analysis results:\n"
+        formatted_results = f"You have access to the following {len(image_analyses)} image attachments and their analysis results:\n"
         for idx, key in enumerate(image_analyses):
             formatted_results += f"## Image {idx + 1}:\n"
-            formatted_results += f"- Name : {key}\n"
-            formatted_results += f"- Analysis: {image_analyses[key]}\n\n"
+            formatted_results += f"- File name : {key}\n"
+            formatted_results += f"- Analysis result: {image_analyses[key]}\n\n"
         return formatted_results
 
     async def aanalyze_images(self, image_attachments: List[AttachmentProperties]) -> tuple:
@@ -122,7 +122,7 @@ class ImageAnalysisService:
                                 "content": [
                                     {
                                         "type": "text",
-                                        "content": "Analyze the image:"
+                                        "content": "Analyze and describe the image:"
                                     },
                                     {
                                         "type": "image_url",
@@ -173,7 +173,7 @@ class ImageAnalysisService:
                                 "content": [
                                     {
                                         "type": "text",
-                                        "content": "Analyze the image:"
+                                        "content": "Analyze and describe the image:"
                                     },
                                     {
                                         "type": "image_url",


### PR DESCRIPTION
# Switching image analysis to use Assistant API vision

## The issue or feature being addressed

Image analysis when agents have the OpenAI.Assistants capability was not assigning a purpose of vision to image files.

## Details on the issue fix or feature implementation

Changed the Assistant API service to assign a purpose of `vision` to image file attachments.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
