### PR TITLE
Removing duplicate OneDriveFileStoreConnector entry in resource references

### DIFF
--- a/deploy/common/data/resource-provider/FoundationaLLM.Configuration/_resource-references.json
+++ b/deploy/common/data/resource-provider/FoundationaLLM.Configuration/_resource-references.json
@@ -55,12 +55,6 @@
 			"Deleted": false
 		},
 		{
-			"Name": "OneDriveFileStoreConnector",
-			"Filename": "/FoundationaLLM.Configuration/OneDriveFileStoreConnector.json",
-			"Type": "api-endpoint",
-			"Deleted": false
-		},
-		{
 			"Name": "SemanticKernelAPI",
 			"Filename": "/FoundationaLLM.Configuration/SemanticKernelAPI.json",
 			"Type": "api-endpoint",


### PR DESCRIPTION
# Removing duplicate OneDriveFileStoreConnector entry in resource references

## Details on the issue fix or feature implementation

Removing duplicate OneDriveFileStoreConnector entry in resource references.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
