### PR TITLE
Conditional message rating and comments

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -9,16 +9,18 @@
 
 The following new App Configuration settings are required:
 
-|Name | Default value |
+|Name | Default value | Description |
 |--- | --- |
-|`FoundationaLLM:PythonSDK:Logging:LogLevel:Default` | `Information` |
-|`FoundationaLLM:PythonSDK:Logging:EnableConsoleLogging` | `false` |
-|`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:RequireScopes` | `true` |
-|`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:AllowACLAuthorization` | `false` |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-` |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` |
+|`FoundationaLLM:PythonSDK:Logging:LogLevel:Default` | `Information` | |
+|`FoundationaLLM:PythonSDK:Logging:EnableConsoleLogging` | `false` | |
+|`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:RequireScopes` | `true` | Indicates whether a scope claim (scp) is required for authorization. Set to `false` to allow authentication from an external proxy API. |
+|`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:AllowACLAuthorization` | `false` | Indicates whether tokens that do not have either of the "scp" or "roles" claims are accepted (True means they are accepted). Set to `true` to allow authentication from an external proxy API. |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-` | |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` | |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` | |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` | |
+|`FoundationaLLM:UserPortal:Configuration:ShowMessageRating` | `true` | If `true`, rating options on agent messages will appear. |
+|`FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup` | `false` | If `true`, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load. |
 
 #### Agent Tool configuration changes
 

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1475,6 +1475,29 @@
 		]
 	},
 	{
+		"namespace": "UserPortal:Configuration",
+		"dependency_injection_key": null,
+		"configuration_section": null,
+		"configuration_keys": [
+			{
+				"name": "ShowLastConversationOnStartup",
+				"description": "If true, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load.",
+				"secret": "",
+				"value": "false",
+				"content_type": "",
+				"first_version": "0.9.0"
+			},
+			{
+				"name": "ShowMessageRating",
+				"description": "If true, rating options on agent messages will appear.",
+				"secret": "",
+				"value": "true",
+				"content_type": "",
+				"first_version": "0.9.0"
+			}
+		]
+	},
+	{
 		"namespace": "ManagementPortal:Authentication:Entra",
 		"dependency_injection_key": null,
 		"configuration_section": null,

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -1094,6 +1094,24 @@ namespace FoundationaLLM.Common.Constants.Configuration
 
         #endregion
 
+        #region FoundationaLLM:UserPortal:Configuration
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup setting.
+        /// <para>Value description:<br/>If true, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load.</para>
+        /// </summary>
+        public const string FoundationaLLM_UserPortal_Configuration_ShowLastConversationOnStartup =
+            "FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:UserPortal:Configuration:ShowMessageRating setting.
+        /// <para>Value description:<br/>If true, rating options on agent messages will appear.</para>
+        /// </summary>
+        public const string FoundationaLLM_UserPortal_Configuration_ShowMessageRating =
+            "FoundationaLLM:UserPortal:Configuration:ShowMessageRating";
+
+        #endregion
+
         #region FoundationaLLM:ManagementPortal:Authentication:Entra
         
         /// <summary>

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -862,6 +862,20 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup",
+            "value": "false",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:UserPortal:Configuration:ShowMessageRating",
+            "value": "true",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:ManagementPortal:Authentication:Entra:Instance",
             "value": "https://login.microsoftonline.com/",
             "label": null,

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -30,7 +30,7 @@
 						:aria-flowto="
 							index === 0 ? null : `message-${getMessageOrderFromReversedIndex(index) + 1}`
 						"
-						@rate="handleRateMessage($event.message, $event.isLiked)"
+						@rate="handleRateMessage($event.message)"
 					/>
 				</template>
 
@@ -150,8 +150,8 @@ export default {
 			return this.messages.length - 1 - index;
 		},
 
-		async handleRateMessage(message: Message, isLiked: Message['rating']) {
-			await this.$appStore.rateMessage(message, isLiked);
+		async handleRateMessage(message: Message) {
+			await this.$appStore.rateMessage(message);
 		},
 
 		handleParentDrop(event) {

--- a/src/ui/UserPortal/js/api.ts
+++ b/src/ui/UserPortal/js/api.ts
@@ -250,12 +250,12 @@ export default {
 	 * @param rating - The rating value for the message.
 	 * @returns The rated message.
 	 */
-	async rateMessage(message: Message, rating: Message['rating']) {
+	async rateMessage(message: Message) {
 		// Create a new instance of the MessageRatingRequest object
 		// and set the rating and comments properties
 		const messageRatingRequest: MessageRatingRequest = {
-			rating: rating,
-			comments: null,
+			rating: message.rating,
+			comments: message.ratingComments,
 		};
 
 		return (await this.fetch(

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -58,6 +58,7 @@ export interface Message {
 	tokens: number;
 	text: string;
 	rating: boolean | null;
+	ratingComments: string | null;
 	vector: Array<Number>;
 	completionPromptId: string | null;
 	contentArtifacts: Array<ContentArtifact>;

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -35,6 +35,7 @@ const allowedKeys = [
 	'FoundationaLLM:UserPortal:Authentication:Entra:TenantId',
 	'FoundationaLLM:UserPortal:Authentication:Entra:Scopes',
 	'FoundationaLLM:UserPortal:Authentication:Entra:CallbackPath',
+	'FoundationaLLM:UserPortal:Configuration:ShowMessageRating',
 	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 ];
 

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -33,6 +33,8 @@ export const useAppConfigStore = defineStore('appConfig', {
 		agentIconUrl: null,
 		allowedUploadFileExtensions: null,
 
+		showMessageRating: null,
+
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
 			clientId: null,
@@ -82,6 +84,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				instanceId,
 				agentIconUrl,
 				allowedUploadFileExtensions,
+				showMessageRating,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -120,6 +123,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe(
 					'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 				),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageRating', false),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -153,6 +157,8 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.instanceId = instanceId;
 			this.agentIconUrl = agentIconUrl;
 			this.allowedUploadFileExtensions = allowedUploadFileExtensions;
+
+			this.showMessageRating = showMessageRating;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -123,7 +123,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe(
 					'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 				),
-				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageRating', false),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageRating', 'false'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -158,7 +158,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.agentIconUrl = agentIconUrl;
 			this.allowedUploadFileExtensions = allowedUploadFileExtensions;
 
-			this.showMessageRating = showMessageRating;
+			this.showMessageRating = this.showMessageRating = JSON.parse(showMessageRating.toLowerCase());;
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -481,19 +481,22 @@ export const useAppStore = defineStore('app', {
 		// 	}
 		// },
 
-		async rateMessage(messageToRate: Message, isLiked: Message['rating']) {
+		async rateMessage(messageToRate: Message) {
 			const existingMessage = this.currentMessages.find(
 				(message) => message.id === messageToRate.id,
 			);
 
 			// Preemptively rate the message for responsiveness, and revert the rating if the request fails.
 			const previousRating = existingMessage.rating;
-			existingMessage.rating = isLiked;
+			const previousRatingComments = existingMessage.ratingComments;
+			existingMessage.rating = messageToRate.rating;
+			existingMessage.ratingComments = messageToRate.ratingComments;
 
 			try {
-				await api.rateMessage(messageToRate, isLiked);
+				await api.rateMessage(messageToRate);
 			} catch (error) {
 				existingMessage.rating = previousRating;
+				existingMessage.ratingComments = previousRatingComments;
 			}
 		},
 


### PR DESCRIPTION
# Conditional message rating and comments

## The issue or feature being addressed

Adds a configuration-controlled condition for displaying rating options on agent messages. Implements ratings via a dialog that includes a field for adding comments.

## Details on the issue fix or feature implementation

References the new `FoundationaLLM:UserPortal:Configuration:ShowMessageRating` App Config setting to determine whether to display ratings on agent messages. Moves from using simple thumbs up/down on the message to displaying a single rating button that shows a dialog box that contains a text area for comments, the rating buttons, and buttons to cancel or save the message rating. Supports removing a rating by selecting a selected rating (eg. when the thumbs up is selected, select it again to clear the rating).

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
