### PR TITLE
Update NuGet package action and version script

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -2,11 +2,6 @@ name: Publish NuGet Packages
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Select the release branch'
-        required: true
-        default: 'release/main'
 
 env:
   DOTNET_VERSION: '8.0.x'
@@ -17,17 +12,15 @@ jobs:
 
     steps:
     - name: Validate branch
-      id: validate_branch
+      if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
       run: |
-        if [[ "${{ github.event.inputs.branch }}" != release/* ]]; then
-          echo "This workflow can only be run on release branches."
-          exit 1
-        fi
+        echo "This workflow can only be run on release branches."
+        exit 1
 
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.branch }}
+        ref: ${{ github.ref }}
 
     - name: Set up .NET Core SDK
       uses: actions/setup-dotnet@v3

--- a/versioning.sh
+++ b/versioning.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Output version for GitHub Actions or other CI systems
-echo "##[set-output name=version;]$VERSION"
+echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 echo "Version: $VERSION"
 
 # Replace the version placeholders in the .csproj files


### PR DESCRIPTION
# Update NuGet package action and version script

## The issue or feature being addressed

Removes the requirement to input a release branch in addition to selecting one. Updates the `versioning.sh` script to replace the deprecated `set-output` command with the newer `$GITHUB_OUTPUT` command.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
