### PR TITLE
Add instance status endpoints to Python APIs

### DIFF
--- a/src/python/AgentHubAPI/app/main.py
+++ b/src/python/AgentHubAPI/app/main.py
@@ -18,7 +18,7 @@ config = get_config()
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',
     summary='API for retrieving Agent metadata',
-    description="""The FoundationaLLM AgentHubAPI is a wrapper around AgentHub
+    description=f"""The FoundationaLLM {API_NAME} is a wrapper around AgentHub
         functionality contained in the foundationallm Python SDK.""",
     version='1.0.0',
     contact={

--- a/src/python/AgentHubAPI/app/routers/status.py
+++ b/src/python/AgentHubAPI/app/routers/status.py
@@ -7,25 +7,50 @@ from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM
 from app.dependencies import API_NAME
 
 router = APIRouter(
-    prefix='/status',
+    prefix='',
     tags=['status'],
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('')
+@router.get(
+    '/status',
+    summary = f'Get the status of the {API_NAME}.'
+)
 async def get_status():
-    """
-    Retrieves the status of the API.
+    f"""
+    Get the status of the {API_NAME}.
     
     Returns
     -------
-    JSON
-        Object containing the name, instance, version, and status of the API.
+    str
+        A JSON object containing the name, version, and status of the {API_NAME}.
     """    
-    statusMessage = {
+    status_message = {
         "name": API_NAME,
-        "instance": os.environ[HOSTNAME],
+        "instance_name": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"
     }
-    return statusMessage
+    return status_message
+
+@router.get(
+    '/instances/{instance_id}/status',
+    summary = f'Get the status of a specified instance of the {API_NAME}.'
+)
+async def get_instance_status(instance_id: str):
+    f"""
+    Get the status of a specified instance of the {API_NAME}.
+    
+    Returns
+    -------
+    str
+        Object containing the name, instance, version, and status of the FoundationaLLM instance of the {API_NAME}.
+    """    
+    instance_status_message = {
+        "name": API_NAME,
+        "instance_id": instance_id,
+        "instance_name": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
+    }
+    return instance_status_message

--- a/src/python/DataSourceHubAPI/app/main.py
+++ b/src/python/DataSourceHubAPI/app/main.py
@@ -18,7 +18,7 @@ config = get_config()
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',
     summary='API for retrieving DataSource metadata',
-    description="""The FoundationaLLM DataSourceHubAPI is a wrapper around DataSourceHub
+    description=f"""The FoundationaLLM {API_NAME} is a wrapper around DataSourceHub
                 functionality contained in the foundationallm Python SDK.""",
     version='1.0.0',
     contact={

--- a/src/python/DataSourceHubAPI/app/routers/status.py
+++ b/src/python/DataSourceHubAPI/app/routers/status.py
@@ -7,25 +7,50 @@ from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM
 from app.dependencies import API_NAME
 
 router = APIRouter(
-    prefix='/status',
+    prefix='',
     tags=['status'],
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('')
+@router.get(
+    '/status',
+    summary = f'Get the status of the {API_NAME}.'
+)
 async def get_status():
-    """
-    Retrieves the status of the API.
+    f"""
+    Get the status of the {API_NAME}.
     
     Returns
     -------
-    JSON
-        Object containing the name, instance, version, and status of the API.
+    str
+        A JSON object containing the name, version, and status of the {API_NAME}.
     """    
-    statusMessage = {
+    status_message = {
         "name": API_NAME,
-        "instance": os.environ[HOSTNAME],
+        "instance_name": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"
     }
-    return statusMessage
+    return status_message
+
+@router.get(
+    '/instances/{instance_id}/status',
+    summary = f'Get the status of a specified instance of the {API_NAME}.'
+)
+async def get_instance_status(instance_id: str):
+    f"""
+    Get the status of a specified instance of the {API_NAME}.
+    
+    Returns
+    -------
+    str
+        Object containing the name, instance, version, and status of the FoundationaLLM instance of the {API_NAME}.
+    """    
+    instance_status_message = {
+        "name": API_NAME,
+        "instance_id": instance_id,
+        "instance_name": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
+    }
+    return instance_status_message

--- a/src/python/GatekeeperIntegrationAPI/app/main.py
+++ b/src/python/GatekeeperIntegrationAPI/app/main.py
@@ -13,7 +13,7 @@ from app.routers import (
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',
     summary='API for extending the FoundationaLLM GatekeeperAPI',
-    description="""The FoundationaLLM GatekeeperIntegrationAPI is a service used to extend the
+    description=f"""The FoundationaLLM {API_NAME} is a service used to extend the
             FoundationaLLM GatekeeperAPI with extra capabilities""",
     version='1.0.0',
     contact={

--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -3,29 +3,54 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
-from foundationallm.integration.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 from app.dependencies import API_NAME
 
 router = APIRouter(
-    prefix='/status',
+    prefix='',
     tags=['status'],
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('')
+@router.get(
+    '/status',
+    summary = f'Get the status of the {API_NAME}.'
+)
 async def get_status():
-    """
-    Retrieves the status of the API.
+    f"""
+    Get the status of the {API_NAME}.
     
     Returns
     -------
-    JSON
-        Object containing the name, instance, version, and status of the API.
+    str
+        A JSON object containing the name, version, and status of the {API_NAME}.
     """    
-    statusMessage = {
+    status_message = {
         "name": API_NAME,
-        "instance": os.environ[HOSTNAME],
+        "instance_name": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"
     }
-    return statusMessage
+    return status_message
+
+@router.get(
+    '/instances/{instance_id}/status',
+    summary = f'Get the status of a specified instance of the {API_NAME}.'
+)
+async def get_instance_status(instance_id: str):
+    f"""
+    Get the status of a specified instance of the {API_NAME}.
+    
+    Returns
+    -------
+    str
+        Object containing the name, instance, version, and status of the FoundationaLLM instance of the {API_NAME}.
+    """    
+    instance_status_message = {
+        "name": API_NAME,
+        "instance_id": instance_id,
+        "instance_name": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
+    }
+    return instance_status_message

--- a/src/python/LangChainAPI/app/main.py
+++ b/src/python/LangChainAPI/app/main.py
@@ -19,7 +19,7 @@ Telemetry.configure_monitoring(config, f'FoundationaLLM:APIEndpoints:{API_NAME}:
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',
     summary='API for interacting with large language models using the LangChain orchestrator.',
-    description="""The FoundationaLLM LangChainAPI is a wrapper around LangChain functionality
+    description=f"""The FoundationaLLM {API_NAME} is a wrapper around LangChain functionality
                 contained in the foundationallm.core Python SDK.""",
     version='1.0.0',
     contact={

--- a/src/python/LangChainAPI/app/routers/status.py
+++ b/src/python/LangChainAPI/app/routers/status.py
@@ -7,26 +7,50 @@ from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM
 from app.dependencies import API_NAME
 
 router = APIRouter(
-    prefix='/instances/{instance_id}/status',
+    prefix='',
     tags=['status'],
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('')
-async def get_status(instance_id: str):
-    """
-    Retrieves the status of the API.
+@router.get(
+    '/status',
+    summary = f'Get the status of the {API_NAME}.'
+)
+async def get_status():
+    f"""
+    Get the status of the {API_NAME}.
     
     Returns
     -------
-    JSON
-        Object containing the name, instance, version, and status of the API.
+    str
+        A JSON object containing the name, version, and status of the {API_NAME}.
     """    
-    statusMessage = {
+    status_message = {
+        "name": API_NAME,
+        "instance_name": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
+    }
+    return status_message
+
+@router.get(
+    '/instances/{instance_id}/status',
+    summary = f'Get the status of a specified instance of the {API_NAME}.'
+)
+async def get_instance_status(instance_id: str):
+    f"""
+    Get the status of a specified instance of the {API_NAME}.
+    
+    Returns
+    -------
+    str
+        Object containing the name, instance, version, and status of the FoundationaLLM instance of the {API_NAME}.
+    """    
+    instance_status_message = {
         "name": API_NAME,
         "instance_id": instance_id,
         "instance_name": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"
     }
-    return statusMessage
+    return instance_status_message

--- a/src/python/PromptHubAPI/app/main.py
+++ b/src/python/PromptHubAPI/app/main.py
@@ -18,7 +18,7 @@ config = get_config()
 app = FastAPI(
     title=f'FoundationaLLM {API_NAME}',
     summary='API for retrieving Prompt metadata',
-    description="""The FoundationaLLM PromptHubAPI is a wrapper around PromptHub
+    description=f"""The FoundationaLLM {API_NAME} is a wrapper around PromptHub
                 functionality contained in the foundationallm.core Python SDK.""",
     version='1.0.0',
     contact={

--- a/src/python/PromptHubAPI/app/routers/status.py
+++ b/src/python/PromptHubAPI/app/routers/status.py
@@ -7,25 +7,50 @@ from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM
 from app.dependencies import API_NAME
 
 router = APIRouter(
-    prefix='/status',
+    prefix='',
     tags=['status'],
     responses={404: {'description':'Not found'}}
 )
 
-@router.get('')
+@router.get(
+    '/status',
+    summary = f'Get the status of the {API_NAME}.'
+)
 async def get_status():
-    """
-    Retrieves the status of the API.
+    f"""
+    Get the status of the {API_NAME}.
     
     Returns
     -------
-    JSON
-        Object containing the name, instance, version, and status of the API.
+    str
+        A JSON object containing the name, version, and status of the {API_NAME}.
     """    
-    statusMessage = {
+    status_message = {
         "name": API_NAME,
-        "instance": os.environ[HOSTNAME],
+        "instance_name": os.environ[HOSTNAME],
         "version": os.environ[FOUNDATIONALLM_VERSION],
         "status": "ready"
     }
-    return statusMessage
+    return status_message
+
+@router.get(
+    '/instances/{instance_id}/status',
+    summary = f'Get the status of a specified instance of the {API_NAME}.'
+)
+async def get_instance_status(instance_id: str):
+    f"""
+    Get the status of a specified instance of the {API_NAME}.
+    
+    Returns
+    -------
+    str
+        Object containing the name, instance, version, and status of the FoundationaLLM instance of the {API_NAME}.
+    """    
+    instance_status_message = {
+        "name": API_NAME,
+        "instance_id": instance_id,
+        "instance_name": os.environ[HOSTNAME],
+        "version": os.environ[FOUNDATIONALLM_VERSION],
+        "status": "ready"
+    }
+    return instance_status_message


### PR DESCRIPTION
# Add instance status endpoints to Python APIs

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

Adding a second status endpoint to each Python API to allow the status of a specified instance to be retrieved.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
