### PR TITLE
Conversation audit fields and property for no agents message

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -66,6 +66,13 @@ When upgrading an existing FoundationaLLM instance, the items from the `resource
 
 Refer to the dedicated upgrade tool for instructions on how to perform this update.
 
+### Configuration changes
+
+This release adds a new App Config setting that should be added to existing environments that are upgrading to 0.8.4 and beyond:
+
+- App Config key: `FoundationaLLM:Branding:NoAgentsMessage`
+- App Config value: `No agents available. Please check with your system administrator for assistance.`
+
 ## Starting with 0.8.3
 
 ### Resource provider changes

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1334,6 +1334,14 @@
 				"value": "FoundationaLLM © 2024",
 				"content_type": "",
 				"first_version": "0.8.0"
+			},
+			{
+				"name": "NoAgentsMessage",
+				"description": "Message to display to users when their agent list is empty.",
+				"secret": "",
+				"value": "No agents available. Please check with your system administrator for assistance.",
+				"content_type": "",
+				"first_version": "0.8.4"
 			}
 		]
 	},

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -981,6 +981,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_Branding_FooterText =
             "FoundationaLLM:Branding:FooterText";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:Branding:NoAgentsMessage setting.
+        /// <para>Value description:<br/>Message to display to users when their agent list is empty.</para>
+        /// </summary>
+        public const string FoundationaLLM_Branding_NoAgentsMessage =
+            "FoundationaLLM:Branding:NoAgentsMessage";
 
         #endregion
 

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -751,7 +751,14 @@
         },
         {
             "key": "FoundationaLLM:Branding:FooterText",
-            "value": "FoundationaLLM © 2024",
+            "value": "FoundationaLLM � 2024",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:Branding:NoAgentsMessage",
+            "value": "No agents available. Please check with your system administrator for assistance.",
             "label": null,
             "content_type": "",
             "tags": {}

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -750,11 +750,11 @@
             "tags": {}
         },
 				{
-					"key": "FoundationaLLM:Branding:FooterText",
-					"value": "FoundationaLLM © 2024",
-					"label": null,
-					"content_type": "",
-					"tags": {}
+						"key": "FoundationaLLM:Branding:FooterText",
+						"value": "FoundationaLLM © 2024",
+						"label": null,
+						"content_type": "",
+						"tags": {}
 				},
         {
             "key": "FoundationaLLM:Branding:NoAgentsMessage",

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -749,13 +749,13 @@
             "content_type": "",
             "tags": {}
         },
-        {
-            "key": "FoundationaLLM:Branding:FooterText",
-            "value": "FoundationaLLM � 2024",
-            "label": null,
-            "content_type": "",
-            "tags": {}
-        },
+				{
+					"key": "FoundationaLLM:Branding:FooterText",
+					"value": "FoundationaLLM © 2024",
+					"label": null,
+					"content_type": "",
+					"tags": {}
+				},
         {
             "key": "FoundationaLLM:Branding:NoAgentsMessage",
             "value": "No agents available. Please check with your system administrator for assistance.",

--- a/src/dotnet/Conversation/ResourceProviders/ConversationResourceProviderService.cs
+++ b/src/dotnet/Conversation/ResourceProviders/ConversationResourceProviderService.cs
@@ -130,6 +130,8 @@ namespace FoundationaLLM.Conversation.ResourceProviders
                     $"The user {userIdentity.UPN} is not authorized to use the provided resource to update the {resourcePath.RawResourcePath} resource path.",
                     StatusCodes.Status403Forbidden);
 
+            UpdateBaseProperties(updatedConversation, userIdentity, existingConversation == null);
+
             if (existingConversation == null
                 || string.IsNullOrWhiteSpace(updatedConversation.ObjectId))
                 updatedConversation.ObjectId = resourcePath.RawResourcePath;


### PR DESCRIPTION
# Conversation audit fields and property for no agents message

## The issue or feature being addressed

Ensures audit properties are populated when creating or saving a conversation. Adds App Config property (`FoundationaLLM:Branding:NoAgentsMessage`) to display a message to users when their agent list is empty.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
