### PR TITLE
Unnecessary Attachment Role Assignments

### DIFF
--- a/src/dotnet/Common/Models/Authorization/ResourcePathAuthorizationResult.cs
+++ b/src/dotnet/Common/Models/Authorization/ResourcePathAuthorizationResult.cs
@@ -65,6 +65,6 @@ namespace FoundationaLLM.Common.Models.Authorization
         /// Owner role assignment is not required when at least one policy is assigned to the resource path.
         /// </remarks>
         [JsonIgnore]
-        public bool MustSetOwnerRoleAssignment => PolicyDefinitionIds.Count > 0;
+        public bool MustSetOwnerRoleAssignment => PolicyDefinitionIds.Count == 0;
     }
 }


### PR DESCRIPTION
# Unnecessary Attachment Role Assignments

## The issue or feature being addressed

Attachment security is controlled via PBAC, meaning that RBAC Owner role assignments aren't necessary.

## Details on the issue fix or feature implementation

This PR adjusts the policy assignments count check in `ResourcePathAuthorizationResult.cs`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
