### PR TITLE
Fixes an issue with the Azure OpenAI FileId filtering predicate

### DIFF
--- a/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
+++ b/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
@@ -196,7 +196,7 @@ namespace FoundationaLLM.AzureOpenAI.ResourceProviders
         {
             var fileUserContext = await LoadFileUserContext(fileUserContextName);
             var fileMapping = fileUserContext.Files.Values
-                .SingleOrDefault(f => f.OpenAIFileId == openAIFileId)
+                .SingleOrDefault(f => !f.Generated && f.OpenAIFileId == openAIFileId)
                     ?? throw new ResourceProviderException(
                         $"Could not find the file {openAIFileId} in the {fileUserContextName} file user context.",
                         StatusCodes.Status404NotFound);

--- a/src/dotnet/Common/Models/ResourceProviders/AzureOpenAI/FileMapping.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/AzureOpenAI/FileMapping.cs
@@ -10,7 +10,7 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.AzureOpenAI
         /// <summary>
         /// The FoundationaLLM.Attachment resource object id.
         /// </summary>
-        [JsonPropertyName("foundationallm_attachment_object_id")]
+        [JsonPropertyName("foundationallm_object_id")]
         public required string FoundationaLLMObjectId { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# Fixes an issue with the Azure OpenAI FileId filtering predicate

## The issue or feature being addressed

The filtering on the FileId value in the `FoundationaLLM.AzureOpenAI` resource provider is not specific enough.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
