### PR TITLE
Adds PackageName to AgentTool

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -9,12 +9,14 @@
 
 The following new App Configuration settings are required:
 
-Name | Default value
---- | ---
-`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-`
-`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-`
-`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-`
-`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-`
+|Name | Default value |
+|--- | --- |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` |
+
+#### Agent Tool configuration changes
 
 When defining tools for an agent, each tool now requires a `package_name` property. This property is used to identify the package that contains the tool's implementation. If the tool is internal, the `package_name` should be set to `FoundationaLLM`, if the tool is external, the `package_name` should be set to the name of the external package.
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -16,6 +16,8 @@ Name | Default value
 `FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-`
 `FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-`
 
+When defining tools for an agent, each tool now requires a `package_name` property. This property is used to identify the package that contains the tool's implementation. If the tool is internal, the `package_name` should be set to `FoundationaLLM`, if the tool is external, the `package_name` should be set to the name of the external package.
+
 ## Starting with 0.8.4
 
 ### Configuration changes

--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentTool.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentTool.cs
@@ -20,6 +20,14 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent
         public required string Description { get; set; }
 
         /// <summary>
+        /// Gets or sets the package name of the tool.
+        /// For internal tools, this value will be FoundationaLLM
+        /// For external tools, this value will be the name of the package.
+        /// </summary>
+        [JsonPropertyName("package_name")]
+        public required string PackageName { get; set; }
+
+        /// <summary>
         /// Gets or sets a dictionary of AI model object identifiers.
         /// </summary>
         /// <remarks>

--- a/src/python/PythonSDK/foundationallm/models/agents/agent_tool.py
+++ b/src/python/PythonSDK/foundationallm/models/agents/agent_tool.py
@@ -10,6 +10,7 @@ class AgentTool(BaseModel):
     """
     name: str = Field(..., description="The name of the agent tool.")
     description: str = Field(..., description="The description of the agent tool.")
+    package_name: str = Field(..., description="The package name of the agent tool. For internal tools, this value will be FoundationaLLM. For external tools, this value will be the name of the package.")
     ai_model_object_ids: Optional[dict] = Field(default=[], description="A dictionary object identifiers of the AIModel objects for the agent tool.")
     api_endpoint_configuration_object_ids: Optional[dict] = Field(default=[], description="A dictionary object identifiers of the APIEndpointConfiguration objects for the agent tool.")
     properties: Optional[dict] = Field(default=[], description="A dictionary of properties for the agent tool.")


### PR DESCRIPTION
# Adds PackageName to AgentTool
## Details on the issue fix or feature implementation

Adds required property "PackageName" to the AgentTool definition. When defining internal tools, this value is set to "FoundationaLLM" when using external imported tools, this values is the package name where the tool code is located.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

