### PR TITLE
(0.8.1) Allow adding virtual user to User Portal API calls

### DIFF
--- a/src/dotnet/Common/Services/DependencyInjection.cs
+++ b/src/dotnet/Common/Services/DependencyInjection.cs
@@ -34,7 +34,7 @@ namespace FoundationaLLM
                         {
                             policy.AllowAnyOrigin();
                             policy.WithHeaders("DNT", "Keep-Alive", "User-Agent", "X-Requested-With", "If-Modified-Since",
-                                "Cache-Control", "Content-Type", "Range", "Authorization");
+                                "Cache-Control", "Content-Type", "Range", "Authorization", "X-User-Identity");
                             policy.AllowAnyMethod();
                         });
                 });

--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -28,6 +28,9 @@
 					<template v-else>
 						<span>Please select a session</span>
 					</template>
+					<template v-if="virtualUser">
+						<span style="margin-left: 10px;">{{ virtualUser }}</span>
+					</template>
 				</div>
 			</div>
 
@@ -86,6 +89,7 @@ export default {
 			agentSelection: null as AgentDropdownOption | null,
 			agentOptions: [] as AgentDropdownOption[],
 			agentOptionsGroup: [] as AgentDropdownOptionsGroup[],
+			virtualUser: null as string | null,
 		};
 	},
 
@@ -124,6 +128,7 @@ export default {
 		const publicAgentOptions = this.agentOptions;
 		const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
 		const noAgentOptions = [{ label: 'None', value: null, disabled: true }];
+		this.virtualUser = await this.$appStore.getVirtualUser();
 
 		this.agentOptionsGroup.push({
 			label: '',

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -370,5 +370,9 @@ export const useAppStore = defineStore('app', {
 				}
 			});
 		},
+
+		async getVirtualUser() {
+			return await api.getVirtualUser();
+		}
 	},
 });


### PR DESCRIPTION
# (0.8.1) Allow adding virtual user to User Portal API calls

## The issue or feature being addressed

For users configured to allow substitute virtual users in their Core API requests, this feature enables them to set the virtual user for viewing chat sessions after load tests via a `virtual_user` querystring parameter.

## Details on the issue fix or feature implementation

Displays the currently set virtual user in the nav header of the User Portal. Change the virtual user by passing in a new value in the querystring parameter or by refreshing the browser.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
