### PR TITLE
(0.8.2) Add horizontal overflow style to handle content that's too wide for the message container

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -551,6 +551,7 @@ export default {
 .message__body {
 	// white-space: pre-wrap;
 	overflow-wrap: break-word;
+	overflow-x: auto;
 	padding-left: 12px;
 	padding-right: 12px;
 	padding-top: 8px;


### PR DESCRIPTION
# (0.8.2) Add horizontal overflow style to handle content that's too wide for the message container

## The issue or feature being addressed

Cherry-pick PR for #1707 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
