### PR TITLE
Fix Cosmos DB change feed issue

### DIFF
--- a/src/dotnet/Core/Services/CosmosDbChangeFeedService.cs
+++ b/src/dotnet/Core/Services/CosmosDbChangeFeedService.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Identity;
 using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Constants.Chat;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.CosmosDB;
 using FoundationaLLM.Common.Models.Conversation;
@@ -126,7 +127,7 @@ namespace FoundationaLLM.Core.Services
         {
             using var logScope = _logger.BeginScope("Cosmos DB Change Feed Processor: ProcessUserSessionsChangeFeedHandler");
 
-            var sessions = input.Where(i => i.Type == nameof(Conversation)).ToArray();
+            var sessions = input.Where(i => i.Type == ConversationTypes.Session).ToArray();
 
             _logger.LogInformation("Cosmos DB Change Feed Processor: Processing {count} changes...", sessions.Count());
 


### PR DESCRIPTION
# Fix Cosmos DB change feed issue

## The issue or feature being addressed

Fixes inconsistency in setting the chat session (conversation) type value in the change feed processor.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
