### PR TITLE
Updating deployment to support file uploads up to 512 MB

### DIFF
--- a/deploy/common/docker/jump-pod/Dockerfile
+++ b/deploy/common/docker/jump-pod/Dockerfile
@@ -1,0 +1,42 @@
+FROM alpine:3.20
+
+RUN apk update
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl \
+    bash \
+    icu-libs \
+    python3 \
+    py3-pip \
+    ipcalc
+
+RUN ipcalc --version
+
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.4.4/powershell-7.4.4-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
+RUN mkdir -p /opt/microsoft/powershell/7
+RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+RUN chmod +x /opt/microsoft/powershell/7/pwsh
+RUN sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+RUN pwsh --version
+
+RUN curl -fsSL https://aka.ms/install-azd.sh -o install-azd.sh
+RUN bash install-azd.sh
+RUN azd version
+
+
+RUN apk add python3 py3-pip
+RUN pip install azure-cli
+
+ENTRYPOINT [ "pwsh" ]

--- a/deploy/common/helm/core-api/templates/deployment.yaml
+++ b/deploy/common/helm/core-api/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         - name: {{ .name }}
       {{- end -}}
       {{- end }}
+      volumes:
+        - name: tmpfs
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -61,6 +64,9 @@ spec:
                   key: {{ .name }}
           {{- end -}}
           {{- end }}
+          volumeMounts:
+            - name: tmpfs
+              mountPath: /tmp
           ports:
             - name: http
               containerPort: 80

--- a/deploy/standard/azd-hooks/utility/Deploy-Backend-Aks.ps1
+++ b/deploy/standard/azd-hooks/utility/Deploy-Backend-Aks.ps1
@@ -79,7 +79,8 @@ foreach ($chart in $chartsToInstall.GetEnumerator()) {
             --namespace ${serviceNamespace} `
             --values $valuesFile `
             --set image.repository=$($registry)/$($chart.Key) `
-            --set image.tag=$version
+            --set image.tag=$version `
+            --set controller.config.proxy-body-size=512m
     }
 }
 

--- a/deploy/standard/config/helm/ingress-nginx.values.backend.template.yml
+++ b/deploy/standard/config/helm/ingress-nginx.values.backend.template.yml
@@ -20,3 +20,5 @@ controller:
     loadBalancerIP: {{privateIpIngressBackend}}
     ports:
       https: 443
+  config:
+    proxy-body-size: 512m


### PR DESCRIPTION
# Updating deployment to support file uploads up to 512 MB

## Details on the issue fix or feature implementation

Updating deployment to support file uploads up to 512 MB.  Updated annotations on the ingress service and rules and added an ephemeral volume for /tmp in the Core API helm chart.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

