### PR TITLE
(0.8.3) Removing conversion of image annotations to image content items

### DIFF
--- a/src/dotnet/Core/Utils/FileMethods.cs
+++ b/src/dotnet/Core/Utils/FileMethods.cs
@@ -9,13 +9,13 @@ namespace FoundationaLLM.Core.Utils
     {
         private static readonly Dictionary<string, string> FileTypeMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            { ".jpg", MessageContentItemTypes.ImageFile },
-            { ".jpeg", MessageContentItemTypes.ImageFile },
-            { ".png", MessageContentItemTypes.ImageFile },
-            { ".gif", MessageContentItemTypes.ImageFile },
-            { ".bmp", MessageContentItemTypes.ImageFile },
-            { ".svg", MessageContentItemTypes.ImageFile },
-            { ".webp", MessageContentItemTypes.ImageFile },
+            //{ ".jpg", MessageContentItemTypes.ImageFile },
+            //{ ".jpeg", MessageContentItemTypes.ImageFile },
+            //{ ".png", MessageContentItemTypes.ImageFile },
+            //{ ".gif", MessageContentItemTypes.ImageFile },
+            //{ ".bmp", MessageContentItemTypes.ImageFile },
+            //{ ".svg", MessageContentItemTypes.ImageFile },
+            //{ ".webp", MessageContentItemTypes.ImageFile },
             { ".html", MessageContentItemTypes.HTML },
             { ".htm", MessageContentItemTypes.HTML }
         };


### PR DESCRIPTION
# Removing conversion of image annotations to image content items

## Details on the issue fix or feature implementation

Cherry-pick of commits is PR #1884.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
