### PR TITLE
Track file uploads across sessions and make generated images responsive

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -50,8 +50,8 @@
 							<div
 								v-if="
 									fileArrayFiltered.length === 0 &&
-									oneDriveFiles.length === 0 &&
-									localFiles.length === 0
+									currentOneDriveFiles.length === 0 &&
+									currentLocalFiles.length === 0
 								"
 								class="file-upload-empty-desktop"
 							>
@@ -98,7 +98,7 @@
 								</div>
 								<Divider v-if="fileArrayFiltered.length > 0" />
 								<div
-									v-for="file of localFiles"
+									v-for="file of currentLocalFiles"
 									:key="file.name + file.type + file.size"
 									class="file-upload-file"
 								>
@@ -123,9 +123,9 @@
 										/>
 									</div>
 								</div>
-								<div v-if="oneDriveFiles && oneDriveFiles.length > 0">
+								<div v-if="currentOneDriveFiles && currentOneDriveFiles.length > 0">
 									<div
-										v-for="file of oneDriveFiles"
+										v-for="file of currentOneDriveFiles"
 										:key="file.name + file.size"
 										class="file-upload-file"
 									>
@@ -153,7 +153,7 @@
 								</div>
 							</div>
 							<div
-								v-if="oneDriveFiles.length > 0 || localFiles.length > 0"
+								v-if="currentOneDriveFiles.length > 0 || currentLocalFiles.length > 0"
 								class="file-upload-button-container"
 							>
 								<Button
@@ -161,13 +161,13 @@
 									label="Upload"
 									class="file-upload-container-button"
 									style="margin-top: 0.5rem"
-									:disabled="isUploading || (localFiles.length === 0 && oneDriveFiles.length === 0)"
+									:disabled="isUploading || (currentLocalFiles.length === 0 && currentOneDriveFiles.length === 0)"
 									@click="handleUpload"
 								/>
 							</div>
 						</template>
 					</FileUpload>
-					<Divider v-if="oneDriveFiles.length > 0 || localFiles.length > 0" />
+					<Divider v-if="currentOneDriveFiles.length > 0 || currentLocalFiles.length > 0" />
 					<div class="file-overlay-panel__footer">
 						<Button
 							:icon="!isMobile ? 'pi pi-file-plus' : undefined"
@@ -379,9 +379,13 @@ export default {
 					mode: 'multiple',
 				},
 			},
-			oneDriveFiles: [] as any[],
-			localFiles: [] as any[],
-			uploadedFiles: [] as any[],
+			sessionFiles: {
+            	sessionId: {
+					oneDriveFiles: [] as any[],
+					localFiles: [] as any[],
+					uploadedFiles: [] as any[]
+				}
+        	},
 			oneDriveBaseURL: null as string | null,
 			disconnectingOneDrive: false,
 			fileToDelete: null as any,
@@ -396,6 +400,22 @@ export default {
 			return this.$appStore.attachments.filter(
 				(attachment) => attachment.sessionId === this.$appStore.currentSession.sessionId,
 			);
+		},
+
+		currentSessionFiles() {
+			return this.getFilesForSession(this.$appStore.currentSession.sessionId);
+		},
+
+		currentOneDriveFiles() {
+			return this.currentSessionFiles.oneDriveFiles;
+		},
+
+		currentLocalFiles() {
+			return this.currentSessionFiles.localFiles;
+		},
+
+		currentUploadedFiles() {
+			return this.currentSessionFiles.uploadedFiles;
 		},
 	},
 
@@ -454,6 +474,40 @@ export default {
 	},
 
 	methods: {
+		getFilesForSession(sessionId) {
+			// Check if sessionFiles[sessionId] exists, if not, initialize it.
+			if (!this.sessionFiles[sessionId]) {
+				this.sessionFiles[sessionId] = { oneDriveFiles: [], localFiles: [], uploadedFiles: [] };
+			}
+			return this.sessionFiles[sessionId];
+		},
+		
+		addFileToSession(sessionId, file, type) {
+			const files = this.getFilesForSession(sessionId);
+			if (type === 'oneDrive') {
+				files.oneDriveFiles.push(file);
+			} else if (type === 'local') {
+				files.localFiles.push(file);
+			} else if (type === 'uploaded') {
+				files.uploadedFiles.push(file);
+			}
+		},
+
+		removeFileFromSession(sessionId, file, type) {
+			const files = this.getFilesForSession(sessionId);
+			if (type === 'oneDrive') {
+				files.oneDriveFiles = files.oneDriveFiles.filter(f => f !== file);
+			} else if (type === 'local') {
+				files.localFiles = files.localFiles.filter(f => f !== file);
+			} else if (type === 'uploaded') {
+				files.uploadedFiles = files.uploadedFiles.filter(f => f.name !== file.fileName);
+			}
+		},
+
+		clearFilesForSession(sessionId) {
+			this.sessionFiles[sessionId] = { oneDriveFiles: [], localFiles: [], uploadedFiles: [] };
+		},
+		
 		toggle(event: any) {
 			this.$refs.menu.toggle(event);
 		},
@@ -497,8 +551,12 @@ export default {
 				});
 			}
 
-			const totalFiles = this.localFiles.length + this.oneDriveFiles.length;
-			const combinedFiles = [...this.localFiles, ...this.oneDriveFiles];
+			// Use session-based file arrays
+			const sessionId = this.$appStore.currentSession.sessionId;
+			const currentFiles = this.getFilesForSession(sessionId);
+			const totalFiles = currentFiles.localFiles.length + currentFiles.oneDriveFiles.length;
+			const combinedFiles = [...currentFiles.localFiles, ...currentFiles.oneDriveFiles];
+
 			combinedFiles.forEach((file) => {
 				if (file instanceof File) {
 					file.source = 'local';
@@ -506,11 +564,12 @@ export default {
 					file.source = 'oneDrive';
 				}
 			});
+
 			let filesUploaded = 0;
 			let filesFailed = 0;
 			const filesProgress = [];
 
-			combinedFiles.forEach(async (file: any, index) => {
+			combinedFiles.forEach(async (file, index) => {
 				try {
 					if (file.source === 'local') {
 						const formData = new FormData();
@@ -531,7 +590,7 @@ export default {
 
 						await this.$appStore.uploadAttachment(
 							formData,
-							this.$appStore.currentSession.sessionId,
+							sessionId,
 							onProgress,
 						);
 					} else if (file.source === 'oneDrive') {
@@ -541,24 +600,21 @@ export default {
 						);
 					}
 					filesUploaded += 1;
-					this.uploadedFiles.push(file);
+					currentFiles.uploadedFiles.push(file);
 				} catch (error) {
 					filesFailed += 1;
 					this.$toast.add({
 						severity: 'error',
 						summary: 'Error',
-						detail: `File upload failed for "${file.name}". ${
-							error.message ? error.message : error.title ? error.title : ''
-						}`,
+						detail: `File upload failed for "${file.name}". ${error.message || error.title || ''}`,
 						life: 5000,
 					});
 				} finally {
 					if (totalFiles === filesUploaded + filesFailed) {
-						// this.showFileUploadDialog = false;
 						this.isUploading = false;
 						this.uploadProgress = 0;
-						this.oneDriveFiles = [];
-						this.localFiles = [];
+						currentFiles.oneDriveFiles = [];
+						currentFiles.localFiles = [];
 						if (this.$refs.menu.visible) {
 							this.$nextTick(() => {
 								this.$refs.menu.alignOverlay();
@@ -586,20 +642,24 @@ export default {
 
 		removeDialogFile() {
 			this.deleteFileProcessing = true;
+			const sessionId = this.$appStore.currentSession.sessionId;
+			const currentFiles = this.getFilesForSession(sessionId);
+
 			if (this.fileToDelete.type === 'local') {
-				this.removeLocalFile(this.fileToDelete.file);
+				this.removeLocalFile(currentFiles, this.fileToDelete.file);
 			} else if (this.fileToDelete.type === 'oneDrive') {
-				this.removeOneDriveFile(this.fileToDelete.file);
+				this.removeOneDriveFile(currentFiles, this.fileToDelete.file);
 			} else if (this.fileToDelete.type === 'attachment') {
-				this.removeAttachment(this.fileToDelete.file);
+				this.removeAttachment(currentFiles, this.fileToDelete.file);
 			}
+			this.removeFileFromSession(sessionId, this.fileToDelete.file, 'uploaded');
 		},
 
-		async removeAttachment(file: any) {
+		async removeAttachment(currentFiles, file) {
 			await this.$appStore.deleteAttachment(file);
 			this.fileToDelete = null;
 			this.deleteFileProcessing = false;
-			this.uploadedFiles = this.uploadedFiles.filter(
+			currentFiles.uploadedFiles = currentFiles.uploadedFiles.filter(
 				(uploadedFile) => uploadedFile.name !== file.name,
 			);
 
@@ -610,8 +670,8 @@ export default {
 			}
 		},
 
-		removeLocalFile(file: any) {
-			this.localFiles = this.localFiles.filter((localFile) => localFile.name !== file.name);
+		removeLocalFile(currentFiles, file) {
+			currentFiles.localFiles = currentFiles.localFiles.filter((localFile) => localFile.name !== file.name);
 			this.fileToDelete = null;
 			this.deleteFileProcessing = false;
 
@@ -622,8 +682,8 @@ export default {
 			}
 		},
 
-		removeOneDriveFile(file: any) {
-			this.oneDriveFiles = this.oneDriveFiles.filter(
+		removeOneDriveFile(currentFiles, file) {
+			currentFiles.oneDriveFiles = currentFiles.oneDriveFiles.filter(
 				(oneDriveFile) => oneDriveFile.name !== file.name,
 			);
 			this.fileToDelete = null;
@@ -655,22 +715,21 @@ export default {
 			return `${formattedSize} ${sizes[i]}`;
 		},
 
-		validateUploadedFiles(files: any) {
+		validateUploadedFiles(files, currentFiles) {
 			const allowedFileTypes = this.$appConfigStore.allowedUploadFileExtensions;
-			const filteredFiles: any[] = [];
+			const filteredFiles = [];
 
-			files.forEach((file: any) => {
-				const localFileAlreadyExists = this.localFiles.some(
-					(existingFile: any) => existingFile.name === file.name && existingFile.size === file.size,
+			files.forEach((file) => {
+				const localFileAlreadyExists = currentFiles.localFiles.some(
+					(existingFile) => existingFile.name === file.name && existingFile.size === file.size,
 				);
-				const oneDriveFileAlreadyExists = this.oneDriveFiles.some(
-					(existingFile: any) => existingFile.name === file.name && existingFile.size === file.size,
+				const oneDriveFileAlreadyExists = currentFiles.oneDriveFiles.some(
+					(existingFile) => existingFile.name === file.name && existingFile.size === file.size,
 				);
-				const uploadedFileAlreadyExists = this.uploadedFiles.some(
-					(existingFile: any) => existingFile.name === file.name && existingFile.size === file.size,
+				const uploadedFileAlreadyExists = currentFiles.uploadedFiles.some(
+					(existingFile) => existingFile.name === file.name && existingFile.size === file.size,
 				);
-				const fileAlreadyExists =
-					localFileAlreadyExists || oneDriveFileAlreadyExists || uploadedFileAlreadyExists;
+				const fileAlreadyExists = localFileAlreadyExists || oneDriveFileAlreadyExists || uploadedFileAlreadyExists;
 
 				if (fileAlreadyExists) return;
 
@@ -685,7 +744,7 @@ export default {
 					const fileExtension = file.name.split('.').pop()?.toLowerCase();
 					const isFileTypeAllowed = allowedFileTypes
 						.split(',')
-						.map((type: string) => type.trim().toLowerCase())
+						.map((type) => type.trim().toLowerCase())
 						.includes(fileExtension);
 
 					if (!isFileTypeAllowed) {
@@ -704,11 +763,8 @@ export default {
 			});
 
 			if (
-				this.localFiles.length +
-					this.oneDriveFiles.length +
-					this.uploadedFiles.length +
-					filteredFiles.length >
-				this.maxFiles
+				currentFiles.localFiles.length + currentFiles.oneDriveFiles.length + currentFiles.uploadedFiles.length + filteredFiles.length >
+					this.maxFiles
 			) {
 				this.$toast.add({
 					severity: 'error',
@@ -717,8 +773,7 @@ export default {
 					life: 5000,
 				});
 				filteredFiles.splice(
-					this.maxFiles -
-						(this.localFiles.length + this.oneDriveFiles.length + this.uploadedFiles.length),
+					this.maxFiles - (currentFiles.localFiles.length + currentFiles.oneDriveFiles.length + currentFiles.uploadedFiles.length),
 				);
 			}
 
@@ -726,10 +781,11 @@ export default {
 		},
 
 		fileSelected(event: any) {
-			const filteredFiles: any[] = [];
-			filteredFiles.push(...this.validateUploadedFiles(event.files));
+			const sessionId = this.$appStore.currentSession.sessionId;
+			const currentFiles = this.getFilesForSession(sessionId);
 
-			this.localFiles = [...this.localFiles, ...filteredFiles];
+			const filteredFiles = this.validateUploadedFiles(event.files, currentFiles);
+			currentFiles.localFiles = [...currentFiles.localFiles, ...filteredFiles];
 
 			if (this.$refs.fileUpload) {
 				this.$refs.fileUpload.clear();
@@ -866,7 +922,7 @@ export default {
 						id: message.id,
 					});
 
-					const command: any = message.data;
+					const command = message.data;
 
 					switch (command.command) {
 						case 'authenticate': {
@@ -897,11 +953,13 @@ export default {
 							this.showOneDriveIframeDialog = false;
 							break;
 
-						case 'pick':
-							const filteredFiles: any[] = [];
-							filteredFiles.push(...this.validateUploadedFiles(command.items));
+						case 'pick': {
+							const filteredFiles = [];
+							const sessionId = this.$appStore.currentSession.sessionId;
+							const currentFiles = this.getFilesForSession(sessionId);
 
-							this.oneDriveFiles.push(...filteredFiles);
+							filteredFiles.push(...this.validateUploadedFiles(command.items, currentFiles));
+							currentFiles.oneDriveFiles.push(...filteredFiles);
 
 							this.$nextTick(() => {
 								this.$refs.menu.alignOverlay();
@@ -921,6 +979,7 @@ export default {
 								},
 							});
 							break;
+						}
 
 						default:
 							console.warn(`Unsupported command: ${JSON.stringify(command)}`, 2);

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -795,6 +795,12 @@ $textColor: var(--accent-text);
 	width: 50vw;
 }
 
+.message__body img {
+    max-width: 100% !important;
+    height: auto !important;
+    display: block !important;
+}
+
 @media only screen and (max-width: 950px) {
 	.prompt-dialog {
 		width: 90vw;


### PR DESCRIPTION
# Track file uploads across sessions and make generated images responsive

## The issue or feature being addressed

Tracks pending and uploaded images across chat sessions, ensuring file upload limits are properly enforced and pending files remain within the conversation before being uploaded.

Makes generated images responsive for a better experience on small screens and mobile.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
