### PR TITLE
Upload file type restrictions

### DIFF
--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -401,6 +401,14 @@
 				"value": "c, cpp, cs, css, doc, docx, html, java, js, json, md, pdf, php, pptx, py, rb, sh, tex, ts, txt",
 				"content_type": "",
 				"first_version": "0.8.0"
+			},
+			{
+				"name": "AllowedUploadFileExtensions",
+				"description": "The comma-separated list file extensions that users are allowed to upload to a conversation.",
+				"secret": "",
+				"value": "c, cpp, cs, css, csv, doc, docx, git, html, java, jpeg, jpg, js, json, md, pdf, php, png, pptx, py, rb, sh, tar, tex, ts, txt, xlsx, xml, zip",
+				"content_type": "",
+				"first_version": "0.8.0"
 			}
 		]
 	},

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -286,6 +286,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_CoreAPI_Configuration_AzureOpenAIAssistantsFileSearchFileExtensions =
             "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions setting.
+        /// <para>Value description:<br/>The comma-separated list file extensions that users are allowed to upload to a conversation.</para>
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_CoreAPI_Configuration_AllowedUploadFileExtensions =
+            "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions";
 
         #endregion
 
@@ -727,10 +734,6 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_AzureOpenAI_Essentials_APIKey =
             "FoundationaLLM:APIEndpoints:AzureOpenAI:Essentials:APIKey";
-
-        #endregion
-
-        #region FoundationaLLM:APIEndpoints:AzureAISearchVectorStore:Configuration
 
         #endregion
 

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -190,6 +190,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions",
+            "value": "c, cpp, cs, css, csv, doc, docx, git, html, java, jpeg, jpg, js, json, md, pdf, php, png, pptx, py, rb, sh, tar, tex, ts, txt, xlsx, xml, zip",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:Instance",
             "value": "https://login.microsoftonline.com/",
             "label": null,

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -359,7 +359,7 @@ export default {
 		},
 
 		fileSelected(event: any) {
-			const allowedFileTypes = this.$appConfigStore.azureOpenAIAssistantsFileSearchFileExtensions;
+			const allowedFileTypes = this.$appConfigStore.allowedUploadFileExtensions;
 			event.files.forEach((file: any, index) => {
 				if (file.size > 536870912) {
 					this.$toast.add({

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -359,12 +359,26 @@ export default {
 		},
 
 		fileSelected(event: any) {
+			const allowedFileTypes = this.$appConfigStore.azureOpenAIAssistantsFileSearchFileExtensions;
 			event.files.forEach((file: any, index) => {
-				if (file.size > 512000000) {
+				if (file.size > 536870912) {
 					this.$toast.add({
 						severity: 'error',
 						summary: 'Error',
 						detail: 'File size exceeds the limit of 512MB.',
+						life: 5000,
+					});
+					event.files.splice(index, 1);
+				}
+				
+				if (!allowedFileTypes || allowedFileTypes === '') {
+					return;
+				}
+				if (!allowedFileTypes.includes(file.name.split('.').pop())) {
+					this.$toast.add({
+						severity: 'error',
+						summary: 'Error',
+						detail: `File type not supported. File: ${file.name}`,
 						life: 5000,
 					});
 					event.files.splice(index, 1);

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -33,6 +33,7 @@ const allowedKeys = [
 	'FoundationaLLM:UserPortal:Authentication:Entra:TenantId',
 	'FoundationaLLM:UserPortal:Authentication:Entra:Scopes',
 	'FoundationaLLM:UserPortal:Authentication:Entra:CallbackPath',
+	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions',
 ];
 
 export default defineEventHandler(async (event) => {

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -33,7 +33,7 @@ const allowedKeys = [
 	'FoundationaLLM:UserPortal:Authentication:Entra:TenantId',
 	'FoundationaLLM:UserPortal:Authentication:Entra:Scopes',
 	'FoundationaLLM:UserPortal:Authentication:Entra:CallbackPath',
-	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions',
+	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 ];
 
 export default defineEventHandler(async (event) => {

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -28,6 +28,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		footerText: null,
 		instanceId: null,
 		agentIconUrl: null,
+		azureOpenAIAssistantsFileSearchFileExtensions: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -75,6 +76,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				footerText,
 				instanceId,
 				agentIconUrl,
+				azureOpenAIAssistantsFileSearchFileExtensions,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -102,6 +104,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe('FoundationaLLM:Branding:FooterText'),
 				getConfigValueSafe('FoundationaLLM:Instance:Id', '00000000-0000-0000-0000-000000000000'),
 				getConfigValueSafe('FoundationaLLM:Branding:AgentIconUrl', '~/assets/FLLM-Agent-Light.svg'),
+				getConfigValueSafe('FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -131,6 +134,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.footerText = footerText;
 			this.instanceId = instanceId;
 			this.agentIconUrl = agentIconUrl;
+			this.azureOpenAIAssistantsFileSearchFileExtensions = azureOpenAIAssistantsFileSearchFileExtensions;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -28,7 +28,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		footerText: null,
 		instanceId: null,
 		agentIconUrl: null,
-		azureOpenAIAssistantsFileSearchFileExtensions: null,
+		allowedUploadFileExtensions: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -76,7 +76,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				footerText,
 				instanceId,
 				agentIconUrl,
-				azureOpenAIAssistantsFileSearchFileExtensions,
+				allowedUploadFileExtensions,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -104,7 +104,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe('FoundationaLLM:Branding:FooterText'),
 				getConfigValueSafe('FoundationaLLM:Instance:Id', '00000000-0000-0000-0000-000000000000'),
 				getConfigValueSafe('FoundationaLLM:Branding:AgentIconUrl', '~/assets/FLLM-Agent-Light.svg'),
-				getConfigValueSafe('FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions'),
+				getConfigValueSafe('FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -134,7 +134,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.footerText = footerText;
 			this.instanceId = instanceId;
 			this.agentIconUrl = agentIconUrl;
-			this.azureOpenAIAssistantsFileSearchFileExtensions = azureOpenAIAssistantsFileSearchFileExtensions;
+			this.allowedUploadFileExtensions = allowedUploadFileExtensions;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;


### PR DESCRIPTION
# Upload file type restrictions

## The issue or feature being addressed

Prevent users from uploading unsupported file types.

## Details on the issue fix or feature implementation

* Add an App Config value (`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions` that lists the allowed upload file types.
* Enforce allowed file types by checking the extension when adding files to the uploader in the User Portal. If the App Config setting is missing or empty, all file types are allowed. Displays an error for each file whose type is not allowed.
* Correctly enforces the 512 MB file size limit by setting the bytes using binary instead of decimal notation.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
