### PR TITLE
User Portal conversation improvements

### DIFF
--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -87,6 +87,10 @@ export default {
 			return this.$appStore.currentSession;
 		},
 
+		pollingSession() {
+			return this.$appStore.pollingSession;
+		},
+
 		lastSelectedAgent() {
 			return this.$appStore.lastSelectedAgent;
 		},
@@ -102,12 +106,24 @@ export default {
 			this.isMessagePending = false;
 			this.isLoading = true;
 			this.userSentMessage = false;
+			
 			await this.$appStore.getMessages();
 			this.$appStore.updateSessionAgentFromMessages(newSession);
+			
 			this.welcomeMessage = this.$appStore.getSessionAgent(newSession)?.resource?.properties?.['welcome_message'] ??
 				this.$appConfigStore.defaultAgentWelcomeMessage ??
 				'Start the conversation using the text box below.';
 			this.isLoading = false;
+		},
+
+		async pollingSession(newPollingSession, oldPollingSession) {
+			if (newPollingSession === oldPollingSession) return;
+			if (newPollingSession === this.currentSession.id) {
+				this.isMessagePending = true;
+			}
+			else {
+				this.isMessagePending = false;
+			}
 		},
 
 		async lastSelectedAgent(newAgent, oldAgent) {
@@ -172,7 +188,7 @@ export default {
 			// await this.$appStore.getMessages();
 			// }
 
-			this.isMessagePending = false;
+			//this.isMessagePending = false;
 		},
 	},
 };

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -24,6 +24,8 @@ export const useAppStore = defineStore('app', {
 	state: () => ({
 		sessions: [] as Session[],
 		currentSession: null as Session | null,
+		newSession: null as Session | null, // Used to store the newly created session. Deleted after the first prompt is sent. This is to prevent an unnecessary fetch of its messages.
+		pollingSession: null as string | null, // Contains the ID of a session that is currently being polled for completion.
 		renamedSessions: [] as Session[],
 		deletedSessions: [] as Session[],
 		currentMessages: [] as Message[],
@@ -158,6 +160,7 @@ export const useAppStore = defineStore('app', {
 
 			const newSession = await api.addSession(properties);
 			await this.getSessions(newSession);
+			this.newSession = newSession;
 
 			// Only add newSession to the list if it doesn't already exist.
 			// We optionally add it because the backend is sometimes slow to update the session list.
@@ -231,6 +234,11 @@ export const useAppStore = defineStore('app', {
 		},
 
 		async getMessages() {
+			if (this.newSession && this.newSession.id === this.currentSession!.id) {
+				// This is a new session, no need to fetch messages.
+				this.currentMessages = [];
+				return;
+			}
 			const messagesResponse = await api.getMessages(this.currentSession.id);
 
 			// Temporarily filter out the duplicate streaming message instances
@@ -263,7 +271,7 @@ export const useAppStore = defineStore('app', {
 					latestMessage.operation_id &&
 					(latestMessage.status === 'InProgress' || latestMessage.status === 'Pending')
 				) {
-					this.startPolling(latestMessage);
+					this.startPolling(latestMessage, this.currentSession.id);
 				}
 			}
 		},
@@ -399,9 +407,12 @@ export const useAppStore = defineStore('app', {
 
 			// For older messages that have a status of "Pending" but no operation id, assume
 			// it is complete and do no initiate polling as it will return empty data
-			if (message.operation_id) this.startPolling(message);
+			if (message.operation_id) this.startPolling(message, this.currentSession.id);
 
-			// return message;
+			// Remove the new session if matches this one, now that we have sent the first message.
+			if (this.newSession && this.newSession.id === initialSession) {
+				this.newSession = null;
+			}
 		},
 
 		getPollingRateMS() {
@@ -411,8 +422,11 @@ export const useAppStore = defineStore('app', {
 			);
 		},
 
-		startPolling(message) {
+		startPolling(message, sessionId: string) {
 			if (this.pollingInterval) return;
+
+			// Indicate that a message in this session is being polled for completion.
+			this.pollingSession = sessionId;
 
 			this.pollingInterval = setInterval(async () => {
 				try {
@@ -433,18 +447,19 @@ export const useAppStore = defineStore('app', {
 					}
 
 					if (updatedMessage.status === 'Completed' || updatedMessage.status === 'Failed') {
-						this.stopPolling();
+						this.stopPolling(sessionId);
 					}
 				} catch (error) {
 					console.error(error);
-					this.stopPolling();
+					this.stopPolling(sessionId);
 				}
 			}, this.getPollingRateMS());
 		},
 
-		stopPolling() {
+		stopPolling(sessionId: string) {
 			clearInterval(this.pollingInterval);
 			this.pollingInterval = null;
+			this.pollingSession = null;
 		},
 
 		/**
@@ -483,7 +498,7 @@ export const useAppStore = defineStore('app', {
 		},
 
 		changeSession(newSession: Session) {
-			this.stopPolling();
+			this.stopPolling(newSession.id);
 
 			const nuxtApp = useNuxtApp();
 			const appConfigStore = useAppConfigStore();


### PR DESCRIPTION
# User Portal conversation improvements

## The issue or feature being addressed

Prevent asking questions while the agent is processing the previous prompt. Optimize performance by not fetching messages after creating a new conversation.

## Details on the issue fix or feature implementation

Keeps track of message polling operations within a conversation, disabling the text input field to prevent sending another prompt while the previous prompt is still processing.

Optimizes performance when creating a new session by not fetching messages after creating a new conversation until after sending the first prompt.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
