### PR TITLE
Fix incorrect copyright character

### DIFF
--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1331,7 +1331,7 @@
 				"name": "FooterText",
 				"description": "Footer text.",
 				"secret": "",
-				"value": "FoundationaLLM (c) 2024",
+				"value": "FoundationaLLM © 2024",
 				"content_type": "",
 				"first_version": "0.8.0"
 			}

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -751,7 +751,7 @@
         },
         {
             "key": "FoundationaLLM:Branding:FooterText",
-            "value": "FoundationaLLM (c) 2024",
+            "value": "FoundationaLLM © 2024",
             "label": null,
             "content_type": "",
             "tags": {}


### PR DESCRIPTION
# Fix incorrect copyright character

## The issue or feature being addressed

An incorrect copyright character is used in the default footer text configuration.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
