### PR TITLE
Utility to run certbot in a container

### DIFF
--- a/deploy/common/docker/certbot-app/Dockerfile
+++ b/deploy/common/docker/certbot-app/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="true"
+ARG USERNAME=certbot
+ARG USER_GID=1001
+ARG USER_UID=1001
+
+COPY library-scripts/*.sh /tmp/library-scripts/
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN bash /tmp/library-scripts/azcli-debian.sh
+RUN bash /tmp/library-scripts/install-certbot.sh
+RUN bash /tmp/library-scripts/pwsh-debian.sh
+
+RUN rm -rf /tmp/library-scripts
+
+RUN mkdir /app
+COPY Function-Library.ps1 /app/Function-Library.ps1
+COPY New-LetsEncryptCertificates.ps1 /app/New-LetsEncryptCertificate.ps1
+
+ENTRYPOINT ["pwsh", "/app/New-LetsEncryptCertificate.ps1"]

--- a/deploy/common/docker/certbot-app/Makefile
+++ b/deploy/common/docker/certbot-app/Makefile
@@ -1,0 +1,11 @@
+default: buildx
+
+buildx: pull prepare
+	bash ./build.sh
+	rm -v Function-Library.ps1
+
+prepare:
+	cp -v ../../scripts/Function-Library.ps1 .
+
+pull:
+	docker pull mcr.microsoft.com/vscode/devcontainers/base:0-bullseye

--- a/deploy/common/docker/certbot-app/New-LetsEncryptCertificates.ps1
+++ b/deploy/common/docker/certbot-app/New-LetsEncryptCertificates.ps1
@@ -1,0 +1,128 @@
+#! /usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    This script generates Let's Encrypt certificates for a given base domain and a list of subdomains.
+
+.DESCRIPTION
+    The script generates Let's Encrypt certificates for a given base domain and a list of subdomains.
+    It uses Certbot and the dns-azure plugin for DNS authentication.
+
+.PARAMETER baseDomain
+    The base domain for which the certificates will be generated.
+
+.PARAMETER email
+    The email address to be used for Let's Encrypt registration and notifications.
+
+.PARAMETER subdomainPrefix
+    An optional prefix to be added to each subdomain.
+
+.NOTES
+    - This script requires Certbot and the dns-azure plugin to be installed.
+    - The script generates certificates for the following subdomains:
+        - api
+        - management
+        - management-api
+        - vectorization-api
+        - www
+    - Certbot DNS Azure documentation: https://docs.certbot-dns-azure.co.uk/en/latest/
+    - Certbot DNS Azure GitHub repository: https://github.com/terrycain/certbot-dns-azure
+
+.EXAMPLE
+    Get-LetsEncryptCertificates.ps1 -baseDomain example.com -email admin@example.com
+
+#>
+
+param(
+    [parameter(Mandatory = $true)][string]$baseDomain,
+    [parameter(Mandatory = $true)][string]$email,
+    [parameter(Mandatory = $false)][string]$subdomainPrefix = ''
+)
+
+Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable)
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+$ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Path
+. $ScriptDirectory/Function-Library.ps1
+
+$basenames = @{
+    "api"            = "coreapi"
+    "management"     = "managementui"
+    "management-api" = "managementapi"
+    "www"            = "chatui"
+}
+
+$directories = @{
+    "config" = "/app/config/certbot/config" | Get-AbsolutePath
+    "work"   = "/app/config/certbot/work" | Get-AbsolutePath
+    "log"    = "/app/config/certbot/log" | Get-AbsolutePath
+    "certs"  = "/app/config/certs" | Get-AbsolutePath
+}
+
+foreach ($directory in $directories.GetEnumerator()) {
+    if (!(Test-Path $directory.Value)) {
+        New-Item -ItemType Directory -Force -Path $directory.Value
+    }
+}
+
+Invoke-CLICommand "Azure Login" {
+    az login
+}
+
+foreach ($basename in $basenames.GetEnumerator()) {
+    # Domain Name
+    if('' -ne $subdomainPrefix) {
+        $hostname = @($subdomainPrefix, $basename.Name) | Join-String -Separator "-"
+    } else {
+        $hostname = $basename.Name
+    }
+
+    $fqdn = @($hostname, $baseDomain) | Join-String -Separator "."
+
+    # File Paths
+    $paths = @{
+        "pemFullChain" = Join-Path $directories["config"] "live" $fqdn "fullchain.pem"
+        "pemPrivKey"   = Join-Path $directories["config"] "live" $fqdn "privkey.pem"
+        "pfx"          = Join-Path $directories["certs"] $basename.Value "${fqdn}.pfx"
+        "pfxDir"       = Join-Path $directories["certs"] $basename.Value
+    }
+
+    if (!(Test-Path $paths["pfxDir"])) {
+        New-Item -ItemType Directory -Force -Path $paths["pfxDir"]
+    }
+
+    Invoke-CLICommand "Generate certificate for ${fqdn}" {
+        certbot certonly `
+            --agree-tos `
+            --email $email `
+            --authenticator dns-azure `
+            --config-dir $directories["config"] `
+            --dns-azure-config /app/config/certbot.ini `
+            --domain $fqdn `
+            --keep-until-expiring `
+            --logs-dir $directories["log"] `
+            --non-interactive `
+            --preferred-challenges dns `
+            --quiet `
+            --work-dir $directories["work"]
+    }
+
+    Invoke-CLICommand "Export certificate for ${fqdn}" {
+        openssl pkcs12 `
+            -export `
+            -inkey $paths["pemPrivKey"] `
+            -in $paths["pemFullChain"] `
+            -out $paths["pfx"] `
+            -passout pass:
+    }
+
+    Invoke-CLICommand "Verify certificate for ${fqdn}" {
+        openssl pkcs12 `
+            -info `
+            -in $paths["pfx"] `
+            -nokeys `
+            -passin pass: `
+            -passout pass:
+    }
+}

--- a/deploy/common/docker/certbot-app/README.md
+++ b/deploy/common/docker/certbot-app/README.md
@@ -1,0 +1,41 @@
+# Utility to run certbot in a container
+
+## Synopsis
+
+```bash
+make && \
+    docker run \
+        -v ./config:/app/config \
+        -it certbot-app \
+        -baseDomain <your zone name> \
+        -email <your email> \
+        -subdomainPrefix <optional prefix for hostnames>
+```
+
+You must replace `<your zone name>` and `<your email>` with the appropriate values.  And optionally, you can replace `<optional prefix for hostnames>` with a prefix for the hostnames or leave this parameter off the list.
+
+Example:
+
+```bash
+make && \
+    docker run \
+        -v ./config:/app/config \
+        -it certbot-app \
+        -baseDomain example.com \
+        -email email@example.com \
+        -subdomainPrefix test
+```
+
+## Before you begin
+
+Create `certbot.ini` in the `config` directory with the following content:
+
+```ini
+dns_azure_use_cli_credentials = true
+
+dns_azure_environment = "AzurePublicCloud"
+
+dns_azure_zone1 = <your zone name>:<your zone resource id>
+```
+
+You must replace  `<your zone name>` and `<your zone resource id>` with the appropriate values.

--- a/deploy/common/docker/certbot-app/build.sh
+++ b/deploy/common/docker/certbot-app/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+REPOSITORY="certbot-app"
+CONTEXT="."
+
+SHA=$(git rev-parse --short HEAD)
+docker buildx build --rm -t "${REPOSITORY}:${SHA}" "${CONTEXT}"
+docker tag "${REPOSITORY}:${SHA}" "${REPOSITORY}:latest"
+
+docker images "${REPOSITORY}"

--- a/deploy/common/docker/certbot-app/config/.gitignore
+++ b/deploy/common/docker/certbot-app/config/.gitignore
@@ -1,0 +1,2 @@
+# Place certbot.ini file in this folder but do not commit it to the repository
+certbot.ini

--- a/deploy/common/docker/certbot-app/library-scripts/azcli-debian.sh
+++ b/deploy/common/docker/certbot-app/library-scripts/azcli-debian.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./azcli-debian.sh
+
+set -e
+
+AZ_VERSION=${1:-"latest"}
+MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
+AZCLI_ARCHIVE_ARCHITECTURES="amd64"
+AZCLI_ARCHIVE_VERSION_CODENAMES="stretch buster bullseye bionic focal jammy"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Get central common setting
+get_common_setting() {
+    if [ "${common_settings_file_loaded}" != "true" ]; then
+        curl -sfL "https://aka.ms/vscode-dev-containers/script-library/settings.env" 2>/dev/null -o /tmp/vsdc-settings.env || echo "Could not download settings file. Skipping."
+        common_settings_file_loaded=true
+    fi
+    if [ -f "/tmp/vsdc-settings.env" ]; then
+        local multi_line=""
+        if [ "$2" = "true" ]; then multi_line="-z"; fi
+        local result="$(grep ${multi_line} -oP "$1=\"?\K[^\"]+" /tmp/vsdc-settings.env | tr -d '\0')"
+        if [ ! -z "${result}" ]; then declare -g $1="${result}"; fi
+    fi
+    echo "$1=${!1}"
+}
+
+# Function to run apt-get if needed
+apt_get_update_if_needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Soft version matching that resolves a version for a given package in the *current apt-cache*
+# Return value is stored in first argument (the unprocessed version)
+apt_cache_version_soft_match() {
+    
+    # Version
+    local variable_name="$1"
+    local requested_version=${!variable_name}
+    # Package Name
+    local package_name="$2"
+    # Exit on no match?
+    local exit_on_no_match="${3:-true}"
+
+    # Ensure we've exported useful variables
+    . /etc/os-release
+    local architecture="$(dpkg --print-architecture)"
+    
+    dot_escaped="${requested_version//./\\.}"
+    dot_plus_escaped="${dot_escaped//+/\\+}"
+    # Regex needs to handle debian package version number format: https://www.systutorials.com/docs/linux/man/5-deb-version/
+    version_regex="^(.+:)?${dot_plus_escaped}([\\.\\+ ~:-]|$)"
+    set +e # Don't exit if finding version fails - handle gracefully
+        fuzzy_version="$(apt-cache madison ${package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${version_regex}")"
+    set -e
+    if [ -z "${fuzzy_version}" ]; then
+        echo "(!) No full or partial for package \"${package_name}\" match found in apt-cache for \"${requested_version}\" on OS ${ID} ${VERSION_CODENAME} (${architecture})."
+
+        if $exit_on_no_match; then
+            echo "Available versions:"
+            apt-cache madison ${package_name} | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
+            exit 1 # Fail entire script
+        else
+            echo "Continuing to fallback method (if available)"
+            return 1;
+        fi
+    fi
+
+    # Globally assign fuzzy_version to this value
+    # Use this value as the return value of this function
+    declare -g ${variable_name}="=${fuzzy_version}"
+    echo "${variable_name} ${!variable_name}"
+}
+
+install_using_apt() {
+    # Install dependencies
+    check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+    # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
+    get_common_setting MICROSOFT_GPG_KEYS_URI
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/azure-cli.list
+    apt-get update
+
+    if [ "${AZ_VERSION}" = "latest" ] || [ "${AZ_VERSION}" = "lts" ] || [ "${AZ_VERSION}" = "stable" ]; then
+        # Empty, meaning grab the "latest" in the apt repo
+        AZ_VERSION=""
+    else
+        # Sets AZ_VERSION to our desired version, if match found.
+        apt_cache_version_soft_match AZ_VERSION "azure-cli" false
+        if [ "$?" != 0 ]; then
+            return 1
+        fi
+    fi
+
+    if ! (apt-get install -yq azure-cli${AZ_VERSION}); then
+        rm -f /etc/apt/sources.list.d/azure-cli.list
+        return 1
+    fi
+}
+
+install_using_pip() {
+    echo "(*) No pre-built binaries available in apt-cache. Installing via pip3."
+    if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install python3-minimal python3-pip libffi-dev python3-venv
+    fi
+    export PIPX_HOME=/usr/local/pipx
+    mkdir -p ${PIPX_HOME}
+    export PIPX_BIN_DIR=/usr/local/bin
+    export PYTHONUSERBASE=/tmp/pip-tmp
+    export PIP_CACHE_DIR=/tmp/pip-tmp/cache
+    pipx_bin=pipx
+    if ! type pipx > /dev/null 2>&1; then
+        pip3 install --disable-pip-version-check --no-cache-dir --user pipx
+        pipx_bin=/tmp/pip-tmp/bin/pipx
+    fi
+
+    if [ "${AZ_VERSION}" = "latest" ] || [ "${AZ_VERSION}" = "lts" ] || [ "${AZ_VERSION}" = "stable" ]; then
+        # Empty, meaning grab the "latest" in the apt repo
+        ver=""
+    else
+        ver="==${AZ_VERSION}"
+    fi
+
+    set +e
+        ${pipx_bin} install --pip-args '--no-cache-dir --force-reinstall' -f azure-cli${ver}
+
+        # Fail gracefully
+        if [ "$?" != 0 ]; then
+            echo "Could not install azure-cli${ver} via pip"
+            rm -rf /tmp/pip-tmp
+            return 1
+        fi
+    set -e
+}
+
+# See if we're on x86_64 and if so, install via apt-get, otherwise use pip3
+echo "(*) Installing Azure CLI..."
+. /etc/os-release
+architecture="$(dpkg --print-architecture)"
+CACHED_AZURE_VERSION="${AZ_VERSION}" # In case we need to fallback to pip and the apt path has modified the AZ_VERSION variable.
+if [[ "${AZCLI_ARCHIVE_ARCHITECTURES}" = *"${architecture}"* ]] && [[  "${AZCLI_ARCHIVE_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
+    install_using_apt || use_pip="true"
+else
+    use_pip="true"
+fi
+
+if [ "${use_pip}" = "true" ]; then
+    AZ_VERSION=${CACHED_AZURE_VERSION}
+    install_using_pip
+
+    if [ "$?" != 0 ]; then
+        echo "Please provide a valid version for your distribution ${ID} ${VERSION_CODENAME} (${architecture})."
+        echo
+        echo "Valid versions in current apt-cache"
+        apt-cache madison azure-cli | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
+        exit 1
+    fi
+fi
+
+echo "Done!"

--- a/deploy/common/docker/certbot-app/library-scripts/common-debian.sh
+++ b/deploy/common/docker/certbot-app/library-scripts/common-debian.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]
+
+set -e
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"automatic"}
+USER_UID=${3:-"automatic"}
+USER_GID=${4:-"automatic"}
+UPGRADE_PACKAGES=${5:-"true"}
+INSTALL_OH_MYS=${6:-"true"}
+ADD_NON_FREE_PACKAGES=${7:-"false"}
+SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+# If in automatic mode, determine if a user already exists, if not use vscode
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=vscode
+    fi
+elif [ "${USERNAME}" = "none" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Load markers to see which steps have already run
+if [ -f "${MARKER_FILE}" ]; then
+    echo "Marker file found:"
+    cat "${MARKER_FILE}"
+    source "${MARKER_FILE}"
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt_get_update_if_needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+
+    package_list="apt-utils \
+        openssh-client \
+        gnupg2 \
+        dirmngr \
+        iproute2 \
+        procps \
+        lsof \
+        htop \
+        net-tools \
+        psmisc \
+        curl \
+        wget \
+        rsync \
+        ca-certificates \
+        unzip \
+        zip \
+        nano \
+        vim-tiny \
+        less \
+        jq \
+        lsb-release \
+        apt-transport-https \
+        dialog \
+        libc6 \
+        libgcc1 \
+        libkrb5-3 \
+        libgssapi-krb5-2 \
+        libicu[0-9][0-9] \
+        liblttng-ust[0-9] \
+        libstdc++6 \
+        zlib1g \
+        locales \
+        sudo \
+        ncdu \
+        man-db \
+        strace \
+        manpages \
+        manpages-dev \
+        init-system-helpers"
+        
+    # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
+    if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
+        # Bring in variables from /etc/os-release like VERSION_CODENAME
+        . /etc/os-release
+        sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
+        sed -i -E "s/deb-src http:\/\/(deb|httredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
+        sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
+        sed -i -E "s/deb-src http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
+        sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
+        sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
+        sed -i "s/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list 
+        sed -i "s/deb-src http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
+        # Handle bullseye location for security https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html
+        sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+        sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+        echo "Running apt-get update..."
+        apt-get update
+        package_list="${package_list} manpages-posix manpages-posix-dev"
+    else
+        apt_get_update_if_needed
+    fi
+
+    # Install libssl1.1 if available
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+        package_list="${package_list}       libssl1.1"
+    fi
+    
+    # Install appropriate version of libssl1.0.x if available
+    libssl_package=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+    if [ "$(echo "$LIlibssl_packageBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+        if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+            # Debian 9
+            package_list="${package_list}       libssl1.0.2"
+        elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+            # Ubuntu 18.04, 16.04, earlier
+            package_list="${package_list}       libssl1.0.0"
+        fi
+    fi
+
+    echo "Packages to verify are installed: ${package_list}"
+    apt-get -y install --no-install-recommends ${package_list} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+        
+    # Install git if not already installed (may be more recent than distro version)
+    if ! type git > /dev/null 2>&1; then
+        apt-get -y install --no-install-recommends git
+    fi
+
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt_get_update_if_needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+    locale-gen
+    LOCALE_ALREADY_SET="true"
+fi
+
+# Create or update a non-root user to match UID/GID.
+group_name="${USERNAME}"
+if id -u ${USERNAME} > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "${USER_GID}" != "automatic" ] && [ "$USER_GID" != "$(id -g $USERNAME)" ]; then 
+        group_name="$(id -gn $USERNAME)"
+        groupmod --gid $USER_GID ${group_name}
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" != "automatic" ] && [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    if [ "${USER_GID}" = "automatic" ]; then
+        groupadd $USERNAME
+    else
+        groupadd --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" = "automatic" ]; then 
+        useradd -s /bin/bash --gid $USERNAME -m $USERNAME
+    else
+        useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+    fi
+fi
+
+# Add sudo support for non-root user
+if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+    chmod 0440 /etc/sudoers.d/$USERNAME
+    EXISTING_NON_ROOT_USER="${USERNAME}"
+fi
+
+# ** Shell customization section **
+if [ "${USERNAME}" = "root" ]; then 
+    user_rc_path="/root"
+else
+    user_rc_path="/home/${USERNAME}"
+fi
+
+# Restore user .bashrc defaults from skeleton file if it doesn't exist or is empty
+if [ ! -f "${user_rc_path}/.bashrc" ] || [ ! -s "${user_rc_path}/.bashrc" ] ; then
+    cp  /etc/skel/.bashrc "${user_rc_path}/.bashrc"
+fi
+
+# Restore user .profile defaults from skeleton file if it doesn't exist or is empty
+if  [ ! -f "${user_rc_path}/.profile" ] || [ ! -s "${user_rc_path}/.profile" ] ; then
+    cp  /etc/skel/.profile "${user_rc_path}/.profile"
+fi
+
+# .bashrc/.zshrc snippet
+rc_snippet="$(cat << 'EOF'
+
+if [ -z "${USER}" ]; then export USER=$(whoami); fi
+if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then export PATH="${PATH}:$HOME/.local/bin"; fi
+
+# Display optional first run image specific notice if configured and terminal is interactive
+if [ -t 1 ] && [[ "${TERM_PROGRAM}" = "vscode" || "${TERM_PROGRAM}" = "codespaces" ]] && [ ! -f "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed" ]; then
+    if [ -f "/usr/local/etc/vscode-dev-containers/first-run-notice.txt" ]; then
+        cat "/usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+    elif [ -f "/workspaces/.codespaces/shared/first-run-notice.txt" ]; then
+        cat "/workspaces/.codespaces/shared/first-run-notice.txt"
+    fi
+    mkdir -p "$HOME/.config/vscode-dev-containers"
+    # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
+    ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &)
+fi
+
+# Set the default git editor if not already set
+if [ -z "$(git config --get core.editor)" ] && [ -z "${GIT_EDITOR}" ]; then
+    if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+        if [[ -n $(command -v code-insiders) &&  -z $(command -v code) ]]; then 
+            export GIT_EDITOR="code-insiders --wait"
+        else 
+            export GIT_EDITOR="code --wait"
+        fi
+    fi
+fi
+
+EOF
+)"
+
+# code shim, it fallbacks to code-insiders if code is not available
+cat << 'EOF' > /usr/local/bin/code
+#!/bin/sh
+
+get_in_path_except_current() {
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
+}
+
+code="$(get_in_path_except_current code)"
+
+if [ -n "$code" ]; then
+    exec "$code" "$@"
+elif [ "$(command -v code-insiders)" ]; then
+    exec code-insiders "$@"
+else
+    echo "code or code-insiders is not installed" >&2
+    exit 127
+fi
+EOF
+chmod +x /usr/local/bin/code
+
+# systemctl shim - tells people to use 'service' if systemd is not running
+cat << 'EOF' > /usr/local/bin/systemctl
+#!/bin/sh
+set -e
+if [ -d "/run/systemd/system" ]; then
+    exec /bin/systemctl "$@"
+else
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
+fi
+EOF
+chmod +x /usr/local/bin/systemctl
+
+# Codespaces bash and OMZ themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+codespaces_bash="$(cat \
+<<'EOF'
+
+# Codespaces bash prompt theme
+__bash_prompt() {
+    local userpart='`export XIT=$? \
+        && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
+        && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
+    local gitbranch='`\
+        if [ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
+            export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+            if [ "${BRANCH}" != "" ]; then \
+                echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+                && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                        echo -n " \[\033[1;33m\]✗"; \
+                fi \
+                && echo -n "\[\033[0;36m\]) "; \
+            fi; \
+        fi`'
+    local lightblue='\[\033[1;34m\]'
+    local removecolor='\[\033[0m\]'
+    PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+    unset -f __bash_prompt
+}
+__bash_prompt
+
+EOF
+)"
+
+codespaces_zsh="$(cat \
+<<'EOF'
+# Codespaces zsh prompt theme
+__zsh_prompt() {
+    local prompt_username
+    if [ ! -z "${GITHUB_USER}" ]; then 
+        prompt_username="@${GITHUB_USER}"
+    else
+        prompt_username="%n"
+    fi
+    PROMPT="%{$fg[green]%}${prompt_username} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )" # User/exit code arrow
+    PROMPT+='%{$fg_bold[blue]%}%(5~|%-1~/…/%3~|%4~)%{$reset_color%} ' # cwd
+    PROMPT+='$([ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ] && git_prompt_info)' # Git status
+    PROMPT+='%{$fg[white]%}$ %{$reset_color%}'
+    unset -f __zsh_prompt
+}
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
+__zsh_prompt
+
+EOF
+)"
+
+# Add RC snippet and custom bash prompt
+if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
+    echo "${rc_snippet}" >> /etc/bash.bashrc
+    echo "${codespaces_bash}" >> "${user_rc_path}/.bashrc"
+    echo 'export PROMPT_DIRTRIM=4' >> "${user_rc_path}/.bashrc"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${codespaces_bash}" >> "/root/.bashrc"
+        echo 'export PROMPT_DIRTRIM=4' >> "/root/.bashrc"
+    fi
+    chown ${USERNAME}:${group_name} "${user_rc_path}/.bashrc"
+    RC_SNIPPET_ALREADY_ADDED="true"
+fi
+
+# Optionally install and configure zsh and Oh My Zsh!
+if [ "${INSTALL_ZSH}" = "true" ]; then
+    if ! type zsh > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get install -y zsh
+    fi
+    if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+        echo "${rc_snippet}" >> /etc/zsh/zshrc
+        ZSH_ALREADY_INSTALLED="true"
+    fi
+
+    # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
+    oh_my_install_dir="${user_rc_path}/.oh-my-zsh"
+    if [ ! -d "${oh_my_install_dir}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+        template_path="${oh_my_install_dir}/templates/zshrc.zsh-template"
+        user_rc_file="${user_rc_path}/.zshrc"
+        umask g-w,o-w
+        mkdir -p ${oh_my_install_dir}
+        git clone --depth=1 \
+            -c core.eol=lf \
+            -c core.autocrlf=false \
+            -c fsck.zeroPaddedFilemode=ignore \
+            -c fetch.fsck.zeroPaddedFilemode=ignore \
+            -c receive.fsck.zeroPaddedFilemode=ignore \
+            "https://github.com/ohmyzsh/ohmyzsh" "${oh_my_install_dir}" 2>&1
+        echo -e "$(cat "${template_path}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${user_rc_file}
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${user_rc_file}
+
+        mkdir -p ${oh_my_install_dir}/custom/themes
+        echo "${codespaces_zsh}" > "${oh_my_install_dir}/custom/themes/codespaces.zsh-theme"
+        # Shrink git while still enabling updates
+        cd "${oh_my_install_dir}"
+        git repack -a -d -f --depth=1 --window=1
+        # Copy to non-root user if one is specified
+        if [ "${USERNAME}" != "root" ]; then
+            cp -rf "${user_rc_file}" "${oh_my_install_dir}" /root
+            chown -R ${USERNAME}:${group_name} "${user_rc_path}"
+        fi
+    fi
+fi
+
+# Persist image metadata info, script if meta.env found in same directory
+meta_info_script="$(cat << 'EOF'
+#!/bin/sh
+. /usr/local/etc/vscode-dev-containers/meta.env
+
+# Minimal output
+if [ "$1" = "version" ] || [ "$1" = "image-version" ]; then
+    echo "${VERSION}"
+    exit 0
+elif [ "$1" = "release" ]; then
+    echo "${GIT_REPOSITORY_RELEASE}"
+    exit 0
+elif [ "$1" = "content" ] || [ "$1" = "content-url" ] || [ "$1" = "contents" ] || [ "$1" = "contents-url" ]; then
+    echo "${CONTENTS_URL}"
+    exit 0
+fi
+
+#Full output
+echo
+echo "Development container image information"
+echo
+if [ ! -z "${VERSION}" ]; then echo "- Image version: ${VERSION}"; fi
+if [ ! -z "${DEFINITION_ID}" ]; then echo "- Definition ID: ${DEFINITION_ID}"; fi
+if [ ! -z "${VARIANT}" ]; then echo "- Variant: ${VARIANT}"; fi
+if [ ! -z "${GIT_REPOSITORY}" ]; then echo "- Source code repository: ${GIT_REPOSITORY}"; fi
+if [ ! -z "${GIT_REPOSITORY_RELEASE}" ]; then echo "- Source code release/branch: ${GIT_REPOSITORY_RELEASE}"; fi
+if [ ! -z "${BUILD_TIMESTAMP}" ]; then echo "- Timestamp: ${BUILD_TIMESTAMP}"; fi
+if [ ! -z "${CONTENTS_URL}" ]; then echo && echo "More info: ${CONTENTS_URL}"; fi
+echo
+EOF
+)"
+if [ -f "${SCRIPT_DIR}/meta.env" ]; then
+    mkdir -p /usr/local/etc/vscode-dev-containers/
+    cp -f "${SCRIPT_DIR}/meta.env" /usr/local/etc/vscode-dev-containers/meta.env
+    echo "${meta_info_script}" > /usr/local/bin/devcontainer-info
+    chmod +x /usr/local/bin/devcontainer-info
+fi
+
+# Write marker file
+mkdir -p "$(dirname "${MARKER_FILE}")"
+echo -e "\
+    PACKAGES_ALREADY_INSTALLED=${PACKAGES_ALREADY_INSTALLED}\n\
+    LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
+    EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
+    RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
+    ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
+
+echo "Done!"

--- a/deploy/common/docker/certbot-app/library-scripts/install-certbot.sh
+++ b/deploy/common/docker/certbot-app/library-scripts/install-certbot.sh
@@ -1,0 +1,8 @@
+set -euox pipefail
+apt update
+apt-get update
+apt-get install -y certbot
+apt-get install -y python3-pip
+python3 -m pip install pip --upgrade
+pip install pyopenssl --upgrade --root-user-action=ignore
+pip3 install certbot certbot-dns-azure --upgrade --root-user-action=ignore

--- a/deploy/common/docker/certbot-app/library-scripts/pwsh-debian.sh
+++ b/deploy/common/docker/certbot-app/library-scripts/pwsh-debian.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# https://learn.microsoft.com/en-us/powershell/scripting/install/install-debian?view=powershell-7.4
+
+###################################
+# Prerequisites
+
+# Update the list of packages
+sudo apt-get update
+
+# Install pre-requisite packages.
+sudo apt-get install -y wget
+
+# Get the version of Debian
+source /etc/os-release
+
+# Download the Microsoft repository GPG keys
+wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+
+# Register the Microsoft repository GPG keys
+sudo dpkg -i packages-microsoft-prod.deb
+
+# Delete the Microsoft repository GPG keys file
+rm packages-microsoft-prod.deb
+
+# Update the list of packages after we added packages.microsoft.com
+sudo apt-get update
+
+###################################
+# Install PowerShell
+sudo apt-get install -y powershell


### PR DESCRIPTION
# Utility to run certbot in a container

## The issue or feature being addressed

Certbot is difficult to run on OSX due to the way OSX manages python

## Details on the issue fix or feature implementation

Run certbot in a container for a consistent experience.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
