### PR TITLE
Updated CosmosDB SDK version

### DIFF
--- a/src/dotnet/Common/Common.csproj
+++ b/src/dotnet/Common/Common.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.17.1" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
     <PackageReference Include="Microsoft.DeepDev.TokenizerLib" Version="1.3.3" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageReference Include="Microsoft.Graph" Version="5.48.0" />

--- a/src/dotnet/Common/Common.csproj
+++ b/src/dotnet/Common/Common.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.17.1" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
     <PackageReference Include="Microsoft.DeepDev.TokenizerLib" Version="1.3.3" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageReference Include="Microsoft.Graph" Version="5.48.0" />

--- a/src/dotnet/Core/Core.csproj
+++ b/src/dotnet/Core/Core.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Polly.Core" Version="8.3.1" />

--- a/src/dotnet/Core/Core.csproj
+++ b/src/dotnet/Core/Core.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Polly.Core" Version="8.3.1" />

--- a/src/dotnet/Management/Management.csproj
+++ b/src/dotnet/Management/Management.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Polly.Core" Version="8.3.1" />
   </ItemGroup>

--- a/src/dotnet/State/State.csproj
+++ b/src/dotnet/State/State.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/State/State.csproj
+++ b/src/dotnet/State/State.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0-preview.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Updated CosmosDB SDK version

## The issue or feature being addressed

Currently, there is an inconsistency in the versions of CosmosDB in the project (`3.39.0` vs `3.41.0-preview`). This causes the Docker build for Management API to fail (see [pre-release build from main](https://github.com/solliancenet/foundationallm/actions/runs/10996440635)).

## Details on the issue fix or feature implementation

This PR updates all occurrences of `3.39.0` with `3.41.0-preview` ([verified build](https://github.com/solliancenet/foundationallm/actions/runs/10996510695)).

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
