### PR TITLE
Handle latency-related issues when renaming and creating sessions

### DIFF
--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -22,9 +22,6 @@
 		</div>
 		<div class="chat-sidebar__section-header">
 			<h2 class="chat-sidebar__section-header__text">Chats</h2>
-			<!-- <button @click="handleAddSession">
-				<span class="text">+</span>
-			</button> -->
 			<VTooltip :auto-hide="false" :popper-triggers="['hover']">
 				<Button
 					icon="pi pi-plus"
@@ -32,6 +29,7 @@
 					severity="secondary"
 					aria-label="Add new chat"
 					@click="handleAddSession"
+					:disabled="createProcessing"
 				/>
 				<template #popper>Add new chat</template>
 			</VTooltip>
@@ -180,6 +178,7 @@ export default {
 			newSessionName: '' as string,
 			sessionToDelete: null as Session | null,
 			deleteProcessing: false,
+			createProcessing: false,
 		};
 	},
 
@@ -219,8 +218,21 @@ export default {
 		},
 
 		async handleAddSession() {
-			const newSession = await this.$appStore.addSession();
-			this.handleSessionSelected(newSession);
+			if (this.createProcessing) return;
+			this.createProcessing = true;
+			try {
+				const newSession = await this.$appStore.addSession();
+				this.handleSessionSelected(newSession);
+			} catch (error) {
+				this.$toast.add({
+					severity: 'error',
+					summary: 'Error',
+					detail: 'Could not create a new session. Please try again.',
+					life: 5000,
+				});
+			} finally {
+				this.createProcessing = false; // Re-enable the button
+			}
 		},
 
 		handleRenameSession() {
@@ -230,9 +242,19 @@ export default {
 
 		async handleDeleteSession() {
 			this.deleteProcessing = true;
-			await this.$appStore.deleteSession(this.sessionToDelete!);
-			this.sessionToDelete = null;
-			this.deleteProcessing = false;
+			try {
+				await this.$appStore.deleteSession(this.sessionToDelete!);
+				this.sessionToDelete = null;
+			} catch (error) {
+				this.$toast.add({
+					severity: 'error',
+					summary: 'Error',
+					detail: 'Could not delete the session. Please try again.',
+					life: 5000,
+				});
+			} finally {
+				this.deleteProcessing = false;
+			}
 		},
 
 		renameSessionInputKeydown(event: KeyboardEvent) {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -96,9 +96,7 @@ export const useAppStore = defineStore('app', {
 				this.sessions = sessions;
 			}
 
-			// If there are any renamed sessions, match them up with the sessions in this.sessions.
-			// If found, set the name in the matching session to the name in the renamed session.
-			// This is necessary due to a delay in the backend updating the session name.
+			// Handle inconsistencies in displaying the rename session due to potential delays in the backend updating the session name.
 			this.renamedSessions.forEach((renamedSession: Session) => {
 				const existingSession = this.sessions.find((s: Session) => s.id === renamedSession.id);
 				if (existingSession) {
@@ -135,7 +133,6 @@ export const useAppStore = defineStore('app', {
 
 			try {
 				await api.renameSession(sessionToRename.id, newSessionName);
-				// Add or update this renamed session in the list of renamed sessions.
 				const existingRenamedSession = this.renamedSessions.find(
 					(session: Session) => session.id === sessionToRename.id,
 				);

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -20,6 +20,7 @@ export const useAppStore = defineStore('app', {
 	state: () => ({
 		sessions: [] as Session[],
 		currentSession: null as Session | null,
+		renamedSessions: [] as Session[],
 		currentMessages: [] as Message[],
 		isSidebarClosed: false as boolean,
 		agents: [] as ResourceProviderGetResult<Agent>[],
@@ -94,6 +95,16 @@ export const useAppStore = defineStore('app', {
 			} else {
 				this.sessions = sessions;
 			}
+
+			// If there are any renamed sessions, match them up with the sessions in this.sessions.
+			// If found, set the name in the matching session to the name in the renamed session.
+			// This is necessary due to a delay in the backend updating the session name.
+			this.renamedSessions.forEach((renamedSession: Session) => {
+				const existingSession = this.sessions.find((s: Session) => s.id === renamedSession.id);
+				if (existingSession) {
+					existingSession.name = renamedSession.name;
+				}
+			});
 		},
 
 		async addSession(properties: ChatSessionProperties) {
@@ -124,6 +135,15 @@ export const useAppStore = defineStore('app', {
 
 			try {
 				await api.renameSession(sessionToRename.id, newSessionName);
+				// Add or update this renamed session in the list of renamed sessions.
+				const existingRenamedSession = this.renamedSessions.find(
+					(session: Session) => session.id === sessionToRename.id,
+				);
+				if (existingRenamedSession) {
+					existingRenamedSession.name = newSessionName;
+				} else {
+					this.renamedSessions = [{ ...sessionToRename, name: newSessionName }, ...this.renamedSessions];
+				}
 			} catch (error) {
 				existingSession.name = previousName;
 			}


### PR DESCRIPTION
# Handle latency-related issues when renaming and creating sessions

## The issue or feature being addressed

Due to latencies caused by backend processes related to chat session/conversation management, immediately creating a new session after renaming one could cause the old name to reappear in the sidebar. Also, rapidly selecting the option to create a new chat session in rapid succession leads to unpredictable results.

## Details on the issue fix or feature implementation

This PR adds front-end improvements to handle back-end latency issues.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
