### PR TITLE
Fix namespace in the Gatekeeper Integration API

### DIFF
--- a/src/python/GatekeeperIntegrationAPI/app/routers/status.py
+++ b/src/python/GatekeeperIntegrationAPI/app/routers/status.py
@@ -3,7 +3,7 @@ Status API endpoint that acts as a health check for the API.
 """
 import os
 from fastapi import APIRouter
-from foundationallm.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
+from foundationallm.integration.config.environment_variables import HOSTNAME, FOUNDATIONALLM_VERSION
 from app.dependencies import API_NAME
 
 router = APIRouter(


### PR DESCRIPTION
# Fix namespace in the Gatekeeper Integration API

## The issue or feature being addressed

Namespace was incorrect for the config module causing the app to not startup.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable