### PR TITLE
Removing unsupported image sizes for DALL-E on Azure

### DIFF
--- a/src/python/PythonSDK/foundationallm/services/image_service.py
+++ b/src/python/PythonSDK/foundationallm/services/image_service.py
@@ -258,7 +258,7 @@ class ImageService:
                         "n": {"type": "integer", "description": "The number of images to generate. Default is 1. For DALL-E 3, the maximum value is 1."},
                         "quality": {"type": "string", "description": "The quality of the image.", "enum": ["standard", "hd"]},
                         "style": {"type": "string", "description": "The style of the image.", "enum": ["natural", "vivid"]},
-                        "size": {"type": "string", "description": "The size of the image in pixels.", "enum": ['256x256', '512x512', '1024x1024', '1792x1024', '1024x1792']}
+                        "size": {"type": "string", "description": "The size of the image in pixels.", "enum": ['1024x1024', '1792x1024', '1024x1792']}
                     },
                     "additionalProperties": False,
                     "required": ["prompt"]


### PR DESCRIPTION
# Removing unsupported image sizes for DALL-E on Azure

## The issue or feature being addressed

Fixes an issue with images being generated in unsupported sizes, resulting in errors.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
