### PR TITLE
Fix condition with selection predicate in AzureOpenAI resource provider

### DIFF
--- a/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
+++ b/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
@@ -196,7 +196,7 @@ namespace FoundationaLLM.AzureOpenAI.ResourceProviders
         {
             var fileUserContext = await LoadFileUserContext(fileUserContextName);
             var fileMapping = fileUserContext.Files.Values
-                .SingleOrDefault(f => !f.Generated && f.OpenAIFileId == openAIFileId)
+                .SingleOrDefault(f => f.Generated && f.OpenAIFileId == openAIFileId)
                     ?? throw new ResourceProviderException(
                         $"Could not find the file {openAIFileId} in the {fileUserContextName} file user context.",
                         StatusCodes.Status404NotFound);


### PR DESCRIPTION
# Fix condition with selection predicate in AzureOpenAI resource provider

## The issue or feature being addressed

The selection predicate ignores files that are generated by OpenAI without being uploaded as attachments.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
