### PR TITLE
(0.8.1) Handle cases when completion response content is null

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -98,8 +98,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             return new CompletionResponse
             {
                 OperationId = completionRequest.OperationId!,
-                Completion = result.Completion!,
-                Content = await TransformContentItems(result.Content!),
+                Completion = result.Completion,
+                Content = result.Content != null ? await TransformContentItems(result.Content) : null,
                 UserPrompt = completionRequest.UserPrompt!,
                 Citations = result.Citations,
                 FullPrompt = result.FullPrompt,


### PR DESCRIPTION
# (0.8.1) Handle cases when completion response content is null

## The issue or feature being addressed

Fixes errors caused by attempting to execute a transformation on a null content property.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
