### PR TITLE
Implement rating comments in the backend

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -34,6 +34,23 @@ The following classes have been renamed:
 | --- | --- |
 | `FoundationaLLM.Common.Models.Orchestration.Response.Citation` | `FoundationaLLM.Common.Models.Orchestration.Response.ContentArtifact` |
 
+#### API endpoint changes
+
+**Core API**
+
+The `/instances/{instanceId}/sessions/{sessionId}/message/{id}/rate` endpoint has been updated to accept the rating in the message body, rather than as a query parameter. Send the following payload in the request body:
+
+```json
+{
+  "rating": true,
+  "comments": "string"
+}
+```
+
+> [!NOTE]
+> Please note that both properties are nullable. Set them to null to clear out the rating and comments.
+
+
 ## Starting with 0.8.4
 
 ### Configuration changes

--- a/src/dotnet/Common/Models/Conversation/Message.cs
+++ b/src/dotnet/Common/Models/Conversation/Message.cs
@@ -64,6 +64,11 @@ public record Message
     public bool? Rating { get; set; }
 
     /// <summary>
+    /// The comments associated with the rating.
+    /// </summary>
+    public string? RatingComments { get; set; }
+
+    /// <summary>
     /// The UPN of the user who created the chat session.
     /// </summary>
     public string UPN { get; set; }

--- a/src/dotnet/Common/Models/Conversation/MessageRatingRequest.cs
+++ b/src/dotnet/Common/Models/Conversation/MessageRatingRequest.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Common.Models.Conversation
+{
+    /// <summary>
+    /// Contains the request for rating a message.
+    /// </summary>
+    public class MessageRatingRequest
+    {
+        /// <summary>
+        /// The rating to assign to the message.
+        /// </summary>
+        [JsonPropertyName("rating")]
+        public bool? Rating { get; set; }
+
+        /// <summary>
+        /// Optional comments associated with the rating.
+        /// </summary>
+        [JsonPropertyName("comments")]
+        public string? Comments { get; set; }
+    }
+}

--- a/src/dotnet/Core/Interfaces/ICoreService.cs
+++ b/src/dotnet/Core/Interfaces/ICoreService.cs
@@ -144,8 +144,8 @@ public interface ICoreService
     /// <param name="instanceId">The instance id.</param>
     /// <param name="id">The message id to rate.</param>
     /// <param name="sessionId">The session id to which the message belongs.</param>
-    /// <param name="rating">The rating to assign to the message.</param>
-    Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, bool? rating);
+    /// <param name="rating">The rating and optional comments to assign to the message.</param>
+    Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating);
 
     /// <summary>
     /// Returns the completion prompt for a given session and completion prompt id.

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -661,7 +661,7 @@ public partial class CoreService(
     }
 
     /// <inheritdoc/>
-    public async Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, bool? rating)
+    public async Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating)
     {
         ArgumentNullException.ThrowIfNull(id);
         ArgumentNullException.ThrowIfNull(sessionId);
@@ -671,7 +671,8 @@ public partial class CoreService(
             sessionId,
             new Dictionary<string, object?>
             {
-                { "/rating", rating }
+                { "/rating", rating.Rating },
+                { "/ratingComments", rating.Comments }
             });
     }
 

--- a/src/dotnet/CoreAPI/Controllers/SessionsController.cs
+++ b/src/dotnet/CoreAPI/Controllers/SessionsController.cs
@@ -49,10 +49,10 @@ namespace FoundationaLLM.Core.API.Controllers
         /// <param name="instanceId">The id of the instance.</param>
         /// <param name="messageId">The id of the message to rate.</param>
         /// <param name="sessionId">The id of the session to which the message belongs.</param>
-        /// <param name="rating">The rating to assign to the message.</param>
+        /// <param name="ratingRequest">The rating and optional comments to assign to the message.</param>
         [HttpPost("{sessionId}/message/{messageId}/rate", Name = "RateMessage")]
-        public async Task<Message> RateMessage(string instanceId, string messageId, string sessionId, bool? rating) =>
-            await _coreService.RateMessageAsync(instanceId, messageId, sessionId, rating);
+        public async Task<Message> RateMessage(string instanceId, string messageId, string sessionId, [FromBody] MessageRatingRequest ratingRequest) =>
+            await _coreService.RateMessageAsync(instanceId, messageId, sessionId, ratingRequest);
 
         /// <summary>
         /// Returns the completion prompt for a given session and completion prompt id.

--- a/src/ui/UserPortal/js/api.ts
+++ b/src/ui/UserPortal/js/api.ts
@@ -1,5 +1,6 @@
 import type {
 	Message,
+	MessageRatingRequest,
 	Session,
 	LongRunningOperation,
 	UserProfile,
@@ -250,16 +251,18 @@ export default {
 	 * @returns The rated message.
 	 */
 	async rateMessage(message: Message, rating: Message['rating']) {
-		const params: {
-			rating?: Message['rating'];
-		} = {};
-		if (rating !== null) params.rating = rating;
+		// Create a new instance of the MessageRatingRequest object
+		// and set the rating and comments properties
+		const messageRatingRequest: MessageRatingRequest = {
+			rating: rating,
+			comments: null,
+		};
 
 		return (await this.fetch(
 			`/instances/${this.instanceId}/sessions/${message.sessionId}/message/${message.id}/rate`,
 			{
 				method: 'POST',
-				params,
+				body: messageRatingRequest,
 			},
 		)) as Message;
 	},

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -67,6 +67,12 @@ export interface Message {
 	analysisResults: Array<AnalysisResult>;
 }
 
+export interface MessageRatingRequest
+{
+    rating: boolean | null;
+	comments: string | null;
+}
+
 export interface Session {
 	id: string;
 	type: string;


### PR DESCRIPTION
# Implement rating comments in the backend

## The issue or feature being addressed

Add the ability to store a comment along with a rating on a message.

## Details on the issue fix or feature implementation

- Adds a new property to the `Message` class for storing comments for a rating.
- Changes the rating endpoint in the Core API to accept a payload in the request body that contains the rating and comments.
- The User Portal's API class has been updated to send the new payload.

> [!NOTE]
> Work remains to add a comments input form in the User Portal's UX.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
