### PR TITLE
Fix typo in action name in the Attachments Contributor role definition

### DIFF
--- a/src/dotnet/Common/Constants/Data/RoleDefinitions.json
+++ b/src/dotnet/Common/Constants/Data/RoleDefinitions.json
@@ -145,7 +145,7 @@
 					"FoundationaLLM.AzureOpenAI/fileUserContexts/read",
 					"FoundationaLLM.AzureOpenAI/fileUserContexts/write",
 					"FoundationaLLM.Configuration/apiEndpointConfigurations/read",
-					"FoundationaLLM.AIModels/aiModels/read"
+					"FoundationaLLM.AIModel/aiModels/read"
 				],
 				"not_actions": [],
 				"data_actions": [],

--- a/src/dotnet/Common/Templates/RoleDefinitions.cs
+++ b/src/dotnet/Common/Templates/RoleDefinitions.cs
@@ -166,7 +166,7 @@ namespace FoundationaLLM.Common.Models.Authorization
                                     "FoundationaLLM.AzureOpenAI/fileUserContexts/read",
                                     "FoundationaLLM.AzureOpenAI/fileUserContexts/write",
                                     "FoundationaLLM.Configuration/apiEndpointConfigurations/read",
-                                    "FoundationaLLM.AIModels/aiModels/read",],
+                                    "FoundationaLLM.AIModel/aiModels/read",],
                                 NotActions = [],
                                 DataActions = [],
                                 NotDataActions = [],

--- a/tests/dotnet/Orchestration.Tests/Orchestration/KnowledgeManagementOrchestrationTests.cs
+++ b/tests/dotnet/Orchestration.Tests/Orchestration/KnowledgeManagementOrchestrationTests.cs
@@ -29,7 +29,9 @@ namespace FoundationaLLM.Orchestration.Tests.Orchestration
                 _orchestrationService,
                 _logger,
                 null,
-                false);
+                null,
+                false,
+                string.Empty);
         }
 
         [Fact]


### PR DESCRIPTION
# Fix typo in action name in the Attachments Contributor role definition

## The issue or feature being addressed

The `FoundationaLLM.AIModel` resource provider name is misspelled in the `Attachments Contributor` role definition.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
