### PR TITLE
Follow setting to show last conversion on startup in UI

### DIFF
--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -289,7 +289,7 @@ export default {
 
 	computed: {
 		sessions() {
-			return this.$appStore.sessions;
+			return this.$appStore.sessions.filter((session) => !session.is_temp);
 		},
 
 		currentSession() {

--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -307,7 +307,7 @@ export default {
 		}
 
 		// Listen for the agent change event.
-        eventBus.on('agentChanged', this.handleAddSession);
+		eventBus.on('agentChanged', this.handleAddSession);
 	},
 
 	methods: {

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -108,7 +108,7 @@ export default {
 
 	watch: {
 		async currentSession(newSession: Session, oldSession: Session) {
-			if (newSession.id === oldSession?.id) return;
+			if (newSession.id === oldSession?.id || oldSession?.is_temp) return;
 			this.isMessagePending = false;
 			this.isLoading = true;
 			this.userSentMessage = false;
@@ -135,6 +135,14 @@ export default {
 				this.isMessagePending = false;
 			}
 		},
+	},
+
+	created() {
+		if (!this.$appConfigStore.showLastConversionOnStartup && this.currentSession?.is_temp) {
+			this.isLoading = false;
+			const sessionAgent = this.$appStore.getSessionAgent(this.currentSession);
+			this.welcomeMessage = this.getWelcomeMessage(sessionAgent);
+		}
 	},
 
 	methods: {

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -108,7 +108,8 @@ export default {
 
 	watch: {
 		async currentSession(newSession: Session, oldSession: Session) {
-			if (newSession.id === oldSession?.id || oldSession?.is_temp) return;
+			const isReplacementForTempSession = oldSession?.is_temp && this.messages.length > 0;
+			if (newSession.id === oldSession?.id || isReplacementForTempSession) return;
 			this.isMessagePending = false;
 			this.isLoading = true;
 			this.userSentMessage = false;

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -82,6 +82,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				instanceId,
 				agentIconUrl,
 				allowedUploadFileExtensions,
+				showLastConversionOnStartup,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -120,6 +121,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe(
 					'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 				),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup', 'true'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -153,6 +155,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.instanceId = instanceId;
 			this.agentIconUrl = agentIconUrl;
 			this.allowedUploadFileExtensions = allowedUploadFileExtensions;
+			this.showLastConversionOnStartup = JSON.parse(showLastConversionOnStartup.toLowerCase());
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -317,6 +317,7 @@ export const useAppStore = defineStore('app', {
 			const lastAssistantMessage = this.currentMessages
 				.filter((message) => message.sender === 'Agent')
 				.pop();
+
 			if (lastAssistantMessage) {
 				const agent = this.agents.find(
 					(agent) => agent.resource.name === lastAssistantMessage.senderDisplayName,

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -90,7 +90,7 @@ export const useAppStore = defineStore('app', {
 
 			if (requestedSession) {
 				this.changeSession(requestedSession);
-			} else if (authStore.showLastConversionOnStartup && this.sessions.length > 0) {
+			} else if (useAppConfigStore().showLastConversionOnStartup && this.sessions.length > 0) {
 				this.changeSession(this.sessions[0]);
 			} else {
 				await this.addSession(this.getDefaultChatSessionProperties());

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -120,6 +120,7 @@ export const useAppStore = defineStore('app', {
 				})
 				.replace(' ', 'T')
 				.replace('T', ' ');
+
 			return {
 				name: formattedNow,
 			};

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -83,12 +83,18 @@ export const useAppStore = defineStore('app', {
 
 			await this.getSessions();
 
-			if (this.sessions.length === 0) {
-				await this.addSession(this.getDefaultChatSessionProperties());
+			// If there is an existing session matching the one requested in the url, select it
+			// otherwise, if showLastConversionOnStartup is true there is a session available to show, select it
+			// otherwise, create a new session
+			const requestedSession = this.sessions.find((session: Session) => session.id === sessionId);
+
+			if (requestedSession) {
+				this.changeSession(requestedSession);
+			} else if (authStore.showLastConversionOnStartup && this.sessions.length > 0) {
 				this.changeSession(this.sessions[0]);
 			} else {
-				const existingSession = this.sessions.find((session: Session) => session.id === sessionId);
-				this.changeSession(existingSession || this.sessions[0]);
+				await this.addSession(this.getDefaultChatSessionProperties());
+				this.changeSession(this.sessions[0]);
 			}
 
 			await this.getUserProfiles();

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -82,7 +82,7 @@ export const useAppStore = defineStore('app', {
 			}
 
 			const sessionIdQuery = useNuxtApp().$router.currentRoute.value.query.chat;
-			if (!appConfigStore.showLastConversionOnStartup && !appConfigStore) {
+			if (!appConfigStore.showLastConversionOnStartup && !sessionIdQuery) {
 				this.sessions.unshift({
 					...this.getDefaultChatSessionProperties(),
 					id: 'new',

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -81,7 +81,8 @@ export const useAppStore = defineStore('app', {
 				return;
 			}
 
-			if (!appConfigStore.showLastConversionOnStartup) {
+			const sessionIdQuery = useNuxtApp().$router.currentRoute.value.query.chat;
+			if (!appConfigStore.showLastConversionOnStartup && !appConfigStore) {
 				this.sessions.unshift({
 					...this.getDefaultChatSessionProperties(),
 					id: 'new',


### PR DESCRIPTION
# Follow setting to show last conversion on startup in UI

## The issue or feature being addressed
- Follow setting to show last conversion on startup in UI

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
