### PR TITLE
Fix the bug with incorrect loading of settings for service principal

### DIFF
--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -127,17 +127,17 @@ namespace FoundationaLLM.Core.API
             var requireScopes = true;
             var allowACLAuthorization = false;
             
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(AppConfigurationKeys
-                    .FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_RequireScopes)))
+            if (!string.IsNullOrWhiteSpace(builder.Configuration.GetValue<string>(
+                AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_RequireScopes)))
             {
-                bool.TryParse(Environment.GetEnvironmentVariable(AppConfigurationKeys
-                    .FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_RequireScopes), out requireScopes);
+                bool.TryParse(builder.Configuration.GetValue<string>(
+                    AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_RequireScopes), out requireScopes);
             }
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(AppConfigurationKeys
-                    .FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_AllowACLAuthorization)))
+            if (!string.IsNullOrWhiteSpace(builder.Configuration.GetValue<string>(
+                AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_AllowACLAuthorization)))
             {
-                bool.TryParse(Environment.GetEnvironmentVariable(AppConfigurationKeys
-                    .FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_AllowACLAuthorization), out allowACLAuthorization);
+                bool.TryParse(builder.Configuration.GetValue<string>(
+                    AppConfigurationKeys.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra_AllowACLAuthorization), out allowACLAuthorization);
             }
             if (isE2ETestEnvironment)
             {


### PR DESCRIPTION
# Fix the bug with incorrect loading of settings for service principal authentication in Core API

## The issue or feature being addressed

Cherry-pick for #2032 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
