### PR TITLE
Fix conversation/agent welcome messages and removes accessibility contrast settings

### DIFF
--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -217,7 +217,7 @@
 				<TabPanel header="Accessibility">
 					<div class="setting-option">
 						<h4 id="auto-hide-toasts" class="setting-option-label">
-							Auto hide toast notifications
+							Auto hide popup notifications
 						</h4>
 						<InputSwitch v-model="$appStore.autoHideToasts" aria-labelledby="auto-hide-toasts" />
 					</div>
@@ -238,10 +238,10 @@
 							<p>{{ Math.round(($appStore.textSize / 1) * 100) }}%</p>
 						</div>
 					</div>
-					<div class="setting-option">
+					<!-- <div class="setting-option">
 						<h4 id="contrast" class="setting-option-label">High contrast mode</h4>
 						<InputSwitch v-model="$appStore.highContrastMode" aria-labelledby="contrast" />
-					</div>
+					</div> -->
 				</TabPanel>
 			</TabView>
 			<template #footer>

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -109,10 +109,8 @@ export default {
 			
 			await this.$appStore.getMessages();
 			this.$appStore.updateSessionAgentFromMessages(newSession);
-			
-			this.welcomeMessage = this.$appStore.getSessionAgent(newSession)?.resource?.properties?.['welcome_message'] ??
-				this.$appConfigStore.defaultAgentWelcomeMessage ??
-				'Start the conversation using the text box below.';
+			let sessionAgent = this.$appStore.getSessionAgent(newSession);
+			this.welcomeMessage = this.getWelcomeMessage(sessionAgent);
 			this.isLoading = false;
 		},
 
@@ -128,13 +126,18 @@ export default {
 
 		async lastSelectedAgent(newAgent, oldAgent) {
 			if (newAgent === oldAgent) return;
-			this.welcomeMessage = newAgent?.resource?.properties?.['welcome_message'] ??
-				this.$appConfigStore.defaultAgentWelcomeMessage ??
-				'Start the conversation using the text box below.';
+			this.welcomeMessage = this.getWelcomeMessage(newAgent);
 		},
 	},
 
 	methods: {
+		getWelcomeMessage(agent) {
+			let welcomeMessage = agent?.resource?.properties?.['welcome_message'];
+			return welcomeMessage && welcomeMessage.trim() !== '' ? welcomeMessage :
+				this.$appConfigStore.defaultAgentWelcomeMessage ?? 
+				'Start the conversation using the text box below.';
+		},
+
 		getMessageOrderFromReversedIndex(index) {
 			return this.messages.length - 1 - index;
 		},


### PR DESCRIPTION
# Fix conversation/agent welcome messages and removes accessibility contrast settings

## The issue or feature being addressed

Fixes issue caused by the `welcome_message` property on an agent exists but empty, which causes the welcome message on a new conversation to be empty instead of falling back to the default welcome message.

Removes the high contrast accessibility setting for now.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
