### PR TITLE
Create Azure OpenAI Assistants at Deploy-Time for QS/Standard

### DIFF
--- a/deploy/quick-start/azd-hooks/postprovision.ps1
+++ b/deploy/quick-start/azd-hooks/postprovision.ps1
@@ -69,6 +69,20 @@ $env:POLICYGUID02 = $($(New-Guid).Guid)
 $env:POLICYGUID03 = $($(New-Guid).Guid)
 $env:POLICYGUID04 = $($(New-Guid).Guid)
 
+Invoke-AndRequireSuccess "Create New OpenAI Assistant" {
+    $accountInfo = $(az resource show --ids $env:AZURE_OPENAI_ID --query "{resourceGroup:resourceGroup,name:name}" | ConvertFrom-Json)
+    $oaiApiKey = $(az cognitiveservices account keys list --name $accountInfo.name --resource-group $accountInfo.resourceGroup --query "key1" --output tsv)
+    $env:OPENAI_ASSISTANT_ID = $(curl "https://$($accountInfo.name).openai.azure.com/openai/assistants?api-version=2024-05-01-preview" `
+        -H "api-key: $oaiApiKey" `
+        -H "Content-Type: application/json" `
+        -d '{
+            "instructions": "\nYou are an analytic agent named Khalil that helps people find information about FoundationaLLM.\nProvide concise answers that are polite and professional.\n\nContext:\nFoundationaLLM simplifies and streamlines building knowledge management (e.g., question/answer agents) and analytic (e.g., self-service business intelligence) copilots over the data sources present across your enterprise.\n\nFoundationaLLM deploys a secure, comprehensive and highly configurable copilot platform to your Azure cloud environment:\n\n- Simplifies integration with enterprise data sources used by agent for in-context learning (e.g., enabling RAG, CoT, ReAct and inner monologue patterns).\n- Provides defense in depth with fine-grain security controls over data used by agent and pre/post completion filters that guard against attack.\n- Hardened solution attacked by an LLM red team from inception.\n- Scalable solution load balances across multiple LLM endpoints.\n- Extensible to new data sources, new LLM orchestrators and LLMs.\n\nYou can learn more about FoundationaLLM at https://foundationallm.ai\n",
+            "name": "FoundationaLLM - FoundationaLLM",
+            "tools": [{"type": "code_interpreter"}, {"type": "file_search"}],
+            "model": "completions4o"
+        }' | ConvertFrom-Json).id
+}
+
 $envConfiguraitons = @{
     "core-api-event-profile"             = @{
         template     = './config/core-api-event-profile.template.json'

--- a/deploy/quick-start/azd-hooks/postprovision.ps1
+++ b/deploy/quick-start/azd-hooks/postprovision.ps1
@@ -72,15 +72,16 @@ $env:POLICYGUID04 = $($(New-Guid).Guid)
 Invoke-AndRequireSuccess "Create New OpenAI Assistant" {
     $accountInfo = $(az resource show --ids $env:AZURE_OPENAI_ID --query "{resourceGroup:resourceGroup,name:name}" | ConvertFrom-Json)
     $oaiApiKey = $(az cognitiveservices account keys list --name $accountInfo.name --resource-group $accountInfo.resourceGroup --query "key1" --output tsv)
+    $promptText = $((Get-Content "./data/resource-provider/FoundationaLLM.Prompt/FoundationaLLM.template.json") | ConvertFrom-Json).prefix
     $env:OPENAI_ASSISTANT_ID = $(curl "https://$($accountInfo.name).openai.azure.com/openai/assistants?api-version=2024-05-01-preview" `
         -H "api-key: $oaiApiKey" `
         -H "Content-Type: application/json" `
-        -d '{
-            "instructions": "\nYou are an analytic agent named Khalil that helps people find information about FoundationaLLM.\nProvide concise answers that are polite and professional.\n\nContext:\nFoundationaLLM simplifies and streamlines building knowledge management (e.g., question/answer agents) and analytic (e.g., self-service business intelligence) copilots over the data sources present across your enterprise.\n\nFoundationaLLM deploys a secure, comprehensive and highly configurable copilot platform to your Azure cloud environment:\n\n- Simplifies integration with enterprise data sources used by agent for in-context learning (e.g., enabling RAG, CoT, ReAct and inner monologue patterns).\n- Provides defense in depth with fine-grain security controls over data used by agent and pre/post completion filters that guard against attack.\n- Hardened solution attacked by an LLM red team from inception.\n- Scalable solution load balances across multiple LLM endpoints.\n- Extensible to new data sources, new LLM orchestrators and LLMs.\n\nYou can learn more about FoundationaLLM at https://foundationallm.ai\n",
-            "name": "FoundationaLLM - FoundationaLLM",
-            "tools": [{"type": "code_interpreter"}, {"type": "file_search"}],
-            "model": "completions4o"
-        }' | ConvertFrom-Json).id
+        -d "{
+            `"instructions`": `"$promptText`",
+            `"name`": `"FoundationaLLM - FoundationaLLM`",
+            `"tools`": [{`"type`": `"code_interpreter`"}, {`"type`": `"file_search`"}],
+            `"model`": `"completions4o`"
+        }" | ConvertFrom-Json).id
 }
 
 $envConfiguraitons = @{

--- a/deploy/quick-start/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
+++ b/deploy/quick-start/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
@@ -21,6 +21,10 @@
 	"capabilities": [
     "OpenAI.Assistants"
   ],
+  "properties": {
+    "welcome_message": "",
+    "Azure.OpenAI.Assistant.Id": "${env:OPENAI_ASSISTANT_ID}"
+  },
   "ai_model_object_id": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.AIModel/aiModels/DefaultCompletionAIModel",
   "prompt_object_id": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.Prompt/prompts/FoundationaLLM"
 }

--- a/deploy/standard/azd-hooks/utility/Upload-SystemPrompts.ps1
+++ b/deploy/standard/azd-hooks/utility/Upload-SystemPrompts.ps1
@@ -59,15 +59,17 @@ $sourcePath = '../../common/data/resource-provider' | Get-AbsolutePath
 Invoke-AndRequireSuccess "Create New OpenAI Assistant" {
     $accountInfo = $(az resource show --ids $env:AZURE_OPENAI_ID --query "{resourceGroup:resourceGroup,name:name}" | ConvertFrom-Json)
     $oaiApiKey = $(az cognitiveservices account keys list --name $accountInfo.name --resource-group $accountInfo.resourceGroup --query "key1" --output tsv)
+    $promptPath = "../data/resource-provider/FoundationaLLM.Prompt/FoundationaLLM.template.json" | Get-AbsolutePath
+    $promptText = $((Get-Content $promptPath) | ConvertFrom-Json).prefix
     $oaiAssistantId = $(curl "https://$($accountInfo.name).openai.azure.com/openai/assistants?api-version=2024-05-01-preview" `
         -H "api-key: $oaiApiKey" `
         -H "Content-Type: application/json" `
-        -d '{
-            "instructions": "\nYou are an analytic agent named Khalil that helps people find information about FoundationaLLM.\nProvide concise answers that are polite and professional.\n\nContext:\nFoundationaLLM simplifies and streamlines building knowledge management (e.g., question/answer agents) and analytic (e.g., self-service business intelligence) copilots over the data sources present across your enterprise.\n\nFoundationaLLM deploys a secure, comprehensive and highly configurable copilot platform to your Azure cloud environment:\n\n- Simplifies integration with enterprise data sources used by agent for in-context learning (e.g., enabling RAG, CoT, ReAct and inner monologue patterns).\n- Provides defense in depth with fine-grain security controls over data used by agent and pre/post completion filters that guard against attack.\n- Hardened solution attacked by an LLM red team from inception.\n- Scalable solution load balances across multiple LLM endpoints.\n- Extensible to new data sources, new LLM orchestrators and LLMs.\n\nYou can learn more about FoundationaLLM at https://foundationallm.ai\n",
-            "name": "FoundationaLLM - FoundationaLLM",
-            "tools": [{"type": "code_interpreter"}, {"type": "file_search"}],
-            "model": "completions4o"
-        }' | ConvertFrom-Json).id
+        -d "{
+            `"instructions`": `"$promptText`",
+            `"name`": `"FoundationaLLM - FoundationaLLM`",
+            `"tools`": [{`"type`": `"code_interpreter`"}, {`"type`": `"file_search`"}],
+            `"model`": `"completions4o`"
+        }" | ConvertFrom-Json).id
 
     $agentPath = $('../../common/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.json' | Get-AbsolutePath)
     (Get-Content $agentPath).Replace('{{oaiAssistantId}}', $oaiAssistantId) | Set-Content $agentPath

--- a/deploy/standard/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
+++ b/deploy/standard/data/resource-provider/FoundationaLLM.Agent/FoundationaLLM.template.json
@@ -21,6 +21,10 @@
   "capabilities": [
     "OpenAI.Assistants"
   ],
+  "properties": {
+    "welcome_message": "",
+    "Azure.OpenAI.Assistant.Id": "{{oaiAssistantId}}"
+  },
   "ai_model_object_id": "/instances/{{instanceId}}/providers/FoundationaLLM.AIModel/aiModels/DefaultCompletionAIModel",
   "prompt_object_id": "/instances/{{instanceId}}/providers/FoundationaLLM.Prompt/prompts/FoundationaLLM"
 }


### PR DESCRIPTION
# Create Azure OpenAI Assistants at Deploy-Time for QS/Standard

## The issue or feature being addressed

Currently, the default FoundationaLLM agent doesn't have an OpenAI Assistant ID associated with it. This means that it won't work unless an administrator saves the agent from the Management UI.

## Details on the issue fix or feature implementation

This fix uses the Azure OpenAI API to create the assistant required by the default FoundationaLLM agent.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
