### PR TITLE
OneDrive iframe mobile view fix

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -381,6 +381,17 @@ export default {
 				selection: {
 					mode: 'multiple',
 				},
+				// pivots: {
+				// 	oneDrive: true,
+				// 	recent: false,
+				// 	shared: false,
+				// 	sharedLibraries: false,
+				// 	myOrganization: false,
+				// 	favorites: false,
+				// },
+				leftNav: {
+					enabled: false,
+				},
 			},
 			sessionFiles: {
 				sessionId: {

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -260,6 +260,7 @@
 			<Dialog
 				v-model:visible="showOneDriveIframeDialog"
 				modal
+				:closable="false"
 				aria-label="OneDrive File Picker Dialog"
 				style="max-width: 98%; min-width: 50%; max-height: 98%"
 				class="onedrive-iframe-dialog"
@@ -1198,6 +1199,10 @@ export default {
 </style>
 
 <style lang="scss">
+.onedrive-iframe-dialog .p-dialog-header {
+	padding: 5px;
+}
+
 @media only screen and (max-width: 545px) {
 	.submit .p-button-label {
 		display: none;

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -381,17 +381,6 @@ export default {
 				selection: {
 					mode: 'multiple',
 				},
-				// pivots: {
-				// 	oneDrive: true,
-				// 	recent: false,
-				// 	shared: false,
-				// 	sharedLibraries: false,
-				// 	myOrganization: false,
-				// 	favorites: false,
-				// },
-				leftNav: {
-					enabled: false,
-				},
 			},
 			sessionFiles: {
 				sessionId: {

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -321,7 +321,7 @@ export default {
 						content: failedMessage,
 						value: failedMessage,
 						origValue: failedMessage,
-					}
+					},
 				];
 			}
 


### PR DESCRIPTION
# OneDrive iframe mobile view fix

## The issue or feature being addressed

Fixes issue where select and close buttons are missing when viewing OneDrive file picker on certain mobile screens.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable