### PR TITLE
(0.8.0) Fix issue with missing resource references in resource provider

### DIFF
--- a/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
+++ b/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
@@ -158,8 +158,11 @@ namespace FoundationaLLM.Attachment.ResourceProviders
                     StatusCodes.Status400BadRequest);
             if (resourceFilter.ObjectIDs is {Count: > 0})
             {
+                var resourceNames = resourceFilter.ObjectIDs
+                    .Select(id => this.GetResourcePath(id, false).ResourceTypeInstances.Last().ResourceId!)
+                    .ToList();
                 var filteredReferences =
-                    await _resourceReferenceStore!.GetResourceReferences(r => !string.IsNullOrWhiteSpace(r.ObjectId) && resourceFilter.ObjectIDs.Contains(r.ObjectId));
+                    await _resourceReferenceStore!.GetResourceReferences(resourceNames);
 
                 return filteredReferences.Select(r => new AttachmentDetail
                 {

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderResourceReferenceStore`1.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderResourceReferenceStore`1.cs
@@ -114,12 +114,40 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         /// </summary>
         /// <param name="predicate">The predicate to filter the resource references.</param>
         /// <returns></returns>
+        /// <remarks>
+        /// This method is not safe in scenarios where multiple instances of a resource provider are running at the same time.
+        /// </remarks>
         public async Task<IEnumerable<T>> GetResourceReferences(Func<T, bool> predicate)
         {
             await _lock.WaitAsync();
             try
             {
-                return _resourceReferences.Values.Where(predicate);
+                return _resourceReferences.Values.Where(rr => predicate(rr) && !rr.Deleted);
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Gets the resource references for the specified resource names.
+        /// </summary>
+        /// <param name="resourceNames">The list of resource names for which the references should be retrieved.</param>
+        /// <returns></returns>
+        public async Task<IEnumerable<T>> GetResourceReferences(IEnumerable<string> resourceNames)
+        {
+            await _lock.WaitAsync();
+            try
+            {
+                if (resourceNames.Except(_resourceReferences.Keys).Any())
+                {
+                    // Some of the resource references are missing, so we need to load them.
+                    await LoadAndMergeResourceReferences();
+                }
+                return resourceNames
+                    .Select(rn => _resourceReferences[rn])
+                    .Where(rr => !rr.Deleted);
             }
             finally
             {
@@ -131,12 +159,15 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         /// Gets all resource references in the store.
         /// </summary>
         /// <returns>A <see cref="List{T}"/> contain</returns>
+        /// <remarks>
+        /// This method is not safe in scenarios where multiple instances of a resource provider are running at the same time.
+        /// </remarks>
         public async Task<List<T>> GetAllResourceReferences()
         {
             await _lock.WaitAsync();
             try
             {
-                return [.. _resourceReferences.Values];
+                return [.. _resourceReferences.Values.Where(rr => !rr.Deleted)];
             }
             finally
             {

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -634,6 +634,13 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
             return null;
         }
 
+        /// <summary>
+        /// Loads a resource based on its name.
+        /// </summary>
+        /// <typeparam name="T">The type of resource to load.</typeparam>
+        /// <param name="resourceName">The name of the resource.</param>
+        /// <returns>The loaded resource.</returns>
+        /// <exception cref="ResourceProviderException"></exception>
         protected async Task<T?> LoadResource<T>(string resourceName) where T : ResourceBase
         {
             try


### PR DESCRIPTION
# Fix issue with missing resource references in resource provider

## The issue or feature being addressed

File no longer exists displayed after a file is uploaded

## Details on the issue fix or feature implementation

Attachment resource provider needs to trigger reload of references

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
