### PR TITLE
Update the default JSON value formatting

### DIFF
--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -416,7 +416,7 @@
 				"name": "MaxUploadsPerMessage",
 				"description": "The maximum number of files that can be uploaded for a single conversation message.",
 				"secret": "",
-				"value": "{ 'value': 10, 'value_exceptions': []}",
+				"value": "{ \\\"value\\\": 10, \\\"value_exceptions\\\": []}",
 				"content_type": "application/json",
 				"first_version": "0.8.2"
 			},
@@ -424,7 +424,7 @@
 				"name": "CompletionResponsePollingIntervalSeconds",
 				"description": "The size in seconds of the polling interval used to check for completion responses.",
 				"secret": "",
-				"value": "{ 'value': 10, 'value_exceptions': []}",
+				"value": "{ \\\"value\\\": 10, \\\"value_exceptions\\\": []}",
 				"content_type": "application/json",
 				"first_version": "0.8.2"
 			}

--- a/src/dotnet/Common/Constants/Data/RoleDefinitions.json
+++ b/src/dotnet/Common/Constants/Data/RoleDefinitions.json
@@ -156,5 +156,34 @@
 		"updated_on": "2024-03-07T00:00:00.0000000Z",
 		"created_by": null,
 		"updated_by": null
+	},
+	{
+		"type": "FoundationaLLM.Authorization/roleDefinitions",
+		"name": "d0d21b90-5317-499a-9208-3a6cb71b84f9",
+		"object_id": "/providers/FoundationaLLM.Authorization/roleDefinitions/d0d21b90-5317-499a-9208-3a6cb71b84f9",
+		"display_name": "Conversations Contributor",
+		"description": "Create and update conversations, including Azure OpenAI Assistants threads.",
+		"assignable_scopes": [
+			"/"
+		],
+		"permissions": [
+			{
+				"actions": [
+					"FoundationaLLM.Conversation/conversations/read",
+					"FoundationaLLM.Conversation/conversations/write",
+					"FoundationaLLM.AzureOpenAI/assistantUserContexts/read",
+					"FoundationaLLM.AzureOpenAI/assistantUserContexts/write",
+					"FoundationaLLM.Configuration/apiEndpointConfigurations/read",
+					"FoundationaLLM.AIModel/aiModels/read"
+				],
+				"not_actions": [],
+				"data_actions": [],
+				"not_data_actions": []
+			}
+		],
+		"created_on": "2024-10-22T00:00:00.0000000Z",
+		"updated_on": "2024-10-22T00:00:00.0000000Z",
+		"created_by": null,
+		"updated_by": null
 	}
 ]

--- a/src/dotnet/Common/Templates/RoleDefinitions.cs
+++ b/src/dotnet/Common/Templates/RoleDefinitions.cs
@@ -179,6 +179,37 @@ namespace FoundationaLLM.Common.Models.Authorization
                         UpdatedBy = null
                     }
                 },
+                {
+                    "/providers/FoundationaLLM.Authorization/roleDefinitions/d0d21b90-5317-499a-9208-3a6cb71b84f9",
+                    new RoleDefinition
+                    {
+                        Name = "d0d21b90-5317-499a-9208-3a6cb71b84f9",
+                        Type = "FoundationaLLM.Authorization/roleDefinitions",
+                        ObjectId = "/providers/FoundationaLLM.Authorization/roleDefinitions/d0d21b90-5317-499a-9208-3a6cb71b84f9",
+                        DisplayName = "Conversations Contributor",
+                        Description = "Create and update conversations, including Azure OpenAI Assistants threads.",
+                        AssignableScopes = [
+                            "/",],
+                        Permissions = [                            
+                            new RoleDefinitionPermissions
+                            {
+                                Actions = [
+                                    "FoundationaLLM.Conversation/conversations/read",
+                                    "FoundationaLLM.Conversation/conversations/write",
+                                    "FoundationaLLM.AzureOpenAI/assistantUserContexts/read",
+                                    "FoundationaLLM.AzureOpenAI/assistantUserContexts/write",
+                                    "FoundationaLLM.Configuration/apiEndpointConfigurations/read",
+                                    "FoundationaLLM.AIModel/aiModels/read",],
+                                NotActions = [],
+                                DataActions = [],
+                                NotDataActions = [],
+                            },],
+                        CreatedOn = DateTimeOffset.Parse("2024-10-22T00:00:00.0000000Z"),
+                        UpdatedOn = DateTimeOffset.Parse("2024-10-22T00:00:00.0000000Z"),
+                        CreatedBy = null,
+                        UpdatedBy = null
+                    }
+                },
             });
     }
 }

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -198,14 +198,14 @@
         },
         {
             "key": "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:MaxUploadsPerMessage",
-            "value": "{ 'value': 10, 'value_exceptions': []}",
+            "value": "{ \"value\": 10, \"value_exceptions\": []}",
             "label": null,
             "content_type": "application/json",
             "tags": {}
         },
         {
             "key": "FoundationaLLM:APIEndpoints:CoreAPI:Configuration:CompletionResponsePollingIntervalSeconds",
-            "value": "{ 'value': 10, 'value_exceptions': []}",
+            "value": "{ \"value\": 10, \"value_exceptions\": []}",
             "label": null,
             "content_type": "application/json",
             "tags": {}


### PR DESCRIPTION
# Update the default JSON value formatting

## The issue or feature being addressed

Fixes the default values for the `FoundationaLLM:APIEndpoints:CoreAPI:Configuration:CompletionResponsePollingIntervalSeconds` and `FoundationaLLM:APIEndpoints:CoreAPI:Configuration:MaxUploadsPerMessage` App Config settings. The default values are using single quotes for the JSON properties instead of double quotes.

Adds the Conversation role definition for assigning RBAC permissions.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
