### PR TITLE
(0.8.2) Make the publish NuGet action use a manual trigger with validation

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,9 +1,12 @@
 name: Publish NuGet Packages
 
 on:
-  push:
-    branches:
-      - 'release/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Select the release branch'
+        required: true
+        default: 'release/main'
 
 env:
   DOTNET_VERSION: '8.0.x'
@@ -13,8 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Validate branch
+      id: validate_branch
+      run: |
+        if [[ "${{ github.event.inputs.branch }}" != release/* ]]; then
+          echo "This workflow can only be run on release branches."
+          exit 1
+        fi
+
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.branch }}
 
     - name: Set up .NET Core SDK
       uses: actions/setup-dotnet@v3
@@ -28,7 +41,7 @@ jobs:
     - name: Build Common
       working-directory: ./src/dotnet/Common
       run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true
-    
+
     - name: Build CoreClient
       working-directory: ./src/dotnet/CoreClient
       run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true


### PR DESCRIPTION
# (0.8.2) Make the publish NuGet action use a manual trigger with validation

## The issue or feature being addressed

Cherry-pick PR for #1758 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
