### PR TITLE
Set the default category for the AzureOpenAI endpoint configuration to LLM

### DIFF
--- a/deploy/quick-start/data/resource-provider/FoundationaLLM.Configuration/AzureOpenAI.template.json
+++ b/deploy/quick-start/data/resource-provider/FoundationaLLM.Configuration/AzureOpenAI.template.json
@@ -5,7 +5,8 @@
     "display_name": null,
     "description": null,
     "cost_center": null,
-    "category": "General",
+    "category": "LLM",
+    "subcategory": null,
     "authentication_type": "APIKey",
     "api_version": "2024-07-01-preview",
     "authentication_parameters": {

--- a/deploy/standard/data/resource-provider/FoundationaLLM.Configuration/AzureOpenAI.template.json
+++ b/deploy/standard/data/resource-provider/FoundationaLLM.Configuration/AzureOpenAI.template.json
@@ -5,7 +5,8 @@
     "display_name": null,
     "description": null,
     "cost_center": null,
-    "category": "General",
+    "category": "LLM",
+    "subcategory": null,
     "authentication_type": "APIKey",
     "api_version": "2024-07-01-preview",
     "authentication_parameters": {

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -68,10 +68,18 @@ Refer to the dedicated upgrade tool for instructions on how to perform this upda
 
 ### Configuration changes
 
+#### App Config settings
+
 This release adds a new App Config setting that should be added to existing environments that are upgrading to 0.8.4 and beyond:
 
 - App Config key: `FoundationaLLM:Branding:NoAgentsMessage`
 - App Config value: `No agents available. Please check with your system administrator for assistance.`
+
+#### Resource provider templates
+
+The `AzureOpenAI.template.json` files within `deploy/quick-start/data/resource-provider/FoundationaLLM.Configuration` and `deploy/standard/data/resource-provider/FoundationaLLM.Configuration` have been updated to set the `category` field to the value `LLM`. This discriminator allows the Management Portal to filter the list of API endpoints by category and provide options to add AI Models to endpoints with the `LLM` category.
+
+The existing `category` property needs to be set to `LLM` on existing API endpoint configurations in the `FoundationaLLM.Configuration` resource provider that fit this description, including the `AzureOpenAI` endpoint configuration.
 
 ## Starting with 0.8.3
 


### PR DESCRIPTION
# Set the default category for the `AzureOpenAI` endpoint configuration to LLM

## The issue or feature being addressed

Changes the default `category` property value for the `AzureOpenAI` endpoint configuration from "General" to "LLM". This change helps differentiate endpoint types for which one or more AI models should be configured.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
