### PR TITLE
Support defining a custom agent icon

### DIFF
--- a/deploy/standard/config/appconfig.template.json
+++ b/deploy/standard/config/appconfig.template.json
@@ -610,6 +610,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:Branding:AgentIconUrl",
+            "value": "",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:Branding:KioskMode",
             "value": "false",
             "label": null,

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1192,6 +1192,14 @@
 				"first_version": "0.8.0"
 			},
 			{
+				"name": "AgentIconUrl",
+				"description": "The agent icon that displays next to the agent select list and agent responses. Can be an absolute URL, relative path, or base64string value.",
+				"secret": "",
+				"value": "",
+				"content_type": "",
+				"first_version": "0.8.0"
+			},
+			{
 				"name": "KioskMode",
 				"description": "Kiosk mode.",
 				"secret": "",

--- a/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
+++ b/src/dotnet/Common/Models/Configuration/Branding/ClientBrandingConfiguration.cs
@@ -14,9 +14,13 @@
         /// </summary>
         public string? PageTitle { get; set; }
         /// <summary>
-        /// The URL of the client's favicon. Can be an absolute URL or a relative URL.
+        /// The URL of the client's favicon. Can be an absolute URL, relative path, or base64string value.
         /// </summary>
         public string? FavIconUrl { get; set; }
+        /// <summary>
+        /// The agent icon that displays next to the agent select list and agent responses. Can be an absolute URL, relative path, or base64string value.
+        /// </summary>
+        public string? AgentIconUrl { get; set; }
         /// <summary>
         /// The URL of the client's logo. Can be an absolute URL or a relative URL.
         /// </summary>

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -854,6 +854,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:Branding:FavIconUrl";
         
         /// <summary>
+        /// The app configuration key for the FoundationaLLM:Branding:AgentIconUrl setting.
+        /// <para>Value description:<br/>The agent icon that displays next to the agent select list and agent responses. Can be an absolute URL, relative path, or base64string value.</para>
+        /// </summary>
+        public const string FoundationaLLM_Branding_AgentIconUrl =
+            "FoundationaLLM:Branding:AgentIconUrl";
+        
+        /// <summary>
         /// The app configuration key for the FoundationaLLM:Branding:KioskMode setting.
         /// <para>Value description:<br/>Kiosk mode.</para>
         /// </summary>

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -624,6 +624,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:Branding:AgentIconUrl",
+            "value": "",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:Branding:KioskMode",
             "value": "false",
             "label": null,

--- a/src/ui/UserPortal/components/AgentIcon.vue
+++ b/src/ui/UserPortal/components/AgentIcon.vue
@@ -1,0 +1,59 @@
+<template>
+    <img
+      v-if="resolvedSrc !== ''"
+      v-tooltip.bottom="tooltip"
+      :alt="alt"
+      class="avatar"
+      :src="resolvedSrc"
+    />
+  </template>
+  
+  <script lang="ts">
+  import { defineComponent, computed } from 'vue';
+  
+  export default defineComponent({
+    name: 'AgentIcon',
+    props: {
+      src: {
+        type: String,
+        required: true,
+      },
+      alt: {
+        type: String,
+        default: 'Agent icon',
+      },
+      tooltip: {
+        type: String,
+        default: '',
+      },
+    },
+    setup(props) {
+      const resolvedSrc = computed(() => {
+        if (props.src.startsWith('~')) {
+          // Handle relative path dynamically
+          return new URL(`../assets/${props.src.slice(9)}`, import.meta.url).href;
+        }
+        return props.src;
+      });
+
+      const tooltipDirective = computed(() => {
+        return props.tooltip !== '' ? { 'v-tooltip': { value: props.tooltip, bottom: true } } : {};
+      });
+  
+      return {
+        resolvedSrc,
+        tooltipDirective,
+      };
+    },
+  });
+  </script>
+  
+  <style scoped>
+  .avatar {
+    /* Add any specific styling for the avatar here */
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
+  </style>
+  

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -5,10 +5,9 @@
 				<div class="message__header">
 					<!-- Sender -->
 					<span class="header__sender">
-						<img
+						<AgentIcon
 							v-if="message.sender !== 'User'"
-							class="avatar"
-							src="~/assets/FLLM-Agent-Light.svg"
+							:src="$appConfigStore.agentIconUrl || '~/assets/FLLM-Agent-Light.svg'"
 							alt="Agent avatar"
 						/>
 						<span>{{ getDisplayName() }}</span>
@@ -234,6 +233,7 @@ import api from '@/js/api';
 import CodeBlockHeader from '@/components/CodeBlockHeader.vue';
 import AttachmentList from '@/components/AttachmentList.vue';
 import AnalysisModal from '@/components/AnalysisModal.vue';
+import AgentIcon from '@/components/AgentIcon.vue';
 
 const renderer = new marked.Renderer();
 

--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -45,11 +45,10 @@
 			<div class="navbar__content__right">
 				<template v-if="currentSession">
 					<span class="header__dropdown">
-						<img
-							v-tooltip.bottom="'Select an agent'"
+						<AgentIcon
+							:src="$appConfigStore.agentIconUrl || '~/assets/FLLM-Agent-Light.svg'"
 							alt="Select an agent"
-							class="avatar"
-							src="~/assets/FLLM-Agent-Light.svg"
+							tooltip="Select an agent"
 						/>
 						<Dropdown
 							v-model="agentSelection"
@@ -72,6 +71,7 @@
 
 <script lang="ts">
 import type { Session } from '@/js/types';
+import AgentIcon from '@/components/AgentIcon.vue';
 
 interface AgentDropdownOption {
 	label: string;

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -12,6 +12,7 @@ const allowedKeys = [
 	'FoundationaLLM:Branding:KioskMode',
 	'FoundationaLLM:Branding:PageTitle',
 	'FoundationaLLM:Branding:FavIconUrl',
+	'FoundationaLLM:Branding:AgentIconUrl',
 	'FoundationaLLM:Branding:LogoUrl',
 	'FoundationaLLM:Branding:LogoText',
 	'FoundationaLLM:Branding:BackgroundColor',

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -28,6 +28,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		secondaryButtonText: null,
 		footerText: null,
 		instanceId: null,
+		agentIconUrl: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -43,7 +44,11 @@ export const useAppConfigStore = defineStore('appConfig', {
 		async getConfigVariables() {
 			const getConfigValueSafe = async (key: string, defaultValue: any = null) => {
 				try {
-					return await api.getConfigValue(key);
+					const value = await api.getConfigValue(key);
+					if (!value) {
+						return defaultValue;
+					}
+					return value;
 				} catch (error) {
 					console.error(`Failed to get config value for key ${key}:`, error);
 					return defaultValue;
@@ -70,6 +75,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				secondaryButtonText,
 				footerText,
 				instanceId,
+				agentIconUrl,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -82,7 +88,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe('FoundationaLLM:Branding:PageTitle'),
 				getConfigValueSafe('FoundationaLLM:Branding:FavIconUrl'),
 				getConfigValueSafe('FoundationaLLM:Branding:LogoUrl', 'foundationallm-logo-white.svg'),
-				getConfigValueSafe('FoundationaLLM:Branding:LogoText'),
+				getConfigValueSafe('FoundationaLLM:Branding:LogoText', ''),
 				getConfigValueSafe('FoundationaLLM:Branding:BackgroundColor', '#fff'),
 				getConfigValueSafe('FoundationaLLM:Branding:PrimaryColor', '#131833'),
 				getConfigValueSafe('FoundationaLLM:Branding:SecondaryColor', '#334581'),
@@ -96,6 +102,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe('FoundationaLLM:Branding:SecondaryButtonTextColor', '#fff'),
 				getConfigValueSafe('FoundationaLLM:Branding:FooterText'),
 				getConfigValueSafe('FoundationaLLM:Instance:Id', '00000000-0000-0000-0000-000000000000'),
+				getConfigValueSafe('FoundationaLLM:Branding:AgentIconUrl', '~/assets/FLLM-Agent-Light.svg'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -124,6 +131,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.secondaryButtonText = secondaryButtonText;
 			this.footerText = footerText;
 			this.instanceId = instanceId;
+			this.agentIconUrl = agentIconUrl;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;


### PR DESCRIPTION
# Support defining a custom agent icon

## The issue or feature being addressed

Provides a new App Config property named `FoundationaLLM:Branding:AgentIconUrl`, which can be an absolute URL, relative path, or base64string value. The agent icon is displayed next to the agent select list and agent responses in the User Portal. If no value is supplied to the App Config property, then the default robot icon is displayed. This can also be used to display the alternate dark version of the default agent robot icon.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
