### PR TITLE
Upload dialog responsiveness

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -493,8 +493,8 @@ export default {
 }
 
 .upload-files-header {
-	width: 100%; /* Ensure the header is responsive */
-	max-width: 500px; /* Limit the max width */
+	width: 100%;
+	max-width: 500px;
 }
 
 .upload-files-header button {
@@ -577,19 +577,18 @@ export default {
 	flex-direction: row;
 	align-items: center;
 	gap: 10px;
-	overflow: hidden; /* Ensure the container doesn't overflow */
-	flex-shrink: 1; /* Allow the container to shrink if needed */
-	max-width: calc(100% - 50px); /* Ensure the container does not exceed the modal width */
+	overflow: hidden;
+	flex-shrink: 1;
+	max-width: calc(100% - 50px);
 
 	span {
 		font-weight: 600;
-		overflow: hidden; /* Hide overflowed text */
-		text-overflow: ellipsis; /* Show ellipsis for overflowed text */
-		white-space: wrap; /* Prevent text from wrapping to the next line */
-		flex-shrink: 1; /* Allow the text to shrink */
-		max-width: 80%; /* Allow the span to shrink, but will expand as needed */
-		min-width: 0; /* Ensures the element shrinks down to zero if needed */
-		/*width: 0; */
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: wrap;
+		flex-shrink: 1;
+		max-width: 80%;
+		min-width: 0;
 	}
 }
 

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -515,6 +515,7 @@ export default {
 	.upload-files-header button {
 		padding: 0.25rem 0.5rem;
 		margin-right: 0.25rem !important;
+		margin-bottom: 0.25rem !important;
 	}
 
 	.tooltip-component {

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -28,6 +28,7 @@
 				header="Upload File(s)"
 				modal
 				aria-label="File Upload Dialog"
+				style="max-width: 98%"
 			>
 				<FileUpload
 					ref="fileUpload"
@@ -492,7 +493,8 @@ export default {
 }
 
 .upload-files-header {
-	width: 500px;
+	width: 100%; /* Ensure the header is responsive */
+	max-width: 500px; /* Limit the max width */
 }
 
 .upload-files-header button {
@@ -574,6 +576,26 @@ export default {
 	flex-direction: row;
 	align-items: center;
 	gap: 10px;
+	overflow: hidden; /* Ensure the container doesn't overflow */
+	flex-shrink: 1; /* Allow the container to shrink if needed */
+	max-width: calc(100% - 50px); /* Ensure the container does not exceed the modal width */
+
+	span {
+		font-weight: 600;
+		overflow: hidden; /* Hide overflowed text */
+		text-overflow: ellipsis; /* Show ellipsis for overflowed text */
+		white-space: wrap; /* Prevent text from wrapping to the next line */
+		flex-shrink: 1; /* Allow the text to shrink */
+		max-width: 80%; /* Allow the span to shrink, but will expand as needed */
+		min-width: 0; /* Ensures the element shrinks down to zero if needed */
+		/*width: 0; */
+	}
+}
+
+@media only screen and (max-width: 405px) {
+	.file-upload-file_info div {
+		display: none;
+	}
 }
 
 .p-fileupload-content {


### PR DESCRIPTION
# Upload dialog responsiveness

## The issue or feature being addressed

Fixes issue with the file upload dialog expanding horizontally off the screen on mobile devices when file names are very long and cannot break onto new lines.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
