### PR TITLE
Improve polling in Gateway Core service

### DIFF
--- a/src/dotnet/Gateway/Services/GatewayCore.cs
+++ b/src/dotnet/Gateway/Services/GatewayCore.cs
@@ -14,7 +14,6 @@ using FoundationaLLM.Gateway.Interfaces;
 using FoundationaLLM.Gateway.Models;
 using FoundationaLLM.Gateway.Models.Configuration;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenAI.Assistants;
@@ -234,7 +233,13 @@ namespace FoundationaLLM.Gateway.Services
                     StringComparison.OrdinalIgnoreCase) == 0)
                 ?? throw new GatewayException($"The Gateway service is not configured to use the {endpoint} endpoint.");
 
-            var azureOpenAIClient = new AzureOpenAIClient(new Uri(azureOpenAIAccount.Endpoint), DefaultAuthentication.AzureCredential);
+            var azureOpenAIClient = new AzureOpenAIClient(
+                new Uri(azureOpenAIAccount.Endpoint),
+                DefaultAuthentication.AzureCredential,
+                new AzureOpenAIClientOptions
+                {
+                    NetworkTimeout = TimeSpan.FromSeconds(1000)
+                });
 
             if (createAssistant)
             {
@@ -323,22 +328,23 @@ namespace FoundationaLLM.Gateway.Services
                 var startTime = DateTimeOffset.UtcNow;
                 _logger.LogInformation("Started vectorization of file {FileId} in vector store {VectorStoreId}.", fileId, vectorStoreId);
 
-                var pollingCount = 0;
-                var maxPollingCountExceeded = false;
+                var maxPollingTimeExceeded = false;
                 while (vectorizationResult.Value.Status == VectorStoreFileAssociationStatus.InProgress)
                 {
-                    await Task.Delay(1000);
-                    if (pollingCount++ > 1800)
+                    await Task.Delay(5000);
+                    if ((DateTimeOffset.UtcNow - startTime).TotalSeconds >= 1000)
                     {
-                        // Will not wait more than 30 minutes for the vectorization to complete.
-                        maxPollingCountExceeded = true;
+                        // Will not wait more than 1000 seconds for the vectorization to complete.
+                        // The Gateway API clients have a 1200 seconds timeout set for the full operation to complete,
+                        // so we don't want to exceed that while polling.
+                        maxPollingTimeExceeded = true;
                         break;
                     }
                     vectorizationResult = await vectorStoreClient.GetFileAssociationAsync(vectorStoreId, fileId);
                 }
 
-                if (maxPollingCountExceeded)
-                    _logger.LogWarning("The maximum polling count was exceeded during the vectorization of file {FileId} in vector store {VectorStoreId}.", fileId, vectorStoreId);
+                if (maxPollingTimeExceeded)
+                    _logger.LogWarning("The maximum polling time (1000 seconds) was exceeded during the vectorization of file {FileId} in vector store {VectorStoreId}.", fileId, vectorStoreId);
                 else
                     _logger.LogInformation("Completed vectorization of file {FileId} in vector store {VectorStoreId} in {TotalSeconds}.",
                         fileId, vectorStoreId, (DateTimeOffset.UtcNow - startTime).TotalSeconds);


### PR DESCRIPTION
# Improve polling in Gateway Core service

## The issue or feature being addressed

Calls to Gateway API can time out before the internal polling process completes.

## Details on the issue fix or feature implementation

Switches from iteration count limit to time limit in Gateway Core polling pattern to avoid allowing the polling operation to exceed the client timeout set for calls to the Gateway API.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
