### PR TITLE
Improve agent listing in the User Portal

### DIFF
--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -171,20 +171,31 @@ export default {
 
 		const publicAgentOptions = this.agentOptions.filter((agent) => !agent.my_agent);
 		const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
-		const noAgentOptions = [{ label: 'None', value: null, disabled: true }];
-		let allAgentsLabel = 'All Agents';
+		const noAgentOptions = [{
+			label: 'None',
+			value: null,
+			disabled: true,
+			type: '',
+			object_id: '',
+			description: ''
+		}];
+		let allAgentsLabel = '';
 		this.virtualUser = await this.$appStore.getVirtualUser();
 
 		this.agentOptionsGroup.push({
 			label: '',
-			items: [{ label: '--select--', value: null }],
+			items: [{
+				label: '--select--', value: null,
+				type: '',
+				object_id: '',
+				description: ''
+			}],
 		});
 
 		if (this.agentOptions.length === 0) {
-			this.agentOptionsGroup.push({
-				label: allAgentsLabel,
-				items: noAgentOptions,
-			});
+			// Append noAgentOptions to the last entry in the agentOptionsGroup
+			this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items
+				.push(...noAgentOptions);
 			return;
 		}
 
@@ -194,12 +205,16 @@ export default {
 				items: privateAgentOptions,
 			});
 			allAgentsLabel = 'Other Agents';
+			this.agentOptionsGroup.push({
+				label: 'Other Agents',
+				items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
+			});
 		}
-
-		this.agentOptionsGroup.push({
-			label: allAgentsLabel,
-			items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
-		});
+		else {
+			this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items
+				.push(...publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions);
+		}
+		
 	},
 
 	mounted() {

--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -169,9 +169,10 @@ export default {
 			this.emptyAgentsMessage = this.$appConfigStore.noAgentsMessage ?? null;
 		}
 
-		const publicAgentOptions = this.agentOptions;
+		const publicAgentOptions = this.agentOptions.filter((agent) => !agent.my_agent);
 		const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
 		const noAgentOptions = [{ label: 'None', value: null, disabled: true }];
+		let allAgentsLabel = 'All Agents';
 		this.virtualUser = await this.$appStore.getVirtualUser();
 
 		this.agentOptionsGroup.push({
@@ -179,14 +180,25 @@ export default {
 			items: [{ label: '--select--', value: null }],
 		});
 
-		this.agentOptionsGroup.push({
-			label: 'All Agents',
-			items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
-		});
+		if (this.agentOptions.length === 0) {
+			this.agentOptionsGroup.push({
+				label: allAgentsLabel,
+				items: noAgentOptions,
+			});
+			return;
+		}
+
+		if (privateAgentOptions.length > 0) {
+			this.agentOptionsGroup.push({
+				label: 'My Agents',
+				items: privateAgentOptions,
+			});
+			allAgentsLabel = 'Other Agents';
+		}
 
 		this.agentOptionsGroup.push({
-			label: 'My Agents',
-			items: privateAgentOptions.length > 0 ? privateAgentOptions : noAgentOptions,
+			label: allAgentsLabel,
+			items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
 		});
 	},
 


### PR DESCRIPTION
# Improve agent listing in the User Portal

## The issue or feature being addressed

Improves the logic of the agent dropdown list.

## Details on the issue fix or feature implementation

This PR adjusts the logic of the agent dropdown list to the following:

1. **No agents**: Persistent message displayed at the top of the page (already in place for 0.8.4), and the agent dropdown list only has a 'None' option.

    ![image](https://github.com/user-attachments/assets/acf7c7f3-ea5d-4fe8-8f7d-49452e859741)

2. **Only public/viewable agents and no "My Agents"**: The agent dropdown list only lists the public/viewable agents.

    ![image](https://github.com/user-attachments/assets/524a9a04-11c6-4334-a6f5-35b14885e71c)

3. **Have "My Agents" in addition to other (public/viewable) agents**: The agent dropdown list has **My Agents** at the top of the list and "Other Agents" underneath, which would be any public/viewable agents that the user does not "own".

    ![image](https://github.com/user-attachments/assets/1ede7731-c163-40e0-8dc6-ae7b6e416950)

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
