### PR TITLE
(0.8.3) Allow multiple files per conversation & do not override user prompt on orchestration error

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -349,8 +349,7 @@ public partial class CoreService(
                         ItemId = conversationItems.UserMessage.Id,
                         PropertyValues = new Dictionary<string, object?>
                         {
-                            { "/status", OperationStatus.Failed },
-                            { "/text", result.StatusMessage }
+                            { "/status", OperationStatus.Failed }
                         }
                     },
                     new PatchOperationItem<Message>

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -537,7 +537,8 @@ export default {
 		handleSend() {
 			this.$emit('send', this.text);
 			this.text = '';
-			this.uploadedFiles = [];
+			const sessionId = this.$appStore.currentSession.sessionId;
+			this.clearFilesForSession(sessionId);
 			this.text = DEFAULT_INPUT_TEXT;
 		},
 


### PR DESCRIPTION
# (0.8.3) Allow multiple files per conversation & do not override user prompt on orchestration error

## The issue or feature being addressed

Cherry-pick PR for #1875 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
