### PR TITLE
Fix file overlay resize error

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -442,7 +442,7 @@ export default {
 		handleResize() {
 			console.log('resize');
 			this.isMobile = window.screen.width < 950;
-			if (this.$refs.menu.style) {
+			if (this.$refs.menu.visible) {
 				this.$nextTick(() => {
 					this.$refs.menu.alignOverlay();
 				});
@@ -1063,10 +1063,6 @@ export default {
 }
 
 @media only screen and (max-width: 950px) {
-	.file-upload-empty-desktop {
-		display: none;
-	}
-
 	.file-overlay-panel__footer {
 		flex-direction: column;
 	}

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -442,9 +442,11 @@ export default {
 		handleResize() {
 			console.log('resize');
 			this.isMobile = window.screen.width < 950;
-			this.$nextTick(() => {
-				this.$refs.menu.alignOverlay();
-			});
+			if (this.$refs.menu.style) {
+				this.$nextTick(() => {
+					this.$refs.menu.alignOverlay();
+				});
+			}
 		},
 
 		adjustTextareaHeight() {

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -440,7 +440,6 @@ export default {
 		},
 
 		handleResize() {
-			console.log('resize');
 			this.isMobile = window.screen.width < 950;
 			if (this.$refs.menu.visible) {
 				this.$nextTick(() => {


### PR DESCRIPTION
# Fix file overlay resize error

## The issue or feature being addressed

- Fixed bug where resizing the screen will give error "Cannot read properties of null (reading 'style')."
- Made file picker message "No files have been added to this message." visible on mobile.

## Details on the issue fix or feature implementation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable