### PR TITLE
Explicitly setting OpenAI roles on OpenAI instance for Quick-Start and Standard

### DIFF
--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -611,11 +611,12 @@ module cosmosRoles './shared/sqlRoleAssignments.bicep' = [
   }
 ]
 
-module openAiRoles './shared/roleAssignments.bicep' = [
+module openAiRoles './shared/openAiRoleAssignments.bicep' = [
   for target in openAiRoleTargets: {
     scope: rg
     name: '${target}-openai-roles-${timestamp}'
     params: {
+      targetOpenAiName: openAiInstance.name
       principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
       roleDefinitionNames: [
         'Cognitive Services OpenAI User'
@@ -625,11 +626,12 @@ module openAiRoles './shared/roleAssignments.bicep' = [
   }
 ]
 
-module openAiContribRole './shared/roleAssignments.bicep' = [
+module openAiContribRole './shared/openAiRoleAssignments.bicep' = [
   for target in openAiContribRoleTargets: {
     scope: rg
     name: '${target}-openai-contrib-${timestamp}'
     params: {
+      targetOpenAiName: openAiInstance.name
       principalId: acaServices[indexOf(serviceNames, target)].outputs.miPrincipalId
       roleDefinitionNames: [
         'Cognitive Services OpenAI Contributor'

--- a/deploy/quick-start/infra/shared/openAiRoleAssignments.bicep
+++ b/deploy/quick-start/infra/shared/openAiRoleAssignments.bicep
@@ -1,0 +1,44 @@
+// See: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+param principalId string
+param roleDefinitionIds object = {}
+param principalType string = 'ServicePrincipal'
+param roleDefinitionNames array = []
+param targetOpenAiName string
+
+/** Locals **/
+var roleDefinitionsToCreate = union(selectedRoleDefinitions, items(roleDefinitionIds))
+var selectedRoleDefinitions = filter(items(roleDefinitions), (item) => contains(roleDefinitionNames, item.key))
+var roleDefinitions = {
+  'Cognitive Services OpenAI Contributor': 'a001fd3d-188f-4b5d-821b-7da978bf7442'
+  'Cognitive Services OpenAI User':        '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+  'Cognitive Services User':               'a97b65f3-24c7-4388-baec-2e87135dc908'
+  'Contributor':                           'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  'Reader':                                'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+}
+
+var roleAssignmentsToCreate = [
+  for roleDefinitionId in roleDefinitionsToCreate: {
+    name: guid(principalId, resourceGroup().id, roleDefinitionId.value)
+    roleDefinitionId: roleDefinitionId.value
+  }
+]
+
+resource targetOpenAi 'Microsoft.CognitiveServices/accounts@2024-04-01-preview' existing = {
+  name: targetOpenAiName
+}
+
+/** Resources **/
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [
+  for roleAssignmentToCreate in roleAssignmentsToCreate: {
+    scope: targetOpenAi
+    name: roleAssignmentToCreate.name
+    properties: {
+      principalType: principalType
+      principalId: principalId
+      roleDefinitionId: subscriptionResourceId(
+        'Microsoft.Authorization/roleDefinitions',
+        roleAssignmentToCreate.roleDefinitionId
+      )
+    }
+  }
+]

--- a/deploy/standard/infra/app-rg.bicep
+++ b/deploy/standard/infra/app-rg.bicep
@@ -31,6 +31,8 @@ param logAnalyticsWorkspaceResourceId string
 @description('Networking Resource Group Name')
 param networkingResourceGroupName string
 
+param openAiName string
+
 @description('OPS Resource Group name')
 param opsResourceGroupName string
 
@@ -434,10 +436,11 @@ module searchIndexDataReaderWorkerRole 'modules/utility/roleAssignments.bicep' =
   }
 }
 
-module cognitiveServicesOpenAiUserRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srBackend[indexOf(vecServiceNames, 'vectorization-api')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
@@ -445,10 +448,11 @@ module cognitiveServicesOpenAiUserRole 'modules/utility/roleAssignments.bicep' =
   }
 }
 
-module cognitiveServicesOpenAiUserWorkerRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserWorkerRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserWorkerRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srBackend[indexOf(backendServiceNames, 'vectorization-job')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
@@ -456,10 +460,11 @@ module cognitiveServicesOpenAiUserWorkerRole 'modules/utility/roleAssignments.bi
   }
 }
 
-module cognitiveServicesOpenAiUserGatewayRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserGatewayRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserGatewayRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srBackend[indexOf(backendServiceNames, 'gateway-api')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI Contributor': 'a001fd3d-188f-4b5d-821b-7da978bf7442'
@@ -467,10 +472,11 @@ module cognitiveServicesOpenAiUserGatewayRole 'modules/utility/roleAssignments.b
   }
 }
 
-module cognitiveServicesOpenAiUserCoreRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserCoreRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserCoreRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srCoreApi[0].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
@@ -479,10 +485,11 @@ module cognitiveServicesOpenAiUserCoreRole 'modules/utility/roleAssignments.bice
   }
 }
 
-module cognitiveServicesOpenAiUserMgmtRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserMgmtRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserMgmtRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srManagementApi[0].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI Contributor': 'a001fd3d-188f-4b5d-821b-7da978bf7442'
@@ -490,10 +497,11 @@ module cognitiveServicesOpenAiUserMgmtRole 'modules/utility/roleAssignments.bice
   }
 }
 
-module cognitiveServicesOpenAiUserLangChainRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserLangChainRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserLangChainRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srBackend[indexOf(backendServiceNames, 'langchain-api')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
@@ -501,10 +509,11 @@ module cognitiveServicesOpenAiUserLangChainRole 'modules/utility/roleAssignments
   }
 }
 
-module cognitiveServicesOpenAiUserSemanticKernelRole 'modules/utility/roleAssignments.bicep' = {
+module cognitiveServicesOpenAiUserSemanticKernelRole 'modules/utility/openAiRoleAssignments.bicep' = {
   name: 'cognitiveServicesOpenAiUserSemKernelRole-${timestamp}'
   scope: resourceGroup(openAiResourceGroupName)
   params: {
+    targetOpenAiName: openAiName
     principalId: srBackend[indexOf(backendServiceNames, 'semantic-kernel-api')].outputs.servicePrincipalId
     roleDefinitionIds: {
       'Cognitive Services OpenAI User': '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'

--- a/deploy/standard/infra/main.bicep
+++ b/deploy/standard/infra/main.bicep
@@ -109,6 +109,7 @@ module app 'app-rg.bicep' = {
     logAnalyticsWorkspaceResourceId: ops.outputs.logAnalyticsWorkspaceId
     networkingResourceGroupName: resourceGroups.net
     openAiResourceGroupName: resourceGroups.oai
+    openAiName: openai.outputs.azureOpenAiName
     opsResourceGroupName: resourceGroups.ops
     project: project
     services: services

--- a/deploy/standard/infra/modules/utility/openAiRoleAssignments.bicep
+++ b/deploy/standard/infra/modules/utility/openAiRoleAssignments.bicep
@@ -1,0 +1,44 @@
+// See: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+param principalId string
+param roleDefinitionIds object = {}
+param principalType string = 'ServicePrincipal'
+param roleDefinitionNames array = []
+param targetOpenAiName string
+
+/** Locals **/
+var roleDefinitionsToCreate = union(selectedRoleDefinitions, items(roleDefinitionIds))
+var selectedRoleDefinitions = filter(items(roleDefinitions), (item) => contains(roleDefinitionNames, item.key))
+var roleDefinitions = {
+  'Cognitive Services OpenAI Contributor': 'a001fd3d-188f-4b5d-821b-7da978bf7442'
+  'Cognitive Services OpenAI User':        '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+  'Cognitive Services User':               'a97b65f3-24c7-4388-baec-2e87135dc908'
+  'Contributor':                           'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  'Reader':                                'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+}
+
+var roleAssignmentsToCreate = [
+  for roleDefinitionId in roleDefinitionsToCreate: {
+    name: guid(principalId, resourceGroup().id, roleDefinitionId.value)
+    roleDefinitionId: roleDefinitionId.value
+  }
+]
+
+resource targetOpenAi 'Microsoft.CognitiveServices/accounts@2024-04-01-preview' existing = {
+  name: targetOpenAiName
+}
+
+/** Resources **/
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [
+  for roleAssignmentToCreate in roleAssignmentsToCreate: {
+    scope: targetOpenAi
+    name: roleAssignmentToCreate.name
+    properties: {
+      principalType: principalType
+      principalId: principalId
+      roleDefinitionId: subscriptionResourceId(
+        'Microsoft.Authorization/roleDefinitions',
+        roleAssignmentToCreate.roleDefinitionId
+      )
+    }
+  }
+]

--- a/deploy/standard/infra/openai-rg.bicep
+++ b/deploy/standard/infra/openai-rg.bicep
@@ -111,4 +111,5 @@ output azureContentSafetyEndpoint string = contentSafety.outputs.endpoint
 output azureOpenAiEndpoint string = azureOpenAiEndpoint
 output azureOpenAiId string = azureOpenAiId
 output azureOpenAiResourceGroup string = openAiInstance.resourceGroup
+output azureOpenAiName string = openAiInstance.name
   


### PR DESCRIPTION
# Explicitly setting OpenAI roles on OpenAI instance for Quick-Start and Standard

## Details on the issue fix or feature implementation

Explicitly setting OpenAI roles on OpenAI instance for Quick-Start and Standard

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
