### PR TITLE
Add missing state object for showing last conversation on startup

### DIFF
--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -34,6 +34,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		allowedUploadFileExtensions: null,
 
 		showMessageRating: null,
+		showLastConversionOnStartup: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {


### PR DESCRIPTION
# Add missing state object for showing last conversation on startup

## The issue or feature being addressed

Adds the `allowedUploadFileExtensions` config state variable to the User Portal's App Config Store.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
