### PR TITLE
(0.8.1) Lazy load principals in dropdown

### DIFF
--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -248,9 +248,6 @@ export default {
 				display_name: '',
 			},
 			dialogPrincipal: null,
-			users: [],
-			groups: [],
-			principalOptionsFiltered: [],
 
 			principalOptions: [],
 			loadingPrincipals: false,

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -249,10 +249,10 @@ export default {
 			},
 			dialogPrincipal: null,
 
-			principalOptions: [],
 			loadingPrincipals: false,
+			principalOptions: [],
 			principalSearchQuery: '',
-			principalsPage: 1,
+			principalsCurrentPage: 1,
 			hasNextPrincipalPage: false,
 		};
 	},
@@ -291,7 +291,7 @@ export default {
 
 		async handlePrincipalSearch(event) {
 			this.principalSearchQuery = event.query;
-			this.principalsPage = 1;
+			this.principalsCurrentPage = 1;
 			this.principalOptions = [];
 			await this.loadMorePrincipals();
 		},
@@ -302,7 +302,7 @@ export default {
 			if (dropdown.scrollHeight - dropdown.scrollTop - buffer <= dropdown.clientHeight) {
 				if (this.loadingPrincipals || !this.hasNextPrincipalPage) return;
 
-				this.principalsPage += 1;
+				this.principalsCurrentPage += 1;
 				await this.loadMorePrincipals();
 			}
 		},
@@ -313,7 +313,7 @@ export default {
 			this.loadingPrincipals = true;
 
 			const principalsCurrentPage = await apiMethod.call(api, {
-				page_number: this.principalsPage,
+				page_number: this.principalsCurrentPage,
 				name: this.principalSearchQuery,
 			});
 

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -252,7 +252,7 @@ export default {
 			principalOptions: [],
 			loadingPrincipals: false,
 			principalSearchQuery: '',
-			principalPage: 1,
+			principalsPage: 1,
 			hasNextPrincipalPage: false,
 		};
 	},
@@ -291,7 +291,7 @@ export default {
 
 		async handlePrincipalSearch(event) {
 			this.principalSearchQuery = event.query;
-			this.principalPage = 1;
+			this.principalsPage = 1;
 			this.principalOptions = [];
 			await this.loadMorePrincipals();
 		},
@@ -302,7 +302,7 @@ export default {
 			if (dropdown.scrollHeight - dropdown.scrollTop - buffer <= dropdown.clientHeight) {
 				if (this.loadingPrincipals || !this.hasNextPrincipalPage) return;
 
-				this.principalPage += 1;
+				this.principalsPage += 1;
 				await this.loadMorePrincipals();
 			}
 		},
@@ -313,7 +313,7 @@ export default {
 			this.loadingPrincipals = true;
 
 			const principalsCurrentPage = await apiMethod.call(api, {
-				page_number: this.principalPage,
+				page_number: this.principalsPage,
 				name: this.principalSearchQuery,
 			});
 


### PR DESCRIPTION
# (0.8.1) Lazy load principals in dropdown

## The issue or feature being addressed

Lazy load paginated principal results in principal autocomplete with search.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
