### PR TITLE
Updating attachment assignment to use OpenAI Assistant routing

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -127,9 +127,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             List<AttachmentProperties> result = [];
             await foreach (var attachment in attachments)
             {
-                var useAttachmentPath =
-                    string.IsNullOrWhiteSpace(attachment.SecondaryProvider)
-                    || (attachment.ContentType ?? string.Empty).StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+                // Use the attachment path if a secondary provider is not set.
+                var useAttachmentPath = string.IsNullOrWhiteSpace(attachment.SecondaryProvider);
 
                 result.Add(new AttachmentProperties
                 {


### PR DESCRIPTION
# Updating attachment assignment to use OpenAI Assistant routing

## The issue or feature being addressed

Image files are not being routed as attachments to the Assistant API correctly.

## Details on the issue fix or feature implementation

Changing the logic to ensure image attachments are routed correctly to the Assistant API. This change reflects a recent change allowing images files to be passed to the Assistant API with a purpose of `vision` made in the Python SDK.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
