### PR TITLE
Add agent tools type and property to the Management Portal

### DIFF
--- a/src/ui/ManagementPortal/js/types.ts
+++ b/src/ui/ManagementPortal/js/types.ts
@@ -44,6 +44,7 @@ export type Agent = ResourceBase & {
 	};
 
 	capabilities: string[];
+	tools: { [key: string]: AgentTool };
 
 	sessions_enabled: boolean;
 	orchestration_settings: {
@@ -84,6 +85,14 @@ export type AgentDataSource = ResourceBase & {
 	name: string;
 	content_source: string;
 	object_id: string;
+};
+
+export type AgentTool = {
+	name: string;
+	description: string;
+	ai_model_object_ids: { [key: string]: string };
+	api_endpoint_configuration_object_ids: { [key: string]: string };
+	properties: { [key: string]: any };
 };
 
 export type ExternalOrchestrationService = ResourceBase & {
@@ -320,6 +329,7 @@ export type CreateAgentRequest = ResourceBase & {
 	};
 
 	capabilities: string[];
+	tools: { [key: string]: AgentTool };
 
 	vectorization: {
 		dedicated_pipeline: boolean;

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -715,6 +715,7 @@ import type {
 	Agent,
 	AgentIndex,
 	AgentDataSource,
+	AgentTool,
 	AIModel,
 	DataSource,
 	CreateAgentRequest,
@@ -816,6 +817,7 @@ export default {
 			textEmbeddingProfileSources: [] as TextEmbeddingProfile[],
 			externalOrchestratorOptions: [] as ExternalOrchestrationService[],
 			aiModelOptions: [] as AIModel[],
+			tools: {} as { [key: string]: AgentTool },
 
 			orchestratorOptions: [
 				{
@@ -974,6 +976,7 @@ export default {
 			}
 			this.loadingStatusText = `Mapping agent values to form...`;
 			this.mapAgentToForm(agent);
+			this.tools = agent.tools;
 		} else {
 			this.editable = true;
 		}
@@ -1281,6 +1284,8 @@ export default {
 					prompt_object_id: promptObjectId,
 					orchestration_settings: this.orchestration_settings,
 					ai_model_object_id: this.selectedAIModel.object_id,
+
+					tools: this.tools,
 				};
 
 				if (this.editAgent) {


### PR DESCRIPTION
# Add agent tools type and property to the Management Portal

## The issue or feature being addressed

Adds the `tools` property to the `Agent` model, along with the new `AgentTool` type. This enables users to update an existing agent without wiping out its defined tools.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
