### PR TITLE
Added confirmation dialog to remove file button and allowed multiple file selection in OneDrive

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -203,7 +203,7 @@
 				:visible="fileToDelete !== null"
 				:closable="false"
 				modal
-				header="Delete a Chat"
+				:header="fileToDelete.type === 'local' | 'oneDrive' ? 'Remove a file' : 'Delete a file'"
 				@keydown="deleteFileKeydown"
 			>
 				<div v-if="deleteFileProcessing" class="delete-dialog-content">
@@ -217,12 +217,12 @@
 					</div>
 				</div>
 				<div v-else>
-					<p>Do you want to delete the file "{{ fileToDelete.name }}" ?</p>
+					<p>Do you want to {{ fileToDelete.type === "local" | "oneDrive" ? "remove" : "delete" }} the file "{{ fileToDelete.name }}" ?</p>
 				</div>
 				<template #footer>
 					<Button label="Cancel" text :disabled="deleteFileProcessing" @click="fileToDelete = null" />
 					<Button
-						label="Delete"
+						:label="fileToDelete.type === 'local' | 'oneDrive' ? 'Remove' : 'Delete'"
 						severity="danger"
 						autofocus
 						:disabled="deleteFileProcessing"
@@ -1025,6 +1025,10 @@ export default {
 @media only screen and (max-width: 950px) {
 	.file-upload-empty-desktop {
 		display: none;
+	}
+
+	.file-overlay-panel__footer {
+		flex-direction: column;
 	}
 }
 </style>

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -349,6 +349,7 @@ export default {
 				},
 				access: { mode: 'read' },
 				search: { enabled: true },
+				multiSelect: true,
 			},
 			oneDriveFiles: [],
 			localFiles: [],
@@ -785,9 +786,13 @@ export default {
 							break;
 
 						case 'pick':
-							console.log(`Picked: ${JSON.stringify(command)}`);
+							console.log(command.items);
+							command.items.forEach((item) => {
+								console.log(`Picked: ${JSON.stringify(item)}`);
+								this.oneDriveFiles.push(item);
+							});
 
-							this.oneDriveFiles.push(...command.items);
+							// this.oneDriveFiles.push(...command.items);
 
 							this.$nextTick(() => {
 								this.$refs.menu.alignOverlay();

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -30,6 +30,14 @@
 					@keydown.esc="hideAllPoppers"
 				/>
 				<OverlayPanel ref="menu" style="max-width: 98%">
+					<div class="file-upload-header">
+						<Button
+							:icon="!isMobile ? 'pi pi-times' : undefined"
+							label="Close"
+							class="file-upload-container-button"
+							@click="toggle"
+						/>
+					</div>
 					<FileUpload
 						ref="fileUpload"
 						:multiple="true"
@@ -39,6 +47,9 @@
 						@select="fileSelected"
 					>
 						<template #content>
+							<div v-if="fileArrayFiltered.length === 0 && oneDriveFiles.length === 0 && localFiles.length === 0" class="file-upload-empty-desktop">
+								<p>No files have been added to this message.</p>
+							</div>
 							<!-- Progress bar -->
 							<div v-if="isUploading" style="padding: 60px 10px">
 								<ProgressBar
@@ -181,12 +192,6 @@
 								@click="oneDriveWorkSchoolConnect"
 							/>
 						</template>
-						<Button
-							:icon="!isMobile ? 'pi pi-times' : undefined"
-							label="Close"
-							class="file-upload-container-button"
-							@click="toggle"
-						/>
 					</div>
 				</OverlayPanel>
 				<template #popper>
@@ -991,6 +996,17 @@ export default {
 	display: flex;
 	justify-content: center;
 	padding: 20px 150px;
+}
+
+.file-upload-header {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 0.5rem;
+}
+
+.file-upload-empty-desktop {
+	text-align: center;
+	margin-bottom: 0.5rem;
 }
 
 @media only screen and (max-width: 405px) {

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -78,7 +78,7 @@
 								</div>
 								<Divider v-if="fileArrayFiltered.length > 0" />
 								<div
-									v-for="(file, index) of localFiles"
+									v-for="(file) of localFiles"
 									:key="file.name + file.type + file.size"
 									class="file-upload-file"
 								>
@@ -105,7 +105,7 @@
 								</div>
 								<div v-if="oneDriveFiles && oneDriveFiles.length > 0">
 									<div
-										v-for="(file, index) of oneDriveFiles"
+										v-for="(file) of oneDriveFiles"
 										:key="file.name + file.size"
 										class="file-upload-file"
 									>
@@ -506,6 +506,7 @@ export default {
 						this.$nextTick(() => {
 							this.$refs.menu.alignOverlay();
 						});
+						this.toggle();
 						if (filesUploaded > 0) {
 							this.$toast.add({
 								severity: 'success',

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -349,7 +349,9 @@ export default {
 				},
 				access: { mode: 'read' },
 				search: { enabled: true },
-				multiSelect: true,
+				selection: {
+					mode: 'multiple',
+				},
 			},
 			oneDriveFiles: [],
 			localFiles: [],

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -181,6 +181,12 @@
 								@click="oneDriveWorkSchoolConnect"
 							/>
 						</template>
+						<Button
+							:icon="!isMobile ? 'pi pi-times' : undefined"
+							label="Close"
+							class="file-upload-container-button"
+							@click="toggle"
+						/>
 					</div>
 				</OverlayPanel>
 				<template #popper>


### PR DESCRIPTION
# Added confirmation dialog to remove file button and allowed multiple file selection in OneDrive

## The issue or feature being addressed

- Added a confirmation dialog to the remove file button.
- Allowed for selecting more than one file on OneDrive (not fully tested).
- Added a close button to the overlay panel.
- Automatic closing of the dialog after the upload completes is added.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable