### PR TITLE
(0.8.0) Add icons to file downloads for content generated by an agent

### DIFF
--- a/src/ui/UserPortal/components/AttachmentList.vue
+++ b/src/ui/UserPortal/components/AttachmentList.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="attachments && attachments.length > 0" class="attachments">
       <div v-for="attachment in attachments" :key="attachment.objectId" class="attachment-item">
-        <i :class="getFileIconClass(attachment)" class="attachment-icon"></i>
+        <i :class="$getFileIconClass(attachment.displayName, false)" class="attachment-icon"></i>
         <span class="attachment-name">{{ attachment.displayName }}</span>
       </div>
     </div>
@@ -16,8 +16,6 @@
   <script lang="ts">
   import { defineComponent, type PropType } from 'vue';
   import type { AttachmentDetail } from '@/js/types';
-  import { getClass, getClassWithColor } from 'file-icons-js';
-  import 'file-icons-js/css/style.css';
   
   export default defineComponent({
     name: 'AttachmentList',
@@ -31,13 +29,6 @@
             required: false,
             default: () => []
         }
-    },
-    methods: {
-      getFileIconClass(attachment: AttachmentDetail) {
-        const fileName = attachment.displayName.toLowerCase();
-        const iconClass = getClass(fileName); //getClassWithColor(fileName);
-        return iconClass || 'pi pi-file';
-      }
     }
   });
   </script>

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -104,12 +104,13 @@
 							</div>
 
 							<div v-else-if="content.type === 'file_path'">
+								Download <i :class="$getFileIconClass(content.fileName, true)" class="attachment-icon"></i> 
 								<a
 									:href="content.blobUrl"
 									:download="content.fileName ?? content.blobUrl ?? content.value"
 									target="_blank"
 								>
-									Download {{ content.fileName ?? content.blobUrl }}
+									{{ content.fileName ?? content.blobUrl }}
 								</a>
 							</div>
 						</div>
@@ -675,6 +676,13 @@ iframe {
 		line-height: 1.5;
 	}
 }
+
+.attachment-icon {
+        width: 24px;
+        margin-right: 4px;
+        vertical-align: middle;
+        line-height: 1;
+    }
 </style>
 
 <style lang="scss">

--- a/src/ui/UserPortal/plugins/fileIconPlugin.ts
+++ b/src/ui/UserPortal/plugins/fileIconPlugin.ts
@@ -1,0 +1,21 @@
+import { defineNuxtPlugin } from '#app';
+import { getClass, getClassWithColor } from 'file-icons-js';
+import 'file-icons-js/css/style.css';
+
+export default defineNuxtPlugin(() => {
+	const getFileIconClass = (fileName: string, useColorVersion: boolean = false) => {
+		var iconClass;
+		if (useColorVersion) {
+			iconClass = getClassWithColor(fileName.toLowerCase());
+		} else {
+			iconClass = getClass(fileName.toLowerCase());
+		}
+		return iconClass || 'pi pi-file'; // Use default icon if no class found
+	};
+
+	return {
+		provide: {
+			getFileIconClass,
+		},
+	};
+});


### PR DESCRIPTION
# (0.8.0) Add icons to file downloads for content generated by an agent

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Centralizes file icon class name method and adds file icons to download links for file content generated by an agent.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
