### PR TITLE
Hide the current session name and show selected agent on mobile

### DIFF
--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -29,7 +29,7 @@
 			<div class="navbar__content__left">
 				<div class="navbar__content__left__item">
 					<template v-if="currentSession">
-						<span>{{ currentSession.name }}</span>
+						<span class="current_session_name">{{ currentSession.name }}</span>
 						<!-- <VTooltip :auto-hide="false" :popper-triggers="['hover']">
 							<Button
 								v-if="!$appConfigStore.isKioskMode"
@@ -318,10 +318,13 @@ export default {
 <style>
 @media only screen and (max-width: 545px) {
 	.dropdown--agent .p-dropdown-label {
-		display: none;
+		/* display: none; */
 	}
 	.dropdown--agent .p-dropdown-trigger {
 		height: 40px;
+	}
+	.current_session_name {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
# Hide the current session name and show selected agent on mobile

## The issue or feature being addressed

Users cannot see the selected agent name on a mobile device. This PR hides the current session name (which is displayed in the left-hand menu) and shows the agent's name in the agent selection dropdown.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
