### PR TITLE
Add caching to Graph API calls

### DIFF
--- a/src/dotnet/Common/Services/Security/MicrosoftGraphIdentityManagementService.cs
+++ b/src/dotnet/Common/Services/Security/MicrosoftGraphIdentityManagementService.cs
@@ -2,10 +2,12 @@
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Collections;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.DirectoryObjects.GetByIds;
 using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 
 namespace FoundationaLLM.Common.Services.Security
 {
@@ -22,37 +24,52 @@ namespace FoundationaLLM.Common.Services.Security
         ILogger<MicrosoftGraphIdentityManagementService> logger) : IIdentityManagementService
     {
         private readonly ILogger<MicrosoftGraphIdentityManagementService> _logger = logger;
+        private readonly IMemoryCache _groupMembershipCache = new MemoryCache(new MemoryCacheOptions
+        {
+            SizeLimit = 5000, // Limit cache size to 5000 lists of security group identifiers.
+            ExpirationScanFrequency = TimeSpan.FromMinutes(1), // Scan for expired items every minute.
+        });
+        private readonly MemoryCacheEntryOptions _cacheEntryOptions = new MemoryCacheEntryOptions()
+            .SetAbsoluteExpiration(TimeSpan.FromMinutes(10)) // Cache entries are valid for 10 minutes.
+            .SetSlidingExpiration(TimeSpan.FromMinutes(5)) // Reset expiration time if accessed within 5 minutes.
+            .SetSize(1); // Each cache entry is a single list of security group identifiers.
+
+        private readonly SemaphoreSlim _cacheLock = new SemaphoreSlim(1, 1);
 
         /// <inheritdoc/>
         public async Task<List<string>> GetGroupsForPrincipal(string userIdentifier)
         {
-            var groups = await graphServiceClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup.GetAsync(requestConfiguration =>
+            if (_groupMembershipCache.TryGetValue(userIdentifier, out List<string>? groupIdsList))
             {
-                requestConfiguration.QueryParameters.Top = 500;
-            }).ConfigureAwait(false);
-
-            var groupMembership = new List<Group>();
-
-            while (groups?.Value != null)
-            {
-                groupMembership.AddRange(groups.Value);
-
-                // Invoke paging if required.
-                if (!string.IsNullOrEmpty(groups.OdataNextLink))
-                {
-                    groups = await graphServiceClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup
-                        .WithUrl(groups.OdataNextLink)
-                        .GetAsync();
-                }
-                else
-                {
-                    break;
-                }
+                return groupIdsList!;
             }
 
-            return groupMembership.Count == 0
-                ? []
-                : groupMembership.Where(x => x.Id != null).Select(x => x.Id!).ToList();
+            // Retrieve group membership from the Graph API outside of the synchronized block.
+            // This is to shorten the time the lock is held (since there is a low probability that multiple simultaneous requests will be made for the same user).
+            // We are prioritizing shorter lock times over the possibility of making multiple Graph API requests.
+            var groupIds = await GetGroupMembershipFromGraph(userIdentifier);
+
+            try
+            {
+                await _cacheLock.WaitAsync();
+
+                // Was the list of group identifiers already added to the cache by another thread?
+                // If yes, just return the cached list.
+                if (_groupMembershipCache.TryGetValue(userIdentifier, out List<string>? newGroupIdsList))
+                {
+                    return newGroupIdsList!;
+                }
+
+                // Add the list of group identifiers to the cache.
+                _groupMembershipCache.Set(userIdentifier, groupIds, _cacheEntryOptions);
+                return groupIds;
+            }
+            finally
+            {
+                _cacheLock.Release();
+            }
+
+            return [];
         }
 
         /// <inheritdoc/>
@@ -251,6 +268,45 @@ namespace FoundationaLLM.Common.Services.Security
                 TotalItems = usersPage?.OdataCount,
                 HasNextPage = usersPage?.OdataNextLink != null
             };
+        }
+
+        private async Task<List<string>> GetGroupMembershipFromGraph(string userIdentifier)
+        {
+            try
+            {
+                var groups = await graphServiceClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup.GetAsync(requestConfiguration =>
+                {
+                    requestConfiguration.QueryParameters.Top = 500;
+                }).ConfigureAwait(false);
+
+                var groupMembership = new List<Group>();
+
+                while (groups?.Value != null)
+                {
+                    groupMembership.AddRange(groups.Value);
+
+                    // Invoke paging if required.
+                    if (!string.IsNullOrEmpty(groups.OdataNextLink))
+                    {
+                        groups = await graphServiceClient.Users[userIdentifier].TransitiveMemberOf.GraphGroup
+                            .WithUrl(groups.OdataNextLink)
+                            .GetAsync();
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                return groupMembership.Count == 0
+                    ? []
+                    : groupMembership.Where(x => x.Id != null).Select(x => x.Id!).ToList();
+            }
+            catch (ODataError ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve group membership from the Graph API for user {UserIdentifier}.", userIdentifier);
+                return [];
+            }
         }
     }
 }


### PR DESCRIPTION
# Add caching to Graph API calls

## The issue or feature being addressed

With the recent changes in the User Portal and the upcoming polling capabilities, Core API is expected to get more calls identified with the same service principal per unit of time. This might pose some concerns with the potential throttling of calls to the Microsoft Graph API.

## Details on the issue fix or feature implementation

Add short-term caching of group membership Graph API call results.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
