### PR TITLE
(0.8.3) Handling failures in Assistant API streaming response

### DIFF
--- a/src/python/LangChainAPI/app/routers/completions.py
+++ b/src/python/LangChainAPI/app/routers/completions.py
@@ -170,10 +170,9 @@ async def create_completion_response(
             )
         except Exception as e:
             # Send the completion response to the State API and mark the operation as failed.
-            error_message = f'Operation {operation_id} failed with error: {e}'
-            print(error_message)
+            print(f'Operation {operation_id} failed with error: {e}')
             error_content = OpenAITextMessageContentItem(
-                value = error_message,
+                value = f'{e}',
                 agent_capability_category = AgentCapabilityCategories.OPENAI_ASSISTANTS if AgentCapabilityCategories.OPENAI_ASSISTANTS in completion_request.agent.capabilities else AgentCapabilityCategories.FOUNDATIONALLM_KNOWLEDGE_MANAGEMENT
             )
             completion_response = CompletionResponse(

--- a/src/python/PythonSDK/foundationallm/event_handlers/openai_assistant_async_event_handler.py
+++ b/src/python/PythonSDK/foundationallm/event_handlers/openai_assistant_async_event_handler.py
@@ -56,6 +56,13 @@ class OpenAIAssistantAsyncEventHandler(AsyncAssistantEventHandler):
         elif event.event == "thread.message.completed":
             self.messages[event.data.id] = event.data # Overwrite the message with the final version.
             await self.update_state_api_content()
+        elif "failed" in event.event:
+            print(f'{event.event} ({event.data.id}): {event.data.last_error.message}')
+            if event.event == "thread.run.failed":
+                raise Exception(event.data.last_error.message)
+            elif event.event == "thread.run.step.failed":
+                pass
+                # Don't end the run, but print out the error for the logs.
 
     @override
     async def on_text_delta(self, delta: TextDelta, snapshot: Text) -> None:


### PR DESCRIPTION
# (0.8.3) Handling failures in Assistant API streaming response

## Details on the issue fix or feature implementation

Cherry-pick of PR #1887 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
