### PR TITLE
(0.8.0) Pinning pydantic version in requirements files

### DIFF
--- a/src/python/AgentHubAPI/requirements.txt
+++ b/src/python/AgentHubAPI/requirements.txt
@@ -3,6 +3,7 @@ azure-identity==1.17.1
 azure-monitor-opentelemetry==1.6.1
 email-validator==2.2.0
 fastapi==0.112.0
+pydantic==2.8.2
 pylint==3.2.6
 tenacity==9.0.0
 uvicorn==0.30.5

--- a/src/python/DataSourceHubAPI/requirements.txt
+++ b/src/python/DataSourceHubAPI/requirements.txt
@@ -3,6 +3,7 @@ azure-identity==1.17.1
 azure-monitor-opentelemetry==1.6.1
 email-validator==2.2.0
 fastapi==0.112.0
+pydantic==2.8.2
 pylint==3.2.6
 tenacity==9.0.0
 uvicorn==0.30.5

--- a/src/python/GatekeeperIntegrationAPI/requirements.txt
+++ b/src/python/GatekeeperIntegrationAPI/requirements.txt
@@ -6,5 +6,6 @@ fastapi==0.112.0
 numpy==1.26.4
 presidio-analyzer==2.2.355
 presidio-anonymizer==2.2.355
+pydantic==2.8.2
 pylint==3.2.6
 uvicorn==0.30.5

--- a/src/python/IntegrationSDK/requirements.txt
+++ b/src/python/IntegrationSDK/requirements.txt
@@ -5,4 +5,5 @@ numpy==1.26.4
 pydantic==2.8.2
 presidio-analyzer==2.2.355
 presidio-anonymizer==2.2.355
+pydantic==2.8.2
 pylint==3.2.6

--- a/src/python/LangChainAPI/requirements.txt
+++ b/src/python/LangChainAPI/requirements.txt
@@ -11,5 +11,6 @@ langchain-experimental==0.0.64
 langchain-openai==0.1.20
 -e git+https://github.com/microsoft/CLAP.git@1af3d710ee796dc96d3a96e2b1fdf66ef2520e63#egg=msclap
 openai==1.40.2
+pydantic==2.8.2
 pylint==3.2.6
 uvicorn==0.30.5

--- a/src/python/PromptHubAPI/requirements.txt
+++ b/src/python/PromptHubAPI/requirements.txt
@@ -3,6 +3,7 @@ azure-identity==1.17.1
 azure-monitor-opentelemetry==1.6.1
 email-validator==2.2.0
 fastapi==0.112.0
+pydantic==2.8.2
 pylint==3.2.6
 tenacity==9.0.0
 uvicorn==0.30.5

--- a/src/python/PythonSDK/requirements.txt
+++ b/src/python/PythonSDK/requirements.txt
@@ -12,3 +12,4 @@ openai==1.40.2
 opentelemetry-api==1.26.0
 opentelemetry-sdk==1.26.0
 pandas==2.2.2
+pydantic==2.8.2


### PR DESCRIPTION
# (0.8.0) Pinning pydantic version in requirements files

## The issue or feature being addressed

Pydantic errors are happening in deployed version.

## Details on the issue fix or feature implementation

Pinning pydantic version to 2.8.2.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
