### PR TITLE
(0.8.2) Small fix returns an object once vectorization completes in Azure OpenAI

### DIFF
--- a/src/dotnet/Gateway/Services/GatewayCore.cs
+++ b/src/dotnet/Gateway/Services/GatewayCore.cs
@@ -342,6 +342,8 @@ namespace FoundationaLLM.Gateway.Services
                 else
                     _logger.LogInformation("Completed vectorization of file {FileId} in vector store {VectorStoreId} in {TotalSeconds}.",
                         fileId, vectorStoreId, (DateTimeOffset.UtcNow - startTime).TotalSeconds);
+
+                result[OpenAIAgentCapabilityParameterNames.AssistantFileId] = fileId;
             }
 
             return result;


### PR DESCRIPTION
# (0.8.2) Small fix returns an object once vectorization completes in Azure OpenAI

## Details on the issue fix or feature implementation

Cherry pick for PR #1669

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

