### PR TITLE
(0.8.0) Display just the agent name

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -431,7 +431,7 @@ export default {
 		getDisplayName() {
 			return this.message.sender === 'User'
 				? this.message.senderDisplayName
-				: `${this.message.sender} - ${this.message.senderDisplayName}`;
+				: this.message.senderDisplayName || 'Agent';
 		},
 
 		handleRate(message: Message, isLiked: boolean) {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -212,6 +212,7 @@ export const useAppStore = defineStore('app', {
 		async sendMessage(text: string) {
 			if (!text) return;
 
+			const agent = this.getSessionAgent(this.currentSession!).resource;
 			const sessionId = this.currentSession!.id;
 			const relevantAttachments = this.attachments.filter(
 				(attachment) => attachment.sessionId === sessionId,
@@ -245,7 +246,7 @@ export const useAppStore = defineStore('app', {
 				id: '',
 				rating: null,
 				sender: 'Assistant',
-				senderDisplayName: 'Assistant',
+				senderDisplayName: agent.name,
 				sessionId: this.currentSession!.id,
 				text: '',
 				timeStamp: new Date().toISOString(),
@@ -255,7 +256,6 @@ export const useAppStore = defineStore('app', {
 			};
 			this.currentMessages.push(tempAssistantMessage);
 
-			const agent = this.getSessionAgent(this.currentSession!).resource;
 			if (agent.long_running) {
 				// Handle long-running operations
 				const operationId = await api.startLongRunningProcess('/completions', {


### PR DESCRIPTION
# (0.8.0) Display just the agent name

## The issue or feature being addressed

Display just the agent name without 'Assistant' in the agent response within the User Portal. Also displays the agent name while awaiting a response back from the server.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
