### PR TITLE
Allow for IP address resolution in Nuxt for Browserstack testing

### DIFF
--- a/src/ui/UserPortal/nuxt.config.ts
+++ b/src/ui/UserPortal/nuxt.config.ts
@@ -55,6 +55,7 @@ export default defineNuxtConfig({
 	devServer: {
 		...(buildLoadingTemplate ? { loadingTemplate: () => buildLoadingTemplate } : {}),
 		port: 3000,
+		host: '0.0.0.0'
 	},
 	runtimeConfig: {
 		APP_CONFIG_ENDPOINT: process.env.APP_CONFIG_ENDPOINT,


### PR DESCRIPTION
# Allow for IP address resolution in Nuxt for Browserstack testing

## The issue or feature being addressed

Adding the host: '0.0.0.0' allows for the Nuxt server to respond to **private** IP address requests. This enables iOS real device testing from Browserstack as iOS blocks resolution of localhost URLs.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
