### PR TITLE
(0.9.0 rc3) Conditionally show message token usage and View Prompt button in the User Portal

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -22,6 +22,7 @@ The following new App Configuration settings are required:
 |`FoundationaLLM:UserPortal:Configuration:ShowMessageRating` | `true` | If `true`, rating options on agent messages will appear. |
 |`FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup` | `false` | If `true`, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load. |
 |`FoundationaLLM:UserPortal:Configuration:ShowMessageTokens` | `true` | If `true`, the number of consumed tokens on agent and user messages will appear. |
+|`FoundationaLLM:UserPortal:Configuration:ShowViewPrompt` | `true` | If `true`, the "View Prompt" button on agent messages will appear. |
 
 #### Agent Tool configuration changes
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -10,17 +10,18 @@
 The following new App Configuration settings are required:
 
 |Name | Default value | Description |
-|--- | --- |
-|`FoundationaLLM:PythonSDK:Logging:LogLevel:Default` | `Information` | |
-|`FoundationaLLM:PythonSDK:Logging:EnableConsoleLogging` | `false` | |
+|--- | --- | --- |
+|`FoundationaLLM:PythonSDK:Logging:LogLevel:Default` | `Information` | `-` |
+|`FoundationaLLM:PythonSDK:Logging:EnableConsoleLogging` | `false` | `-` |
 |`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:RequireScopes` | `true` | Indicates whether a scope claim (scp) is required for authorization. Set to `false` to allow authentication from an external proxy API. |
 |`FoundationaLLM:APIEndpoints:CoreAPI:Configuration:Entra:AllowACLAuthorization` | `false` | Indicates whether tokens that do not have either of the "scp" or "roles" claims are accepted (True means they are accepted). Set to `true` to allow authentication from an external proxy API. |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-` | |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` | |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` | |
-|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` | |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AccountName` | `-` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` | `-` |
 |`FoundationaLLM:UserPortal:Configuration:ShowMessageRating` | `true` | If `true`, rating options on agent messages will appear. |
 |`FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup` | `false` | If `true`, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load. |
+|`FoundationaLLM:UserPortal:Configuration:ShowMessageTokens` | `true` | If `true`, the number of consumed tokens on agent and user messages will appear. |
 
 #### Agent Tool configuration changes
 

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1494,6 +1494,14 @@
 				"value": "true",
 				"content_type": "",
 				"first_version": "0.9.0"
+			},
+			{
+				"name": "ShowMessageTokens",
+				"description": "If true, the number of consumed tokens on agent and user messages will appear.",
+				"secret": "",
+				"value": "true",
+				"content_type": "",
+				"first_version": "0.9.0"
 			}
 		]
 	},

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1502,6 +1502,14 @@
 				"value": "true",
 				"content_type": "",
 				"first_version": "0.9.0"
+			},
+			{
+				"name": "ShowViewPrompt",
+				"description": "If true, the 'View Prompt' button on agent messages will appear.",
+				"secret": "",
+				"value": "true",
+				"content_type": "",
+				"first_version": "0.9.0"
 			}
 		]
 	},

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -1109,6 +1109,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_UserPortal_Configuration_ShowMessageRating =
             "FoundationaLLM:UserPortal:Configuration:ShowMessageRating";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:UserPortal:Configuration:ShowMessageTokens setting.
+        /// <para>Value description:<br/>If true, the number of consumed tokens on agent and user messages will appear.</para>
+        /// </summary>
+        public const string FoundationaLLM_UserPortal_Configuration_ShowMessageTokens =
+            "FoundationaLLM:UserPortal:Configuration:ShowMessageTokens";
 
         #endregion
 

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -1116,6 +1116,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_UserPortal_Configuration_ShowMessageTokens =
             "FoundationaLLM:UserPortal:Configuration:ShowMessageTokens";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:UserPortal:Configuration:ShowViewPrompt setting.
+        /// <para>Value description:<br/>If true, the 'View Prompt' button on agent messages will appear.</para>
+        /// </summary>
+        public const string FoundationaLLM_UserPortal_Configuration_ShowViewPrompt =
+            "FoundationaLLM:UserPortal:Configuration:ShowViewPrompt";
 
         #endregion
 

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -876,6 +876,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:UserPortal:Configuration:ShowMessageTokens",
+            "value": "true",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:ManagementPortal:Authentication:Entra:Instance",
             "value": "https://login.microsoftonline.com/",
             "label": null,

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -883,6 +883,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:UserPortal:Configuration:ShowViewPrompt",
+            "value": "true",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:ManagementPortal:Authentication:Entra:Instance",
             "value": "https://login.microsoftonline.com/",
             "label": null,

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -16,6 +16,7 @@
 					<!-- Tokens & Timestamp -->
 					<span class="message__header--right">
 						<Chip
+							v-if="$appConfigStore.showMessageTokens"
 							:label="`Tokens: ${message.tokens}`"
 							class="token-chip"
 							:class="message.sender === 'User' ? 'token-chip--out' : 'token-chip--in'"
@@ -143,8 +144,9 @@
 							@click.stop="handleCopyMessageContent"
 						/>
 
-						<!-- View prompt buttom -->
+						<!-- View prompt button -->
 						<Button
+							v-if="$appConfigStore.showViewPrompt"	
 							class="message__button"
 							:disabled="message.type === 'LoadingMessage'"
 							size="small"

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -37,6 +37,8 @@ const allowedKeys = [
 	'FoundationaLLM:UserPortal:Authentication:Entra:Scopes',
 	'FoundationaLLM:UserPortal:Authentication:Entra:CallbackPath',
 	'FoundationaLLM:UserPortal:Configuration:ShowMessageRating',
+	'FoundationaLLM:UserPortal:Configuration:ShowViewPrompt',
+	'FoundationaLLM:UserPortal:Configuration:ShowMessageTokens',
 	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 ];
 

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -35,6 +35,8 @@ export const useAppConfigStore = defineStore('appConfig', {
 
 		showMessageRating: null,
 		showLastConversionOnStartup: null,
+		showMessageTokens: null,
+		showViewPrompt: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -87,6 +89,8 @@ export const useAppConfigStore = defineStore('appConfig', {
 				allowedUploadFileExtensions,
 				showMessageRating,
 				showLastConversionOnStartup,
+				showMessageTokens,
+				showViewPrompt,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -127,6 +131,8 @@ export const useAppConfigStore = defineStore('appConfig', {
 				),
 				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageRating', 'false'),
 				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup', 'true'),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageTokens', 'true'),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowViewPrompt', 'true'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -161,8 +167,10 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.agentIconUrl = agentIconUrl;
 			this.allowedUploadFileExtensions = allowedUploadFileExtensions;
 
-			this.showMessageRating = this.showMessageRating = JSON.parse(showMessageRating.toLowerCase());;
+			this.showMessageRating = this.showMessageRating = JSON.parse(showMessageRating.toLowerCase());
 			this.showLastConversionOnStartup = JSON.parse(showLastConversionOnStartup.toLowerCase());
+			this.showMessageTokens = JSON.parse(showMessageTokens.toLowerCase());
+			this.showViewPrompt = JSON.parse(showViewPrompt.toLowerCase());
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;


### PR DESCRIPTION
# (0.9.0 rc3) Conditionally show message token usage and View Prompt button in the User Portal

## The issue or feature being addressed

Cherry-pick PR for #2048 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
