### PR TITLE
Vectorization Resource Provider Casting Fix

### DIFF
--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
@@ -709,7 +709,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
             ResourceProviderUpsertOptions? options = null) =>
             resource switch
             {
-                VectorizationRequest vectorizationRequest => (TResult) await UpdateVectorizationRequest(resourcePath, vectorizationRequest, userIdentity),
+                VectorizationRequest vectorizationRequest => (await UpdateVectorizationRequest(resourcePath, vectorizationRequest, userIdentity) as TResult)!,
                 _ => throw new ResourceProviderException(
                     $"The type {nameof(T)} is not supported by the {_name} resource provider.",
                     StatusCodes.Status400BadRequest)
@@ -717,7 +717,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
 
         #region Helpers for UpsertResourceAsync<T>
 
-        private async Task<ResourceProviderUpsertResult> UpdateVectorizationRequest(ResourcePath resourcePath, VectorizationRequest request, UnifiedUserIdentity userIdentity)
+        private async Task<ResourceProviderUpsertResult<VectorizationRequest>> UpdateVectorizationRequest(ResourcePath resourcePath, VectorizationRequest request, UnifiedUserIdentity userIdentity)
         {
             request.ObjectId = resourcePath.GetObjectId(_instanceSettings.Id, _name);
             await PopulateRequestResourceFilePath(request);
@@ -748,7 +748,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
                 default,
                 default);
 
-            return new ResourceProviderUpsertResult
+            return new ResourceProviderUpsertResult<VectorizationRequest>
             {
                 ObjectId = request.ObjectId,
                 ResourceExists = false


### PR DESCRIPTION
# Vectorization Resource Provider Casting Fix

## The issue or feature being addressed

Currently, the Vectorization API throws the following exception when requested to process a vectorization request.

```
Unable to cast object of type 'FoundationaLLM.Common.Models.ResourceProviders.ResourceProviderUpsertResult' to type 'FoundationaLLM.Common.Models.ResourceProviders.ResourceProviderUpsertResult`1[FoundationaLLM.Common.Models.ResourceProviders.Vectorization.VectorizationRequest]'. 
```

## Details on the issue fix or feature implementation

This PR corrects the cast inside `VectorizationResourceProviderService.cs`.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
