### PR TITLE
(0.8.4) Removing duplicate config keys

### DIFF
--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -896,13 +896,6 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:Branding:CompanyName";
         
         /// <summary>
-        /// The app configuration key for the FoundationaLLM:Branding:DefaultAgentWelcomeMessage setting.
-        /// <para>Value description:<br/>Default agent welcome message.</para>
-        /// </summary>
-        public const string FoundationaLLM_Branding_DefaultAgentWelcomeMessage =
-            "FoundationaLLM:Branding:DefaultAgentWelcomeMessage";
-        
-        /// <summary>
         /// The app configuration key for the FoundationaLLM:Branding:FavIconUrl setting.
         /// <para>Value description:<br/>Fav icon url.</para>
         /// </summary>
@@ -936,13 +929,6 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_Branding_LogoUrl =
             "FoundationaLLM:Branding:LogoUrl";
-        
-        /// <summary>
-        /// The app configuration key for the FoundationaLLM:Branding:NoAgentsMessage setting.
-        /// <para>Value description:<br/>No available agents message.</para>
-        /// </summary>
-        public const string FoundationaLLM_Branding_NoAgentsMessage =
-            "FoundationaLLM:Branding:NoAgentsMessage";
         
         /// <summary>
         /// The app configuration key for the FoundationaLLM:Branding:PageTitle setting.


### PR DESCRIPTION
# (0.8.4) Removing duplicate config keys

## Details on the issue fix or feature implementation

(0.8.4) Removing duplicate config keys resulting from two different PRs performing a similar change (adding two new configuration keys) into `release/0.8.4`.  This PR corrects that error.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
