### PR TITLE
File store config and file upload improvements

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -13,6 +13,22 @@ Name | Default value
 --- | ---
 `FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions` | `c, cpp, cs, css, csv, doc, docx, git, html, java, jpeg, jpg, js, json, md, pdf, php, png, pptx, py, rb, sh, tar, tex, ts, txt, xlsx, xml, zip`
 `FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AzureOpenAIAssistantsFileSearchFileExtensions` | `c, cpp, cs, css, doc, docx, html, java, js, json, md, pdf, php, pptx, py, rb, sh, tex, ts, txt`
+`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:MaxUploadsPerMessage` | `{ "value": 10, "value_exceptions": [] }`
+
+>[!NOTE]
+> Here is an example of an override for the `MaxUploadsPerMessage` setting:
+> ```json
+>{
+>	"value": 1,
+>	"value_exceptions": [
+>		{
+>			"user_principal_name": "ciprian@solliance.net",
+>			"value": 5,
+>			"enabled": true
+>		}
+>	]
+>}
+> ```
 
 The following settings are optional (they should not be set by default):
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -19,7 +19,7 @@ Name | Default value
 > Here is an example of an override for the `MaxUploadsPerMessage` setting:
 > ```json
 >{
->	"value": 1,
+>	"value": 10,
 >	"value_exceptions": [
 >		{
 >			"user_principal_name": "ciprian@solliance.net",

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -411,6 +411,14 @@
 				"value": "c, cpp, cs, css, csv, doc, docx, git, html, java, jpeg, jpg, js, json, md, pdf, php, png, pptx, py, rb, sh, tar, tex, ts, txt, xlsx, xml, zip",
 				"content_type": "",
 				"first_version": "0.8.0"
+			},
+			{
+				"name": "MaxUploadsPerMessage",
+				"description": "The maximum number of files that can be uploaded for a single conversation message.",
+				"secret": "",
+				"value": "{ 'value': 10, 'value_exceptions': []}",
+				"content_type": "application/json",
+				"first_version": "0.8.2"
 			}
 		]
 	},

--- a/src/dotnet/Common/Models/ResourceProviders/Configuration/ConfigurationValue`1.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Configuration/ConfigurationValue`1.cs
@@ -1,0 +1,76 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Common.Models.ResourceProviders.Configuration
+{
+    /// <summary>
+    /// Provides a strongly typed configuration value with support for per-user exceptions.
+    /// </summary>
+    /// <typeparam name="T">The type of the configuration value</typeparam>
+    public class ConfigurationValue<T>
+    {
+        /// <summary>
+        /// Gets or sets the value of the configuration entry.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public required T Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of exceptions to the configuration value.
+        /// </summary>
+        [JsonPropertyName("value_exceptions")]
+        public List<ConfigurationValueException<T>> Exceptions { get; set; } = [];
+
+        /// <summary>
+        /// Gets the value of the configuration entry for the specified user.
+        /// </summary>
+        /// <remarks>
+        /// The method returns the user-specific value if an active exception exists for the user.
+        /// If not, the method returns the default value.
+        /// </remarks>
+        /// <param name="userPrincipalName">The user principal name (UPN) of the user.</param>
+        /// <returns>The configuration value.</returns>
+        public T GetValueForUser(string userPrincipalName)
+        {
+            ArgumentNullException.ThrowIfNull(userPrincipalName, nameof(userPrincipalName));
+
+            var userException = Exceptions
+                .SingleOrDefault(e => e.UserPrincipalName == userPrincipalName && e.Enabled);
+
+            return userException == null ? Value : userException.Value;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string into a <see cref="ConfigurationValue{T}"/>.
+        /// </summary>
+        /// <param name="json">The serialized representation of the configuration value.</param>
+        /// <returns>A <see cref="ConfigurationValue{T}"/> providing the configuration value.</returns>
+        public static ConfigurationValue<T> Deserialize(string json) =>
+            JsonSerializer.Deserialize<ConfigurationValue<T>>(json)!;
+    }
+
+    /// <summary>
+    /// Provides the user-specific value of a strongly typed configuration value.
+    /// </summary>
+    /// <typeparam name="T">The type of the configuration value.</typeparam>
+    public class ConfigurationValueException<T>
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the configuration value is enabled.
+        /// </summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user principal name for the user to which the exception applies.
+        /// </summary>
+        [JsonPropertyName("user_principal_name")]
+        public required string UserPrincipalName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the configuration exception entry.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public required T Value { get; set; }
+    }
+}

--- a/src/dotnet/Common/Settings/FileStoreConfiguration.cs
+++ b/src/dotnet/Common/Settings/FileStoreConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
+
+namespace FoundationaLLM.Common.Settings
+{
+    /// <summary>
+    /// The configuration for the file store.
+    /// </summary>
+    public class FileStoreConfiguration
+    {
+        /// <summary>
+        /// Indicates the maximum number of files that can be uploaded in a single message.
+        /// </summary>
+        public int MaxUploadsPerMessage { get; set; } = 10;
+        /// <summary>
+        /// A list of API endpoint configurations for file store connectors.
+        /// </summary>
+        public IEnumerable<APIEndpointConfiguration>? FileStoreConnectors { get; set; }
+    }
+}

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -293,6 +293,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_CoreAPI_Configuration_AllowedUploadFileExtensions =
             "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:APIEndpoints:CoreAPI:Configuration:MaxUploadsPerMessage setting.
+        /// <para>Value description:<br/>The maximum number of files that can be uploaded for a single conversation message.</para>
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_CoreAPI_Configuration_MaxUploadsPerMessage =
+            "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:MaxUploadsPerMessage";
 
         #endregion
 

--- a/src/dotnet/Core/Interfaces/ICoreService.cs
+++ b/src/dotnet/Core/Interfaces/ICoreService.cs
@@ -6,6 +6,7 @@ using FoundationaLLM.Common.Models.Orchestration.Response;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
+using FoundationaLLM.Common.Settings;
 
 namespace FoundationaLLM.Core.Interfaces;
 
@@ -155,4 +156,12 @@ public interface ICoreService
     /// <returns>A list of API endpoint configurations for file store connectors.</returns>
     Task<IEnumerable<APIEndpointConfiguration>> GetFileStoreConnectors(string instanceId,
         UnifiedUserIdentity userIdentity);
+
+    /// <summary>
+    /// Gets the file store configuration for the given instance.
+    /// </summary>
+    /// <param name="instanceId">The FoundationaLLM instance id.</param>
+    /// <param name="userIdentity">The <see cref="UnifiedUserIdentity"/> providing information about the calling user identity.</param>
+    /// <returns>The file store configuration.</returns>
+    Task<FileStoreConfiguration> GetFileStoreConfiguration(string instanceId, UnifiedUserIdentity userIdentity);
 }

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -9,7 +9,6 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Configuration.Branding;
 using FoundationaLLM.Common.Models.Conversation;
-using FoundationaLLM.Common.Models.Orchestration;
 using FoundationaLLM.Common.Models.Orchestration.Request;
 using FoundationaLLM.Common.Models.Orchestration.Response;
 using FoundationaLLM.Common.Models.Orchestration.Response.OpenAI;
@@ -19,6 +18,7 @@ using FoundationaLLM.Common.Models.ResourceProviders.AIModel;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using FoundationaLLM.Common.Models.ResourceProviders.AzureOpenAI;
 using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
+using FoundationaLLM.Common.Settings;
 using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Core.Models;
 using FoundationaLLM.Core.Models.Configuration;
@@ -26,7 +26,6 @@ using FoundationaLLM.Core.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Graph.Models;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Conversation = FoundationaLLM.Common.Models.Conversation.Conversation;
@@ -538,6 +537,16 @@ public partial class CoreService(
         var apiEndpointConfigurations = await _configurationResourceProvider.GetResourcesAsync<APIEndpointConfiguration>(instanceId, userIdentity);
         var resources = apiEndpointConfigurations.Select(c => c.Resource).ToList();
         return resources.Where(c => c.Category == APIEndpointCategory.FileStoreConnector);
+    }
+
+    /// <inheritdoc/>
+    public async Task<FileStoreConfiguration> GetFileStoreConfiguration(string instanceId, UnifiedUserIdentity userIdentity)
+    {
+        var configuration = new FileStoreConfiguration
+        {
+            FileStoreConnectors = await GetFileStoreConnectors(instanceId, userIdentity)
+        };
+        return configuration;
     }
 
     private IDownstreamAPIService GetDownstreamAPIService(AgentGatekeeperOverrideOption agentOption) =>

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -542,9 +542,17 @@ public partial class CoreService(
     /// <inheritdoc/>
     public async Task<FileStoreConfiguration> GetFileStoreConfiguration(string instanceId, UnifiedUserIdentity userIdentity)
     {
+        var appConfigurationValue = await _configurationResourceProvider.GetResourceAsync<AppConfigurationKeyValue>(
+            instanceId,
+            AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_MaxUploadsPerMessage,
+            userIdentity);
+
+        var configurationValue = ConfigurationValue<int>.Deserialize(appConfigurationValue.Value!);
+
         var configuration = new FileStoreConfiguration
         {
-            FileStoreConnectors = await GetFileStoreConnectors(instanceId, userIdentity)
+            FileStoreConnectors = await GetFileStoreConnectors(instanceId, userIdentity),
+            MaxUploadsPerMessage = configurationValue.GetValueForUser(userIdentity.UPN!)
         };
         return configuration;
     }

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -542,7 +542,7 @@ public partial class CoreService(
     /// <inheritdoc/>
     public async Task<FileStoreConfiguration> GetFileStoreConfiguration(string instanceId, UnifiedUserIdentity userIdentity)
     {
-        var appConfigurationValue = await _configurationResourceProvider.GetResourceAsync<AppConfigurationKeyValue>(
+        var appConfigurationValue = await _configurationResourceProvider.GetResourceAsync<AppConfigurationKeyBase>(
             instanceId,
             AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_MaxUploadsPerMessage,
             userIdentity);

--- a/src/dotnet/CoreAPI/Controllers/FilesController.cs
+++ b/src/dotnet/CoreAPI/Controllers/FilesController.cs
@@ -118,12 +118,12 @@ namespace FoundationaLLM.Core.API.Controllers
 
 
         /// <summary>
-        /// Returns a list of file store connectors.
+        /// Returns the file store configuration.
         /// </summary>
         /// <param name="instanceId">The instance ID.</param>
         /// <returns></returns>
-        [HttpGet("file-store-connectors")]
+        [HttpGet("file-store-configuration")]
         public async Task<IActionResult> GetFileStoreConnectors(string instanceId) =>
-            new OkObjectResult(await _coreService.GetFileStoreConnectors(instanceId, _callContext.CurrentUserIdentity!));
+            new OkObjectResult(await _coreService.GetFileStoreConfiguration(instanceId, _callContext.CurrentUserIdentity!));
     }
 }

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -29,7 +29,10 @@
 					@click="toggle"
 					@keydown.esc="hideAllPoppers"
 				/>
-				<OverlayPanel ref="menu" style="max-width: 98%">
+				<OverlayPanel
+					ref="menu"
+					:dismissable="false"
+					style="max-width: 98%">
 					<div class="file-upload-header">
 						<Button
 							:icon="!isMobile ? 'pi pi-times' : undefined"
@@ -358,14 +361,14 @@ export default {
 					mode: 'multiple',
 				},
 			},
-			oneDriveFiles: [],
-			localFiles: [],
+			oneDriveFiles: [] as any[],
+			localFiles: [] as any[],
 			oneDriveBaseURL: null as string | null,
 			disconnectingOneDrive: false,
-			connectingOneDrive: false,
 			fileToDelete: null as any,
 			deleteFileProcessing: false,
 			connectingOneDrive: true,
+			maxFiles: 5,
 		};
 	},
 
@@ -405,7 +408,7 @@ export default {
 			this.connectingOneDrive = false;
 		}
 
-		await this.$appStore.getFileStoreConnectors();
+		await this.$appStore.getFileStoreConfiguration();
 		await this.$appStore.getAgents();
 
 		this.agents = this.$appStore.agents.map((agent) => ({
@@ -413,9 +416,13 @@ export default {
 			value: agent.resource.name,
 		}));
 
-		this.oneDriveBaseURL = this.$appStore.fileStoreConnectors.find(
+		this.oneDriveBaseURL = this.$appStore.fileStoreConfiguration.fileStoreConnectors?.find(
 			(connector) => connector.subcategory === 'OneDriveWorkSchool',
 		)?.url;
+
+		if (this.$appStore.fileStoreConfiguration.maxUploadsPerMessage) {
+			this.maxFiles = this.$appStore.fileStoreConfiguration.maxUploadsPerMessage;
+		}
 	},
 
 	mounted() {
@@ -443,7 +450,9 @@ export default {
 			console.log('resize');
 			this.isMobile = window.screen.width < 950;
 			this.$nextTick(() => {
-				this.$refs.menu.alignOverlay();
+				if (this.$refs.menu) {
+					this.$refs.menu.alignOverlay();
+				}
 			});
 		},
 
@@ -607,14 +616,18 @@ export default {
 			return `${formattedSize} ${sizes[i]}`;
 		},
 
-		fileSelected(event: any) {
+		validateUploadedFiles(files: any) {
 			const allowedFileTypes = this.$appConfigStore.allowedUploadFileExtensions;
 			const filteredFiles: any[] = [];
 
-			event.files.forEach((file: any) => {
-				const fileAlreadyExists = this.localFiles.some(
+			files.forEach((file: any) => {
+				const localFileAlreadyExists = this.localFiles.some(
 					(existingFile: any) => existingFile.name === file.name && existingFile.size === file.size,
 				);
+				const oneDriveFileAlreadyExists = this.oneDriveFiles.some(
+					(existingFile: any) => existingFile.name === file.name && existingFile.size === file.size,
+				);
+				const fileAlreadyExists = localFileAlreadyExists || oneDriveFileAlreadyExists;
 
 				if (fileAlreadyExists) return;
 
@@ -646,6 +659,23 @@ export default {
 					filteredFiles.push(file);
 				}
 			});
+
+			if (this.localFiles.length + this.oneDriveFiles.length + filteredFiles.length > this.maxFiles) {
+				this.$toast.add({
+					severity: 'error',
+					summary: 'Error',
+					detail: `You can only upload a maximum of ${this.maxFiles} files at a time.`,
+					life: 5000,
+				});
+				filteredFiles.splice((this.maxFiles - (this.localFiles.length + this.oneDriveFiles.length)));
+			}
+
+			return filteredFiles;
+		},
+
+		fileSelected(event: any) {
+			const filteredFiles: any[] = [];
+			filteredFiles.push(...this.validateUploadedFiles(event.files));
 
 			this.localFiles = [...this.localFiles, ...filteredFiles];
 
@@ -743,7 +773,7 @@ export default {
 
 			form.submit();
 
-			window.addEventListener('message', (event) => {
+			const handleWindowMessage = (event) => {
 				const message = event.data;
 
 				if (
@@ -757,7 +787,10 @@ export default {
 						type: 'activate',
 					});
 				}
-			});
+			};
+
+			window.removeEventListener('message', handleWindowMessage);
+			window.addEventListener('message', handleWindowMessage);
 		},
 
 		async messageListener(event) {
@@ -807,13 +840,10 @@ export default {
 							break;
 
 						case 'pick':
-							console.log(command.items);
-							command.items.forEach((item) => {
-								console.log(`Picked: ${JSON.stringify(item)}`);
-								this.oneDriveFiles.push(item);
-							});
+							const filteredFiles: any[] = [];
+							filteredFiles.push(...this.validateUploadedFiles(command.items));
 
-							// this.oneDriveFiles.push(...command.items);
+							this.oneDriveFiles.push(...filteredFiles);
 
 							this.$nextTick(() => {
 								this.$refs.menu.alignOverlay();

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -368,7 +368,7 @@ export default {
 			fileToDelete: null as any,
 			deleteFileProcessing: false,
 			connectingOneDrive: true,
-			maxFiles: 5,
+			maxFiles: 10,
 		};
 	},
 

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -664,7 +664,7 @@ export default {
 				this.$toast.add({
 					severity: 'error',
 					summary: 'Error',
-					detail: `You can only upload a maximum of ${this.maxFiles} files at a time.`,
+					detail: `You can only upload a maximum of ${this.maxFiles} ${this.maxFiles === 1 ? 'file' : 'files'} at a time.`,
 					life: 5000,
 				});
 				filteredFiles.splice((this.maxFiles - (this.localFiles.length + this.oneDriveFiles.length)));

--- a/src/ui/UserPortal/js/api.ts
+++ b/src/ui/UserPortal/js/api.ts
@@ -2,7 +2,7 @@ import type {
 	Message,
 	Session,
 	UserProfile,
-	FileStoreConnector,
+	FileStoreConfiguration,
 	OneDriveWorkSchool,
 	ChatSessionProperties,
 	CompletionPrompt,
@@ -10,7 +10,6 @@ import type {
 	CompletionRequest,
 	ResourceProviderGetResult,
 	ResourceProviderUpsertResult,
-	// ResourceProviderDeleteResult,
 	ResourceProviderDeleteResults,
 } from '@/js/types';
 
@@ -374,10 +373,15 @@ export default {
 		})) as ResourceProviderDeleteResults;
 	},
 
-	async getFileStoreConnectors() {
+	/**
+	 * Retrieves the file store configuration for the current instance.
+	 *
+	 * @returns {Promise<FileStoreConfiguration>} A promise that resolves to the file store configuration.
+	 */
+	async getFileStoreConfiguration() {
 		return (await this.fetch(
-			`/instances/${this.instanceId}/files/file-store-connectors`,
-		)) as FileStoreConnector[];
+			`/instances/${this.instanceId}/files/file-store-configuration`,
+		)) as FileStoreConfiguration;
 	},
 
 	/**

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -135,6 +135,11 @@ export interface UserProfile {
 	flags: Record<string, boolean>;
 }
 
+export interface FileStoreConfiguration {
+    maxUploadsPerMessage: number;
+    fileStoreConnectors?: FileStoreConnector[];
+}
+
 export interface FileStoreConnector {
 	name: string;
 	category: string;

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -7,11 +7,10 @@ import type {
 	Message,
 	UserProfile,
 	Agent,
-	FileStoreConnector,
+	FileStoreConfiguration,
 	OneDriveWorkSchool,
 	ResourceProviderGetResult,
 	ResourceProviderUpsertResult,
-	// ResourceProviderDeleteResult,
 	ResourceProviderDeleteResults,
 	Attachment,
 	MessageContent,
@@ -32,7 +31,7 @@ export const useAppStore = defineStore('app', {
 		lastSelectedAgent: null as ResourceProviderGetResult<Agent> | null,
 		attachments: [] as Attachment[],
 		longRunningOperations: new Map<string, string>(), // sessionId -> operationId
-		fileStoreConnectors: [] as FileStoreConnector[],
+		fileStoreConfiguration: null as FileStoreConfiguration | null,
 		oneDriveWorkSchool: null as boolean | null,
 		userProfiles: null as UserProfile | null,
 	}),
@@ -384,9 +383,9 @@ export const useAppStore = defineStore('app', {
 			return this.agents;
 		},
 
-		async getFileStoreConnectors() {
-			this.fileStoreConnectors = await api.getFileStoreConnectors();
-			return this.fileStoreConnectors;
+		async getFileStoreConfiguration() {
+			this.fileStoreConfiguration = await api.getFileStoreConfiguration();
+			return this.fileStoreConfiguration;
 		},
 
 		async oneDriveWorkSchoolConnect() {

--- a/src/ui/UserPortal/stores/authStore.ts
+++ b/src/ui/UserPortal/stores/authStore.ts
@@ -30,7 +30,7 @@ export const useAuthStore = defineStore('auth', {
 
 		oneDriveWorkSchoolScopes() {
 			const appStore = useAppStore();
-			return appStore.fileStoreConnectors.find(
+			return appStore.fileStoreConfiguration?.fileStoreConnectors?.find(
 				(connector) => connector.subcategory === 'OneDriveWorkSchool',
 			)?.authentication_parameters['scope'];
 		},
@@ -133,7 +133,7 @@ export const useAuthStore = defineStore('auth', {
 
 		async getOneDriveWorkSchoolToken(): string | null {
 			const appStore = useAppStore();
-			const oneDriveBaseURL = appStore.fileStoreConnectors.find(
+			const oneDriveBaseURL = appStore.fileStoreConfiguration?.fileStoreConnectors?.find(
 				(connector) => connector.subcategory === 'OneDriveWorkSchool',
 			)?.url;
 			const oneDriveToken = await this.msalInstance.acquireTokenSilent({


### PR DESCRIPTION
# File store config and file upload improvements

## The issue or feature being addressed

This PR adds a file store configuration class to indicate the maximum number of files users can upload with a message and stores the list of file connectors, such as OneDrive. It also improves file uploading and file validation.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
