### PR TITLE
Small fix returns an object once vectorization completes in Azure OpenAI

### DIFF
--- a/src/dotnet/Gateway/Services/GatewayCore.cs
+++ b/src/dotnet/Gateway/Services/GatewayCore.cs
@@ -342,6 +342,8 @@ namespace FoundationaLLM.Gateway.Services
                 else
                     _logger.LogInformation("Completed vectorization of file {FileId} in vector store {VectorStoreId} in {TotalSeconds}.",
                         fileId, vectorStoreId, (DateTimeOffset.UtcNow - startTime).TotalSeconds);
+
+                result[OpenAIAgentCapabilityParameterNames.AssistantFileId] = fileId;
             }
 
             return result;


### PR DESCRIPTION
# Small fix returns an object once vectorization completes in Azure OpenAI

## Details on the issue fix or feature implementation

The orchestration API expects a return value from operations resulting from the Gateway API Agent Capabilities, vectorization of a file was returning nothing. Modified it to return the file id that was vectorized.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
