### PR TITLE
Make the UserPrompt property writeable at runtime

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -35,6 +35,10 @@ jobs:
       working-directory: ./src/dotnet/Common
       run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true
 
+    - name: Build Configuration
+      working-directory: ./src/dotnet/Configuration
+      run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true
+
     - name: Build CoreClient
       working-directory: ./src/dotnet/CoreClient
       run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true
@@ -47,6 +51,10 @@ jobs:
       working-directory: ./src/dotnet/Common
       run: dotnet pack --configuration Release /p:PackageVersion=${{ steps.versioning.outputs.version }} -p:GITHUB_ACTIONS=true --output ./nupkg
 
+    - name: Pack Configuration
+      working-directory: ./src/dotnet/Configuration
+      run: dotnet pack --configuration Release /p:PackageVersion=${{ steps.versioning.outputs.version }} -p:GITHUB_ACTIONS=true --output ./nupkg
+
     - name: Pack CoreClient
       working-directory: ./src/dotnet/CoreClient
       run: dotnet pack --configuration Release /p:PackageVersion=${{ steps.versioning.outputs.version }} -p:GITHUB_ACTIONS=true --output ./nupkg
@@ -57,6 +65,10 @@ jobs:
 
     - name: Publish Common to NuGet
       working-directory: ./src/dotnet/Common
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Publish Configuration to NuGet
+      working-directory: ./src/dotnet/Configuration
       run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Publish CoreClient to NuGet

--- a/src/dotnet/Common/Models/Orchestration/Request/CompletionRequestBase.cs
+++ b/src/dotnet/Common/Models/Orchestration/Request/CompletionRequestBase.cs
@@ -30,7 +30,7 @@ namespace FoundationaLLM.Common.Models.Orchestration.Request
         /// Represent the input or user prompt.
         /// </summary>
         [JsonPropertyName("user_prompt")]
-        public required string UserPrompt { get; init; }
+        public required string UserPrompt { get; set; }
 
         /// <summary>
         /// The message history associated with the completion request.


### PR DESCRIPTION
# Make the UserPrompt property writeable at runtime

## The issue or feature being addressed

Reusing a `CompletionRequest` instance is not possible because the `UserPrompt` property does not have a getter.

## Details on the issue fix or feature implementation

Add a getter to the `UserPrompt` property on `CompletionRequest`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
