### PR TITLE
Adds RunnableConfig to LangGraph call to support passing vars to tools

### DIFF
--- a/src/python/LangChainAPI/requirements.txt
+++ b/src/python/LangChainAPI/requirements.txt
@@ -15,4 +15,5 @@ langgraph==0.2.53
 openai==1.55.3
 pydantic==2.8.2
 pylint==3.2.6
+unidecode==1.3.8
 uvicorn==0.30.5

--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -434,7 +434,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
             graph = create_react_agent(llm, tools=tools, state_modifier=self.prompt.prefix)
             messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
             messages.append(HumanMessage(content=request.user_prompt))
-            response = await graph.ainvoke({'messages': messages})
+            response = await graph.ainvoke({'messages': messages}, config={"configurable": {"original_user_prompt": self.prompt.prefix}})
             # TODO: process tool messages with analysis results AIMessage with content='' but has addition_kwargs={'tool_calls';[...]}
             # print(response)
             final_message = response["messages"][-1]

--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -434,7 +434,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
             graph = create_react_agent(llm, tools=tools, state_modifier=self.prompt.prefix)
             messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
             messages.append(HumanMessage(content=request.user_prompt))
-            response = await graph.ainvoke({'messages': messages}, config={"configurable": {"original_user_prompt": self.prompt.prefix}})
+            response = await graph.ainvoke({'messages': messages}, config={"configurable": {"original_user_prompt": request.user_prompt}})
             # TODO: process tool messages with analysis results AIMessage with content='' but has addition_kwargs={'tool_calls';[...]}
             # print(response)
             final_message = response["messages"][-1]

--- a/src/python/PythonSDK/requirements.txt
+++ b/src/python/PythonSDK/requirements.txt
@@ -16,3 +16,4 @@ opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0
 pandas==2.2.2
 pydantic==2.8.2
+unidecode==1.3.8


### PR DESCRIPTION
# Adds RunnableConfig to LangGraph call to support passing vars to tools

## Details on the issue fix or feature implementation

Invocation of the LangGraph ReAct agent graph now includes a config property that contains the original user prompt so that it may be retrieved on the tools associated with the run.

Adds Unidecode package to LangChain API and PythonSDK requirements.txt

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
