### PR TITLE
Adds IndexingProfileObjectIds and TextEmbeddingModelNames to AgentTool

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentTool.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentTool.cs
@@ -46,6 +46,18 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent
         public Dictionary<string, string> APIEndpointConfigurationObjectIds { get; set; } = [];
 
         /// <summary>
+        /// Gets or sets a dictionary of indexing profile object identifiers.
+        /// </summary>
+        [JsonPropertyName("indexing_profile_object_ids")]
+        public Dictionary<string, string> IndexingProfileObjectIds { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets a dictionary of text embedding model names.
+        /// </summary>
+        [JsonPropertyName("text_embedding_model_names")]
+        public Dictionary<string, string> TextEmbeddingModelNames { get; set; } = [];
+
+        /// <summary>
         /// Gets or sets a dictionary of properties that are specific to the tool.
         /// </summary>
         [JsonPropertyName("properties")]

--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -349,6 +349,15 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
 
                     explodedObjects[apiEndpointConfigurationObjectId] = toolAPIEndpointConfiguration;
                 }
+
+                foreach (var indexingProfileObjectId in tool.IndexingProfileObjectIds.Values)
+                {
+                    var indexingProfile = await vectorizationResourceProvider.GetResourceAsync<IndexingProfile>(
+                                               indexingProfileObjectId,
+                                               currentUserIdentity);
+
+                    explodedObjects[indexingProfileObjectId] = indexingProfile;                    
+                }
             }
 
             explodedObjects[CompletionRequestObjectsKeys.ToolNames] = toolNames;

--- a/src/python/PythonSDK/foundationallm/models/agents/agent_tool.py
+++ b/src/python/PythonSDK/foundationallm/models/agents/agent_tool.py
@@ -13,4 +13,6 @@ class AgentTool(BaseModel):
     package_name: str = Field(..., description="The package name of the agent tool. For internal tools, this value will be FoundationaLLM. For external tools, this value will be the name of the package.")
     ai_model_object_ids: Optional[dict] = Field(default=[], description="A dictionary object identifiers of the AIModel objects for the agent tool.")
     api_endpoint_configuration_object_ids: Optional[dict] = Field(default=[], description="A dictionary object identifiers of the APIEndpointConfiguration objects for the agent tool.")
+    indexing_profile_object_ids: Optional[dict] = Field(default=[], description="A dictionary object identifiers of the IndexingProfile objects for the agent tool.")
+    text_embedding_model_names: Optional[dict] = Field(default=[], description="A dictionary of text embedding model names for the agent tool.")
     properties: Optional[dict] = Field(default=[], description="A dictionary of properties for the agent tool.")


### PR DESCRIPTION
# Adds IndexingProfileObjectIds and TextEmbeddingModelNames to AgentTool

## Details on the issue fix or feature implementation

Provides indexing profiles and embedding model names dictionaries to the Agent Tool definition.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
