### PR TITLE
Handle annotations generated by the file search tool

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -161,19 +161,22 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
 
             var result = contentItems.Select(ci => TransformContentItem(ci, newFileMappings)).ToList();
 
-            var fileUserContext = await _azureOpenAIResourceProvider.GetResource<FileUserContext>(
-                _fileUserContextObjectId,
-                _callContext.CurrentUserIdentity!);
-
-            foreach (var fileMapping in newFileMappings)
+            if (newFileMappings.Count > 0)
             {
-                fileUserContext.Files.TryAdd(fileMapping.FoundationaLLMObjectId, fileMapping);
+                var fileUserContext = await _azureOpenAIResourceProvider.GetResource<FileUserContext>(
+                    _fileUserContextObjectId,
+                    _callContext.CurrentUserIdentity!);
+
+                foreach (var fileMapping in newFileMappings)
+                {
+                    fileUserContext.Files.TryAdd(fileMapping.FoundationaLLMObjectId, fileMapping);
+                }
+
+                await _azureOpenAIResourceProvider.UpsertResourceAsync<FileUserContext, FileUserContextUpsertResult>(
+                    _fileUserContextObjectId,
+                    fileUserContext,
+                    _callContext.CurrentUserIdentity!);
             }
-            
-            await _azureOpenAIResourceProvider.UpsertResourceAsync<FileUserContext, FileUserContextUpsertResult>(
-                _fileUserContextObjectId,
-                fileUserContext,
-                _callContext.CurrentUserIdentity!);
 
             return result;
         }
@@ -213,16 +216,25 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
 
         private OpenAIFilePathContentItem TransformOpenAIAssistantsFilePath(OpenAIFilePathContentItem openAIFilePath, List<FileMapping> newFileMappings)
         {
-            newFileMappings.Add(new FileMapping
+            if (!string.IsNullOrWhiteSpace(openAIFilePath.FileId))
             {
-                FoundationaLLMObjectId = $"/instances/{_instanceId}/providers/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{AzureOpenAIResourceTypeNames.FileUserContexts}/{_fileUserContextName}/{AzureOpenAIResourceTypeNames.FilesContent}/{openAIFilePath.FileId}",
-                OriginalFileName = openAIFilePath.FileId!,
-                ContentType = "application/octet-stream",
-                OpenAIFileId = openAIFilePath.FileId!,
-                Generated = true,
-                OpenAIFileGeneratedOn = DateTimeOffset.UtcNow
-            });
-            openAIFilePath.FileUrl = $"{{{{fllm_base_url}}}}/instances/{_instanceId}/files/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{openAIFilePath.FileId}";
+                // Empty file ids occur when dealing with file search annotations.
+                // Looks like the assistant is providing "internal" RAG pattern references to vectorized text chunks that were included in the context.
+                // In this case, we should not generate a file mapping as it will result in invalid file urls.
+                newFileMappings.Add(new FileMapping
+                {
+                    FoundationaLLMObjectId = $"/instances/{_instanceId}/providers/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{AzureOpenAIResourceTypeNames.FileUserContexts}/{_fileUserContextName}/{AzureOpenAIResourceTypeNames.FilesContent}/{openAIFilePath.FileId}",
+                    OriginalFileName = openAIFilePath.FileId!,
+                    ContentType = "application/octet-stream",
+                    OpenAIFileId = openAIFilePath.FileId!,
+                    Generated = true,
+                    OpenAIFileGeneratedOn = DateTimeOffset.UtcNow
+                });
+                openAIFilePath.FileUrl = $"{{{{fllm_base_url}}}}/instances/{_instanceId}/files/{ResourceProviderNames.FoundationaLLM_AzureOpenAI}/{openAIFilePath.FileId}";
+            }
+            else
+                openAIFilePath.FileUrl = null;
+
             return openAIFilePath;
         }
 
@@ -231,9 +243,18 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             openAITextMessage.Annotations = openAITextMessage.Annotations
                 .Select(a => TransformOpenAIAssistantsFilePath(a, newFileMappings))
                 .ToList();
-            var sandboxPlaceholders = openAITextMessage.Annotations.ToDictionary(
-                a => a.Text!,
-                a => $"{{{{fllm_base_url}}}}{a.FileUrl!}");
+
+            #region Replace code interpreter placeholders with file urls
+
+            // Code interpreter placeholders are assumed to be in the form of (sandbox:file-id).
+            // They are expected to be unique and have a valid corresponding file url.
+            var codeInterpreterPlaceholders = openAITextMessage.Annotations
+                .Where(a => !string.IsNullOrWhiteSpace(a.FileUrl) && !string.IsNullOrWhiteSpace(a.Text))
+                .DistinctBy(a => a.Text)
+                .ToDictionary(
+                    a => a.Text!,
+                    a => $"{{{{fllm_base_url}}}}{a.FileUrl}");
+            
 
             var input = openAITextMessage.Value!;
             var regex = new Regex(@"\(sandbox:[^)]*\)");
@@ -250,7 +271,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                 var startIndex = previousMatch == null ? 0 : previousMatch.Index + previousMatch.Length;
                 output.Add(input.Substring(startIndex, match.Index - startIndex));
                 var token = input.Substring(match.Index, match.Length);
-                if (sandboxPlaceholders.TryGetValue(token, out var replacement))
+                if (codeInterpreterPlaceholders.TryGetValue(token, out var replacement))
                     output.Add(replacement);
                 else
                     output.Add(token);
@@ -261,6 +282,25 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             output.Add(input.Substring(previousMatch!.Index + previousMatch.Length));
 
             openAITextMessage.Value = string.Join("", output);
+
+            #endregion
+
+            #region Replace file search placeholders with empty strings
+
+            // File search placeholders are assumed to be unique and not have a corresponding file url.
+            var fileSearchPlaceholders = openAITextMessage.Annotations
+                .Where(a => string.IsNullOrWhiteSpace(a.FileUrl) && !string.IsNullOrWhiteSpace(a.Text))
+                .DistinctBy(a => a.Text)
+                .Select(a => a.Text!)
+                .ToList();
+
+            foreach (var fileSearchPlaceholder in fileSearchPlaceholders)
+            {
+                openAITextMessage.Value = openAITextMessage.Value.Replace(fileSearchPlaceholder, string.Empty);
+            }
+
+            #endregion
+
             return openAITextMessage;
         }
 

--- a/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/KnowledgeManagementOrchestration.cs
@@ -253,7 +253,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                 .DistinctBy(a => a.Text)
                 .ToDictionary(
                     a => a.Text!,
-                    a => $"{{{{fllm_base_url}}}}{a.FileUrl}");
+                    a => $"{a.FileUrl}");
             
 
             var input = openAITextMessage.Value!;


### PR DESCRIPTION
# Handle annotations generated by the file search tool

## Details on the issue fix or feature implementation

- Incorrect handling of files generated with the same ID as attachments by OpenAI
- Incorrect handling of annotations with identical File Ids in TransformOpenAIAssistantsTextMessage

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
