### PR TITLE
Allow saving empty configuration values

### DIFF
--- a/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
+++ b/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
@@ -266,9 +266,6 @@ namespace FoundationaLLM.Configuration.Services
             if (string.IsNullOrWhiteSpace(appConfig.Key))
                 throw new ResourceProviderException("The key name is invalid.", StatusCodes.Status400BadRequest);
 
-            if (string.IsNullOrWhiteSpace(appConfig.Value))
-                throw new ResourceProviderException("The key value is invalid.", StatusCodes.Status400BadRequest);
-
             if (appConfig.ContentType == null)
                 throw new ResourceProviderException("The key content type is invalid.", StatusCodes.Status400BadRequest);
 


### PR DESCRIPTION
# Allow saving empty configuration values

## The issue or feature being addressed

400 error is thrown while attempting to save a blank value to an App Config setting. This PR removes the non-empty value enforcement.

## Details on the issue fix or feature implementation

It is valid to need to save an empty value to a configuration setting. For example, one might wish to clear out the `FoundationaLLM:Branding:AgentIconUrl` to use the default value. Doing so is not possible via the Management API while enforcing non-empty config values is in place. This change allows such valid actions to take place.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
