### PR TITLE
(0.8.1) Updating FLLM App Registration Creation Script to always authorize AZCLI app ID for APIs

### DIFF
--- a/deploy/common/scripts/Create-FllmEntraIdApps.ps1
+++ b/deploy/common/scripts/Create-FllmEntraIdApps.ps1
@@ -126,19 +126,21 @@ function New-FllmEntraIdApps {
         ## Updates the API App Registration
         Write-Host -ForegroundColor Yellow "Preparing updates for the API App Registration $($fllmAppRegMetaData.Api.Name)"
         $appConfig = Get-content $fllmApiConfigPath | ConvertFrom-Json -Depth 20
+        $preAuthorizedApp = @(
+            @{
+                "appId" = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
+                "delegatedPermissionIds" = @("$($appPermissionsId)")
+            }
+        )
+
         if ($createClientApp) {
-            $preAuthorizedApp = @(
-                @{
-                    "appId" = $($fllmAppRegMetaData.Client.AppId); 
-                    "delegatedPermissionIds" = @("$($appPermissionsId)") 
-                },
-                @{
-                    "appId" = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
-                    "delegatedPermissionIds" = @("$($appPermissionsId)")
-                }
-            )
-            $appConfig.api.preAuthorizedApplications = $preAuthorizedApp
+            $preAuthorizedApp += @{
+                "appId" = $($fllmAppRegMetaData.Client.AppId); 
+                "delegatedPermissionIds" = @("$($appPermissionsId)") 
+            }
         }
+
+        $appConfig.api.preAuthorizedApplications = $preAuthorizedApp
         $appConfig.identifierUris = @($($fllmAppRegMetaData.Api.Uri))
         $appConfigUpdate = $appConfig | ConvertTo-Json -Depth 20
         Write-Host -ForegroundColor Yellow "Final Update to API App Registration $($fllmAppRegMetaData.Api.Name)"


### PR DESCRIPTION
# (0.8.1) Updating FLLM App Registration Creation Script to always authorize AZCLI app ID for APIs

## Details on the issue fix or feature implementation

Cherry pick for #1698 

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
