### PR TITLE
Adding CosmosDB Data Contributor Role to Gatekeeper API

### DIFF
--- a/deploy/quick-start/infra/main.bicep
+++ b/deploy/quick-start/infra/main.bicep
@@ -618,6 +618,7 @@ var cosmosRoleTargets = [
   'core-job'
   'state-api'
   'gateway-api'
+  'gatekeeper-api'
   'orchestration-api'
   'management-api'
 ]

--- a/deploy/standard/infra/app-rg.bicep
+++ b/deploy/standard/infra/app-rg.bicep
@@ -406,6 +406,19 @@ module cosmosRoles './modules/sqlRoleAssignments.bicep' = {
   dependsOn: [srBackend]
 }
 
+module gatekeeperApiCosmosRoles './modules/sqlRoleAssignments.bicep' = {
+  scope: resourceGroup(storageResourceGroupName)
+  name: 'gatekeeper-api-cosmos-role'
+  params: {
+    accountName: cosmosDb.name
+    principalId: srBackend[indexOf(backendServiceNames, 'gatekeeper-api')].outputs.servicePrincipalId
+    roleDefinitionIds: {
+      'Cosmos DB Built-in Data Contributor': '00000000-0000-0000-0000-000000000002'
+    }
+  }
+  dependsOn: [srBackend]
+}
+
 module gatewayApiCosmosRoles './modules/sqlRoleAssignments.bicep' = {
   scope: resourceGroup(storageResourceGroupName)
   name: 'gateway-api-cosmos-role'


### PR DESCRIPTION
# Adding CosmosDB Data Contributor Role to Gatekeeper API

## Details on the issue fix or feature implementation

Adding CosmosDB Data Contributor Role to Gatekeeper API in Quick-Start and Standard Deployments.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
