### PR TITLE
Management Portal VPAT Accessibility Changes

### DIFF
--- a/src/ui/ManagementPortal/app.vue
+++ b/src/ui/ManagementPortal/app.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<div class="main-content">
 		<Head>
 			<Title>{{ pageTitle }}</Title>
 			<Meta name="description" :content="pageTitle" />
@@ -11,7 +11,7 @@
 		</NuxtLayout>
 
 		<Toast position="top-center" />
-	</main>
+	</div>
 </template>
 
 <script lang="ts">
@@ -59,7 +59,7 @@ html,
 body,
 #__nuxt,
 #__layout,
-main {
+.main-content {
 	height: 100%;
 	margin: 0;
 	font-family: 'Poppins', sans-serif;

--- a/src/ui/ManagementPortal/components/ApiStatusCard.vue
+++ b/src/ui/ManagementPortal/components/ApiStatusCard.vue
@@ -1,9 +1,9 @@
 <template>
-	<div class="api-status-card">
+	<div class="api-status-card" role="region">
 		<h2>{{ apiName }}</h2>
 		<div v-if="loading" class="loading" aria-live="polite">Loading...</div>
 		<div v-else-if="error" class="error" aria-live="assertive">{{ error }}</div>
-		<div v-else-if="apiStatus" role="region">
+		<div v-else-if="apiStatus">
 			<div class="api-detail">
 				<p><strong>Name:</strong> {{ apiStatus.name }}</p>
 				<p><strong>Description:</strong> {{ description }}</p>

--- a/src/ui/ManagementPortal/components/ApiStatusCard.vue
+++ b/src/ui/ManagementPortal/components/ApiStatusCard.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="api-status-card">
 		<h2>{{ apiName }}</h2>
-		<div v-if="loading" class="loading">Loading...</div>
-		<div v-else-if="error" class="error">{{ error }}</div>
-		<div v-else-if="apiStatus">
+		<div v-if="loading" class="loading" aria-live="polite">Loading...</div>
+		<div v-else-if="error" class="error" aria-live="assertive">{{ error }}</div>
+		<div v-else-if="apiStatus" role="region">
 			<div class="api-detail">
 				<p><strong>Name:</strong> {{ apiStatus.name }}</p>
 				<p><strong>Description:</strong> {{ description }}</p>

--- a/src/ui/ManagementPortal/components/ColorInput.vue
+++ b/src/ui/ManagementPortal/components/ColorInput.vue
@@ -20,13 +20,16 @@
 			class="color-picker"
 			@change="onColorChange"
 		/>
-		<Button
-			:disabled="value === originalValue"
-			class="color-undo-button"
-			icon="pi pi-undo"
-			aria-label="Reset to default color"
-			@click="$emit('reset', originalValue)"
-		/>
+		<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+			<Button
+				:disabled="value === originalValue"
+				class="color-undo-button"
+				icon="pi pi-undo"
+				aria-label="Reset to initial color"
+				@click="$emit('reset', originalValue)"
+			/>
+			<template #popper><div role="tooltip">Reset to initial color</div></template>
+		</VTooltip>
 	</div>
 </template>
 

--- a/src/ui/ManagementPortal/components/CreateAgentStepItem.vue
+++ b/src/ui/ManagementPortal/components/CreateAgentStepItem.vue
@@ -2,22 +2,45 @@
 	<div class="step">
 		<div class="step-container">
 			<!-- Editing view -->
-			<div v-if="isOpen" class="step-container__edit">
+			<div 
+				v-if="isOpen"
+				class="step-container__edit"
+				:id="'step-content-' + id"
+				role="region"
+				:aria-labelledby="'step-header-' + id"
+			>
 				<div class="step-container__edit__inner">
 					<slot name="edit" />
 
 					<div class="d-flex justify-content-end">
-						<Button class="mt-2" label="Done" @click="handleClose" />
+						<Button class="mt-2" label="Done" aria-label="Close step editing" @click="handleClose" />
 					</div>
 				</div>
 
-				<div class="step-container__edit__arrow" @click="handleClose">
+				<div
+					class="step-container__edit__arrow"
+					role="button"
+					aria-label="Close editing"
+					tabindex="0"
+					@click="handleClose"
+					@keydown.enter.prevent="handleClose"
+					@keydown.space.prevent="handleClose"
+				>
 					<span class="pi pi-arrow-down" style="font-size: 1rem"></span>
 				</div>
 			</div>
 
 			<!-- Default view -->
-			<div class="step-container__view" @click="handleOpen">
+			<div
+				class="step-container__view"
+				@click="handleOpen"
+				@keydown.enter.prevent="handleOpen"
+				@keydown.space.prevent="handleOpen"
+				role="button"
+				tabindex="0"
+				:aria-expanded="isOpen"
+				:aria-controls="'step-content-' + id"
+			>
 				<div class="step-container__view__inner">
 					<slot />
 				</div>
@@ -71,6 +94,11 @@ export default {
 		handleOpen() {
 			this.editing = true;
 			this.$appStore.createAgentOpenItemId = this.id;
+
+			this.$nextTick(() => {
+				const doneButton = this.$el.querySelector('.step-container__edit__inner .mt-2');
+				doneButton?.focus();
+			});
 		},
 
 		handleClose() {
@@ -78,6 +106,11 @@ export default {
 			if (this.$appStore.createAgentOpenItemId === this.id) {
 				this.$appStore.createAgentOpenItemId = null;
 			}
+
+			this.$nextTick(() => {
+				const stepHeader = this.$el.querySelector('.step-container__view');
+				stepHeader?.focus();
+			});
 		},
 	},
 };

--- a/src/ui/ManagementPortal/components/CreateAgentStepItem.vue
+++ b/src/ui/ManagementPortal/components/CreateAgentStepItem.vue
@@ -63,6 +63,11 @@ export default {
 			required: false,
 			default: false,
 		},
+		focusQuery: {
+			type: String,
+			required: false,
+			default: '',
+		},
 	},
 
 	emits: ['update:modelValue'],
@@ -96,8 +101,8 @@ export default {
 			this.$appStore.createAgentOpenItemId = this.id;
 
 			this.$nextTick(() => {
-				const doneButton = this.$el.querySelector('.step-container__edit__inner .mt-2');
-				doneButton?.focus();
+				const focusElement = this.$el.querySelector(this.focusQuery);
+				focusElement?.focus();
 			});
 		},
 

--- a/src/ui/ManagementPortal/components/CustomQuillEditor.vue
+++ b/src/ui/ManagementPortal/components/CustomQuillEditor.vue
@@ -15,15 +15,15 @@
 						<option value="large"></option>
 						<option value="huge"></option>
 					</select>
-					<button class="ql-bold" aria-label="Bold"></button>
-					<button class="ql-italic" aria-label="Italic"></button>
-					<button class="ql-underline" aria-label="Underline"></button>
-					<button class="ql-strike" aria-label="Strike"></button>
-					<button class="ql-link" aria-label="Link"></button>
-					<button class="ql-image" aria-label="Image"></button>
-					<button class="ql-list" value="ordered" aria-label="Ordered List"></button>
-					<button class="ql-list" value="bullet" aria-label="Unordered List"></button>
-					<button class="ql-clean" aria-label="Remove Styles"></button>
+					<button class="ql-bold" aria-label="Bold" title="Bold"></button>
+					<button class="ql-italic" aria-label="Italic" title="Italic"></button>
+					<button class="ql-underline" aria-label="Underline" title="Underline"></button>
+					<button class="ql-strike" aria-label="Strike" title="Strike"></button>
+					<button class="ql-link" aria-label="Link" title="Link"></button>
+					<button class="ql-image" aria-label="Image" title="Image"></button>
+					<button class="ql-list" value="ordered" aria-label="Ordered List" title="Ordered List"></button>
+					<button class="ql-list" value="bullet" aria-label="Unordered List" title="Unordered List"></button>
+					<button class="ql-clean" aria-label="Remove Styles" title="Remove Styles"></button>
 					<button
 						class="quill-view-html"
 						aria-label="Edit HTML"

--- a/src/ui/ManagementPortal/components/PrivateStorage.vue
+++ b/src/ui/ManagementPortal/components/PrivateStorage.vue
@@ -2,7 +2,7 @@
 	<div>
 		<!-- Loading overlay -->
 		<template v-if="loading">
-			<div class="grid__loading-overlay">
+			<div class="grid__loading-overlay" role="status" aria-live="polite">
 				<LoadingGrid />
 				<div>{{ loadingStatusText }}</div>
 			</div>

--- a/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
+++ b/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
@@ -151,7 +151,6 @@
 		<Dialog
 			:visible="roleAssignmentToDelete !== null"
 			modal
-			v-focustrap
 			header="Delete Role Assignment"
 			:closable="false"
 		>
@@ -162,7 +161,7 @@
 			</p>
 			<template #footer>
 				<Button label="Cancel" text @click="roleAssignmentToDelete = null" />
-				<Button label="Delete" severity="danger" autofocus @click="handleDeleteRoleAssignment" />
+				<Button label="Delete" severity="danger" @click="handleDeleteRoleAssignment" />
 			</template>
 		</Dialog>
 	</div>

--- a/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
+++ b/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
@@ -151,6 +151,7 @@
 		<Dialog
 			:visible="roleAssignmentToDelete !== null"
 			modal
+			v-focustrap
 			header="Delete Role Assignment"
 			:closable="false"
 		>
@@ -161,7 +162,7 @@
 			</p>
 			<template #footer>
 				<Button label="Cancel" text @click="roleAssignmentToDelete = null" />
-				<Button label="Delete" severity="danger" @click="handleDeleteRoleAssignment" />
+				<Button label="Delete" severity="danger" autofocus @click="handleDeleteRoleAssignment" />
 			</template>
 		</Dialog>
 	</div>

--- a/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
+++ b/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
@@ -2,7 +2,7 @@
 	<div :class="{ 'grid--loading': loading }">
 		<!-- Loading overlay -->
 		<template v-if="loading">
-			<div class="grid__loading-overlay">
+			<div class="grid__loading-overlay" role="status" aria-live="polite">
 				<LoadingGrid />
 				<div>{{ loadingStatusText }}</div>
 			</div>
@@ -136,8 +136,12 @@
 				}"
 			>
 				<template #body="{ data }">
-					<Button link @click="roleAssignmentToDelete = data">
-						<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+					<Button
+						link
+						:aria-label="`Delete role assignment for ${data.principal.display_name}`"
+						@click="roleAssignmentToDelete = data"
+					>
+						<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 					</Button>
 				</template>
 			</Column>

--- a/src/ui/ManagementPortal/components/Sidebar.vue
+++ b/src/ui/ManagementPortal/components/Sidebar.vue
@@ -1,5 +1,6 @@
 <template>
-	<div class="sidebar">
+	<div class="sidebar" role="navigation">
+		<h2 id="sidebar-title" class="visually-hidden">Main Navigation</h2>
 		<!-- Sidebar section header -->
 		<div class="sidebar__header">
 			<template v-if="$appConfigStore.logoUrl">
@@ -7,7 +8,7 @@
 					<img
 						:src="$filters.publicDirectory($appConfigStore.logoUrl)"
 						aria-label="Logo as link to home"
-						alt="Logo"
+						:alt="$appConfigStore.logoText"
 					/>
 				</NuxtLink>
 			</template>
@@ -209,5 +210,16 @@ a {
 
 .sidebar__sign-out-button {
 	width: 100%;
+}
+
+.visually-hidden {
+	position: absolute;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	width: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
 }
 </style>

--- a/src/ui/ManagementPortal/components/Sidebar.vue
+++ b/src/ui/ManagementPortal/components/Sidebar.vue
@@ -4,7 +4,7 @@
 		<!-- Sidebar section header -->
 		<div class="sidebar__header">
 			<template v-if="$appConfigStore.logoUrl">
-				<NuxtLink to="/">
+				<NuxtLink to="/" aria-label="Navigate to homepage">
 					<img
 						:src="$filters.publicDirectory($appConfigStore.logoUrl)"
 						aria-label="Logo as link to home"
@@ -18,23 +18,25 @@
 		</div>
 
 		<!-- Agents -->
-		<div class="sidebar__section-header">
-			<span class="pi pi-users"></span>
+		<h3 class="sidebar__section-header">
+			<span class="pi pi-users" aria-hidden="true"></span>
 			<span>Agents</span>
-		</div>
-
-		<NuxtLink to="/agents/create" class="sidebar__item">Create New Agent</NuxtLink>
-		<NuxtLink to="/agents/public" class="sidebar__item">All Agents</NuxtLink>
-		<NuxtLink to="/agents/private" class="sidebar__item">My Agents</NuxtLink>
+		</h3>
+		<ul>
+			<li><NuxtLink to="/agents/create" class="sidebar__item">Create New Agent</NuxtLink></li>
+			<li><NuxtLink to="/agents/public" class="sidebar__item">All Agents</NuxtLink></li>
+			<li><NuxtLink to="/agents/private" class="sidebar__item">My Agents</NuxtLink></li>
+		</ul>
 		<!-- <div class="sidebar__item">Performance</div> -->
 
 		<!-- Data Catalog -->
-		<div class="sidebar__section-header">
-			<span class="pi pi-database"></span>
+		<h3 class="sidebar__section-header">
+			<span class="pi pi-database" aria-hidden="true"></span>
 			<span>Data Catalog</span>
-		</div>
-
-		<NuxtLink to="/data-sources" class="sidebar__item">Data Sources</NuxtLink>
+		</h3>
+		<ul>
+			<li><NuxtLink to="/data-sources" class="sidebar__item">Data Sources</NuxtLink></li>
+		</ul>
 		<!-- <div class="sidebar__item">Vector Stores</div> -->
 
 		<!-- Quotas -->
@@ -54,27 +56,35 @@
 		<div class="sidebar__item">Language Models & Endpoints</div> -->
 
 		<!-- Security -->
-		<div class="sidebar__section-header">
-			<span class="pi pi-shield"></span>
+		<h3 class="sidebar__section-header">
+			<span class="pi pi-shield" aria-hidden="true"></span>
 			<span>Security</span>
-		</div>
-
-		<NuxtLink to="/security/role-assignments" class="sidebar__item">
-			Instance Access Control
-		</NuxtLink>
+		</h3>
+		<ul>
+			<li>
+				<NuxtLink to="/security/role-assignments" class="sidebar__item">
+					Instance Access Control
+				</NuxtLink>
+			</li>
+		</ul>
 
 		<!-- FLLM Deployment -->
-		<div class="sidebar__section-header">
-			<span class="pi pi-cloud"></span>
+		<h3 class="sidebar__section-header">
+			<span class="pi pi-cloud" aria-hidden="true"></span>
 			<span>FLLM Platform</span>
-		</div>
-
-		<NuxtLink to="/branding" class="sidebar__item">Branding</NuxtLink>
-		<NuxtLink to="/info" class="sidebar__item">Deployment Information</NuxtLink>
+		</h3>
+		<ul>
+			<li><NuxtLink to="/branding" class="sidebar__item">Branding</NuxtLink></li>
+			<li><NuxtLink to="/info" class="sidebar__item">Deployment Information</NuxtLink></li>
+		</ul>
 
 		<!-- Logged in user -->
 		<div v-if="$authStore.currentAccount?.name" class="sidebar__account">
-			<UserAvatar class="sidebar__avatar" size="large" />
+			<UserAvatar
+				class="sidebar__avatar"
+				size="large"
+				:aria-label="`User Avatar for ${$authStore.currentAccount?.name}`"
+			/>
 
 			<div>
 				<VTooltip :auto-hide="isMobile" :popper-triggers="isMobile ? [] : ['hover']">
@@ -94,6 +104,7 @@
 					severity="secondary"
 					size="small"
 					@click="$authStore.logout()"
+					aria-label="Sign out of the application"
 				/>
 			</div>
 		</div>
@@ -127,6 +138,17 @@ a {
 	z-index: 3;
 	flex-shrink: 0;
 	overflow-y: scroll;
+}
+
+.sidebar ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin: 0;
+  padding: 0;
 }
 
 .sidebar__header {

--- a/src/ui/ManagementPortal/layouts/default.vue
+++ b/src/ui/ManagementPortal/layouts/default.vue
@@ -44,6 +44,7 @@ export default {
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
+	overflow-x: auto;
 }
 
 .page-content {

--- a/src/ui/ManagementPortal/layouts/default.vue
+++ b/src/ui/ManagementPortal/layouts/default.vue
@@ -1,5 +1,13 @@
 <template>
 	<div class="wrapper">
+		<Button
+			class="skip-to-main-content-button"
+			role="link"
+			label="Skip to main content"
+			aria-label="Skip to main content"
+			@click="focusMainContent"
+		/>
+
 		<Sidebar />
 		<div class="page">
 			<!-- Page to render -->
@@ -35,6 +43,14 @@ export default {
 			await this.$authStore.logoutSilent();
 			this.$router.push({ name: 'auth/login' });
 		},
+
+		focusMainContent() {
+			const mainContent = document.getElementById('main-content');
+			const focusableElements = mainContent.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])');
+			if (focusableElements.length > 0) {
+				focusableElements[0].focus();
+			}
+		},
 	},
 };
 </script>
@@ -56,5 +72,32 @@ footer {
 	font-size: 0.85rem;
 	margin-top: 24px;
 	padding-right: 24px;
+}
+
+.skip-to-main-content-button {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	border: 0;
+}
+
+.skip-to-main-content-button:focus {
+	position: fixed !important; /* Override sr-only */
+	top: 10px !important; /* Ensure visibility */
+	left: 10px !important;
+	width: auto !important;
+	height: auto !important;
+	z-index: 100 !important;
+	padding: 10px !important;
+	border: 2px solid #fff !important;
+	outline: none !important;
+	box-shadow: 0 0 5px rgba(0, 0, 0, 0.3) !important;
+	clip: auto !important; /* Remove clip hiding */
+	width: auto !important;
+	height: auto !important;
 }
 </style>

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -28,7 +28,7 @@
 		<div class="steps" :class="{ 'steps--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="steps__loading-overlay">
+				<div class="steps__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -53,6 +53,7 @@
 						v-if="nameValidationStatus === 'valid'"
 						class="icon valid"
 						title="Name is available"
+						aria-label="Name is available"
 					>
 						✔️
 					</span>
@@ -60,6 +61,7 @@
 						v-else-if="nameValidationStatus === 'invalid'"
 						class="icon invalid"
 						:title="validationMessage"
+						:aria-label="validationMessage"
 					>
 						❌
 					</span>

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -150,7 +150,7 @@
 
 					<!-- Data source -->
 					<div v-if="dedicated_pipeline">
-						<CreateAgentStepItem v-model="editDataSource">
+						<CreateAgentStepItem v-model="editDataSource" focusQuery=".step-container__edit__option">
 							<template v-if="selectedDataSource">
 								<div class="step-container__header">{{ selectedDataSource.type }}</div>
 								<div>
@@ -187,7 +187,9 @@
 											'step-container__edit__option--selected':
 												dataSource.name === selectedDataSource?.name,
 										}"
+										tabindex="0"
 										@click.stop="handleDataSourceSelected(dataSource)"
+										@keydown.enter="handleDataSourceSelected(dataSource)"
 									>
 										<div>
 											<div v-if="dataSource.object_id !== ''">
@@ -213,7 +215,7 @@
 					</div>
 
 					<!-- Index source -->
-					<CreateAgentStepItem v-model="editIndexSource">
+					<CreateAgentStepItem v-model="editIndexSource" focusQuery=".step-container__edit__option">
 						<template v-if="selectedIndexSource">
 							<div v-if="selectedIndexSource.object_id !== ''">
 								<div class="step-container__header">{{ selectedIndexSource.name }}</div>
@@ -243,7 +245,9 @@
 									'step-container__edit__option--selected':
 										indexSource.name === selectedIndexSource?.name,
 								}"
+								tabindex="0"
 								@click.stop="handleIndexSourceSelected(indexSource)"
+								@keydown.enter="handleIndexSourceSelected(indexSource)"
 							>
 								<div v-if="indexSource.object_id !== ''">
 									<div class="step-container__header">{{ indexSource.name }}</div>
@@ -270,7 +274,7 @@
 					</template>
 
 					<!-- Text embedding profiles -->
-					<CreateAgentStepItem v-model="editTextEmbeddingProfile">
+					<CreateAgentStepItem v-model="editTextEmbeddingProfile" focusQuery=".step-container__edit__option">
 						<template v-if="selectedTextEmbeddingProfile">
 							<div v-if="selectedTextEmbeddingProfile.object_id !== ''">
 								<div class="step-container__header">{{ selectedTextEmbeddingProfile.name }}</div>
@@ -307,7 +311,9 @@
 									'step-container__edit__option--selected':
 										textEmbeddingProfile.name === selectedTextEmbeddingProfile?.name,
 								}"
+								tabindex="0"
 								@click.stop="handleTextEmbeddingProfileSelected(textEmbeddingProfile)"
+								@keydown.enter="handleTextEmbeddingProfileSelected(textEmbeddingProfile)"
 							>
 								<div v-if="textEmbeddingProfile.object_id !== ''">
 									<div class="step-container__header">{{ textEmbeddingProfile.name }}</div>
@@ -340,7 +346,7 @@
 
 						<!-- Process indexing -->
 
-						<CreateAgentStepItem>
+						<CreateAgentStepItem focusQuery=".chunk-size-input">
 							<div class="step-container__header">Splitting & Chunking</div>
 
 							<div>
@@ -361,7 +367,7 @@
 									<InputText
 										v-model="chunkSize"
 										type="number"
-										class="mt-2"
+										class="mt-2 chunk-size-input"
 										aria-label="aria-chunk-size"
 									/>
 								</div>
@@ -379,7 +385,7 @@
 						</CreateAgentStepItem>
 
 						<!-- Trigger -->
-						<CreateAgentStepItem>
+						<CreateAgentStepItem focusQuery=".frequency-dropdown span">
 							<div class="step-container__header">Trigger</div>
 							<div>Runs every time a new item is added to the data source.</div>
 
@@ -401,7 +407,7 @@
 									<span id="aria-frequency" class="step-option__header">Frequency:</span>
 									<Dropdown
 										v-model="triggerFrequency"
-										class="dropdown--agent"
+										class="dropdown--agent frequency-dropdown"
 										:options="triggerFrequencyOptions"
 										placeholder="--Select--"
 										aria-label="aria-frequency"
@@ -440,7 +446,7 @@
 				<div class="step-header">How should user-agent interactions be gated?</div>
 
 				<!-- Conversation history -->
-				<CreateAgentStepItem>
+				<CreateAgentStepItem focusQuery=".conversation-history-toggle input">
 					<div class="step-container__header">Conversation History</div>
 
 					<div>
@@ -480,6 +486,7 @@
 									off-label="No"
 									off-icon="pi pi-times-circle"
 									aria-labelledby="aria-conversation-history aria-conversation-history-enabled"
+									class="conversation-history-toggle"
 								/>
 							</span>
 						</div>
@@ -497,7 +504,7 @@
 				</CreateAgentStepItem>
 
 				<!-- Gatekeeper -->
-				<CreateAgentStepItem>
+				<CreateAgentStepItem focusQuery=".gatekeeper-toggle input">
 					<div class="step-container__header">Gatekeeper</div>
 
 					<div>
@@ -549,6 +556,7 @@
 									off-label="No"
 									off-icon="pi pi-times-circle"
 									aria-labelledby="aria-gatekeeper aria-gatekeeper-enabled"
+									class="gatekeeper-toggle"
 								/>
 							</span>
 						</div>
@@ -604,7 +612,7 @@
 				<div class="step-header">Which capabilities should the agent have?</div>
 
 				<!-- AI model -->
-				<CreateAgentStepItem v-model="editAIModel">
+				<CreateAgentStepItem v-model="editAIModel" focusQuery=".step-container__edit__option">
 					<template v-if="selectedAIModel">
 						<div v-if="selectedAIModel.object_id !== ''">
 							<div class="step-container__header">{{ selectedAIModel.name }}</div>
@@ -625,7 +633,9 @@
 							:class="{
 								'step-container__edit__option--selected': aiModel.name === selectedAIModel?.name,
 							}"
+							tabindex="0"
 							@click.stop="handleAIModelSelected(aiModel)"
+							@keydown.enter="handleAIModelSelected(aiModel)"
 						>
 							<div v-if="aiModel.object_id !== ''">
 								<div class="step-container__header">{{ aiModel.name }}</div>
@@ -639,7 +649,7 @@
 				</CreateAgentStepItem>
 
 				<!-- Agent capabilities -->
-				<CreateAgentStepItem>
+				<CreateAgentStepItem focusQuery=".agent-capabilities-dropdown input">
 					<div>
 						<span class="step-option__header">Agent Capabilities:</span>
 						<span>{{
@@ -654,7 +664,7 @@
 							<span class="step-option__header">Agent Capabilities:</span>
 							<MultiSelect
 								v-model="selectedAgentCapabilities"
-								class="dropdown--agent"
+								class="dropdown--agent agent-capabilities-dropdown"
 								:options="agentCapabilitiesOptions"
 								option-label="name"
 								display="chip"

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<div style="display: flex">
 			<!-- Title -->
 			<div style="flex: 1">

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<div style="display: flex">
 			<!-- Title -->
 			<div style="flex: 1">
@@ -97,613 +97,619 @@
 			</div>
 
 			<!-- Knowledge source -->
-			<div class="step-section-header span-2">Knowledge Source</div>
+			<section aria-labelledby="knowledge-source" class="span-2 steps">
+				<h3 class="step-section-header span-2" id="knowledge-source">Knowledge Source</h3>
 
-			<div id="aria-inline-context" class="step-header span-2">
-				Does this agent have an inline context?
-			</div>
-			<div class="span-2">
-				<div class="d-flex align-center mt-2">
-					<span>
-						<ToggleButton
-							v-model="inline_context"
-							on-label="Yes"
-							on-icon="pi pi-check-circle"
-							off-label="No"
-							off-icon="pi pi-times-circle"
-							aria-labelledby="aria-inline-context"
-						/>
-					</span>
-				</div>
-			</div>
-
-			<template v-if="!inline_context">
-				<div id="aria-dedicated-pipeline" class="step-header span-2">
-					Do you want this agent to have a dedicated pipeline?
+				<div id="aria-inline-context" class="step-header span-2">
+					Does this agent have an inline context?
 				</div>
 				<div class="span-2">
 					<div class="d-flex align-center mt-2">
 						<span>
 							<ToggleButton
-								v-model="dedicated_pipeline"
+								v-model="inline_context"
 								on-label="Yes"
 								on-icon="pi pi-check-circle"
 								off-label="No"
 								off-icon="pi pi-times-circle"
-								aria-labelledby="aria-dedicated-pipeline"
+								aria-labelledby="aria-inline-context"
 							/>
 						</span>
 					</div>
 				</div>
 
-				<template v-if="dedicated_pipeline">
-					<div class="step-header">Where is the data?</div>
-				</template>
-				<template v-if="dedicated_pipeline">
-					<div class="step-header">Where should the data be indexed?</div>
-				</template>
-				<template v-else>
-					<div class="step-header">Select your index</div>
-					<div class="step-header">Select the text embedding profile</div>
-				</template>
-
-				<!-- Data source -->
-				<div v-if="dedicated_pipeline">
-					<CreateAgentStepItem v-model="editDataSource">
-						<template v-if="selectedDataSource">
-							<div class="step-container__header">{{ selectedDataSource.type }}</div>
-							<div>
-								<div v-if="selectedDataSource.object_id !== ''">
-									<span class="step-option__header">Name:</span>
-								</div>
-								<span>{{ selectedDataSource.name }}</span>
-							</div>
-							<!-- <div>
-								<span class="step-option__header">Container name:</span>
-								<span>{{ selectedDataSource.Container.Name }}</span>
-							</div> -->
-
-							<!-- <div>
-								<span class="step-option__header">Data Format(s):</span>
-								<span v-for="format in selectedDataSource.Formats" :key="format" class="mr-1">
-									{{ format }}
-								</span>
-							</div> -->
-						</template>
-						<template v-else>Please select a data source.</template>
-
-						<template #edit>
-							<div class="step-container__edit__header">Please select a data source.</div>
-
-							<div v-for="(group, type) in groupedDataSources" :key="type">
-								<div class="step-container__edit__group-header">{{ type }}</div>
-
-								<div
-									v-for="dataSource in group"
-									:key="dataSource.name"
-									class="step-container__edit__option"
-									:class="{
-										'step-container__edit__option--selected':
-											dataSource.name === selectedDataSource?.name,
-									}"
-									@click.stop="handleDataSourceSelected(dataSource)"
-								>
-									<div>
-										<div v-if="dataSource.object_id !== ''">
-											<span class="step-option__header">Name:</span>
-										</div>
-										<span>{{ dataSource.name }}</span>
-									</div>
-									<!-- <div>
-										<span class="step-option__header">Container name:</span>
-										<span>{{ dataSource.Container.Name }}</span>
-									</div> -->
-
-									<!-- <div>
-										<span class="step-option__header">Data Format(s):</span>
-										<span v-for="format in dataSource.Formats" :key="format" class="mr-1">
-											{{ format }}
-										</span>
-									</div> -->
-								</div>
-							</div>
-						</template>
-					</CreateAgentStepItem>
-				</div>
-
-				<!-- Index source -->
-				<CreateAgentStepItem v-model="editIndexSource">
-					<template v-if="selectedIndexSource">
-						<div v-if="selectedIndexSource.object_id !== ''">
-							<div class="step-container__header">{{ selectedIndexSource.name }}</div>
-							<div>
-								<span class="step-option__header">URL:</span>
-								<span>{{ selectedIndexSource.resolved_configuration_references.Endpoint }}</span>
-							</div>
-							<div>
-								<span class="step-option__header">Index Name:</span>
-								<span>{{ selectedIndexSource.settings.IndexName }}</span>
-							</div>
+				<template v-if="!inline_context">
+					<div id="aria-dedicated-pipeline" class="step-header span-2">
+						Do you want this agent to have a dedicated pipeline?
+					</div>
+					<div class="span-2">
+						<div class="d-flex align-center mt-2">
+							<span>
+								<ToggleButton
+									v-model="dedicated_pipeline"
+									on-label="Yes"
+									on-icon="pi pi-check-circle"
+									off-label="No"
+									off-icon="pi pi-times-circle"
+									aria-labelledby="aria-dedicated-pipeline"
+								/>
+							</span>
 						</div>
-						<div v-else>
-							<div class="step-container__header">DEFAULT</div>
-							{{ selectedIndexSource.name }}
-						</div>
+					</div>
+
+					<template v-if="dedicated_pipeline">
+						<div class="step-header">Where is the data?</div>
 					</template>
-					<template v-else>Please select an index source.</template>
+					<template v-if="dedicated_pipeline">
+						<div class="step-header">Where should the data be indexed?</div>
+					</template>
+					<template v-else>
+						<div class="step-header">Select your index</div>
+						<div class="step-header">Select the text embedding profile</div>
+					</template>
 
-					<template #edit>
-						<div class="step-container__edit__header">Please select an index source.</div>
-						<div
-							v-for="indexSource in indexSources"
-							:key="indexSource.name"
-							class="step-container__edit__option"
-							:class="{
-								'step-container__edit__option--selected':
-									indexSource.name === selectedIndexSource?.name,
-							}"
-							@click.stop="handleIndexSourceSelected(indexSource)"
-						>
-							<div v-if="indexSource.object_id !== ''">
-								<div class="step-container__header">{{ indexSource.name }}</div>
-								<div v-if="indexSource.resolved_configuration_references.Endpoint">
-									<span class="step-option__header">URL:</span>
-									<span>{{ indexSource.resolved_configuration_references.Endpoint }}</span>
+					<!-- Data source -->
+					<div v-if="dedicated_pipeline">
+						<CreateAgentStepItem v-model="editDataSource">
+							<template v-if="selectedDataSource">
+								<div class="step-container__header">{{ selectedDataSource.type }}</div>
+								<div>
+									<div v-if="selectedDataSource.object_id !== ''">
+										<span class="step-option__header">Name:</span>
+									</div>
+									<span>{{ selectedDataSource.name }}</span>
 								</div>
-								<div v-if="indexSource.settings.IndexName">
+								<!-- <div>
+									<span class="step-option__header">Container name:</span>
+									<span>{{ selectedDataSource.Container.Name }}</span>
+								</div> -->
+
+								<!-- <div>
+									<span class="step-option__header">Data Format(s):</span>
+									<span v-for="format in selectedDataSource.Formats" :key="format" class="mr-1">
+										{{ format }}
+									</span>
+								</div> -->
+							</template>
+							<template v-else>Please select a data source.</template>
+
+							<template #edit>
+								<div class="step-container__edit__header">Please select a data source.</div>
+
+								<div v-for="(group, type) in groupedDataSources" :key="type">
+									<div class="step-container__edit__group-header">{{ type }}</div>
+
+									<div
+										v-for="dataSource in group"
+										:key="dataSource.name"
+										class="step-container__edit__option"
+										:class="{
+											'step-container__edit__option--selected':
+												dataSource.name === selectedDataSource?.name,
+										}"
+										@click.stop="handleDataSourceSelected(dataSource)"
+									>
+										<div>
+											<div v-if="dataSource.object_id !== ''">
+												<span class="step-option__header">Name:</span>
+											</div>
+											<span>{{ dataSource.name }}</span>
+										</div>
+										<!-- <div>
+											<span class="step-option__header">Container name:</span>
+											<span>{{ dataSource.Container.Name }}</span>
+										</div> -->
+
+										<!-- <div>
+											<span class="step-option__header">Data Format(s):</span>
+											<span v-for="format in dataSource.Formats" :key="format" class="mr-1">
+												{{ format }}
+											</span>
+										</div> -->
+									</div>
+								</div>
+							</template>
+						</CreateAgentStepItem>
+					</div>
+
+					<!-- Index source -->
+					<CreateAgentStepItem v-model="editIndexSource">
+						<template v-if="selectedIndexSource">
+							<div v-if="selectedIndexSource.object_id !== ''">
+								<div class="step-container__header">{{ selectedIndexSource.name }}</div>
+								<div>
+									<span class="step-option__header">URL:</span>
+									<span>{{ selectedIndexSource.resolved_configuration_references.Endpoint }}</span>
+								</div>
+								<div>
 									<span class="step-option__header">Index Name:</span>
-									<span>{{ indexSource.settings.IndexName }}</span>
+									<span>{{ selectedIndexSource.settings.IndexName }}</span>
 								</div>
 							</div>
 							<div v-else>
 								<div class="step-container__header">DEFAULT</div>
-								{{ indexSource.name }}
+								{{ selectedIndexSource.name }}
 							</div>
-						</div>
+						</template>
+						<template v-else>Please select an index source.</template>
+
+						<template #edit>
+							<div class="step-container__edit__header">Please select an index source.</div>
+							<div
+								v-for="indexSource in indexSources"
+								:key="indexSource.name"
+								class="step-container__edit__option"
+								:class="{
+									'step-container__edit__option--selected':
+										indexSource.name === selectedIndexSource?.name,
+								}"
+								@click.stop="handleIndexSourceSelected(indexSource)"
+							>
+								<div v-if="indexSource.object_id !== ''">
+									<div class="step-container__header">{{ indexSource.name }}</div>
+									<div v-if="indexSource.resolved_configuration_references.Endpoint">
+										<span class="step-option__header">URL:</span>
+										<span>{{ indexSource.resolved_configuration_references.Endpoint }}</span>
+									</div>
+									<div v-if="indexSource.settings.IndexName">
+										<span class="step-option__header">Index Name:</span>
+										<span>{{ indexSource.settings.IndexName }}</span>
+									</div>
+								</div>
+								<div v-else>
+									<div class="step-container__header">DEFAULT</div>
+									{{ indexSource.name }}
+								</div>
+							</div>
+						</template>
+					</CreateAgentStepItem>
+
+					<template v-if="dedicated_pipeline">
+						<div class="step-header">Select the text embedding profile</div>
+						<div class="step-header"></div>
 					</template>
-				</CreateAgentStepItem>
 
-				<template v-if="dedicated_pipeline">
-					<div class="step-header">Select the text embedding profile</div>
-					<div class="step-header"></div>
-				</template>
-
-				<!-- Text embedding profiles -->
-				<CreateAgentStepItem v-model="editTextEmbeddingProfile">
-					<template v-if="selectedTextEmbeddingProfile">
-						<div v-if="selectedTextEmbeddingProfile.object_id !== ''">
-							<div class="step-container__header">{{ selectedTextEmbeddingProfile.name }}</div>
-							<div v-if="selectedTextEmbeddingProfile.resolved_configuration_references?.Endpoint">
-								<span class="step-option__header">URL:</span>
-								<span>{{
-									selectedTextEmbeddingProfile.resolved_configuration_references.Endpoint
-								}}</span
-								><br />
-								<span class="step-option__header">Deployment:</span>
-								<span>{{
-									selectedTextEmbeddingProfile.resolved_configuration_references.DeploymentName
-								}}</span>
-							</div>
-							<div v-if="selectedTextEmbeddingProfile.settings?.model_name">
-								<span class="step-option__header">Model Name:</span>
-								<span>{{ selectedTextEmbeddingProfile.settings.model_name }}</span>
-							</div>
-						</div>
-						<div v-else>
-							<div class="step-container__header">DEFAULT</div>
-							{{ selectedTextEmbeddingProfile.name }}
-						</div>
-					</template>
-					<template v-else>Please select text embedding profile.</template>
-
-					<template #edit>
-						<div class="step-container__edit__header">Please select text embedding profile.</div>
-						<div
-							v-for="textEmbeddingProfile in textEmbeddingProfileSources"
-							:key="textEmbeddingProfile.name"
-							class="step-container__edit__option"
-							:class="{
-								'step-container__edit__option--selected':
-									textEmbeddingProfile.name === selectedTextEmbeddingProfile?.name,
-							}"
-							@click.stop="handleTextEmbeddingProfileSelected(textEmbeddingProfile)"
-						>
-							<div v-if="textEmbeddingProfile.object_id !== ''">
-								<div class="step-container__header">{{ textEmbeddingProfile.name }}</div>
-								<div v-if="textEmbeddingProfile.resolved_configuration_references?.Endpoint">
+					<!-- Text embedding profiles -->
+					<CreateAgentStepItem v-model="editTextEmbeddingProfile">
+						<template v-if="selectedTextEmbeddingProfile">
+							<div v-if="selectedTextEmbeddingProfile.object_id !== ''">
+								<div class="step-container__header">{{ selectedTextEmbeddingProfile.name }}</div>
+								<div v-if="selectedTextEmbeddingProfile.resolved_configuration_references?.Endpoint">
 									<span class="step-option__header">URL:</span>
-									<span>{{ textEmbeddingProfile.resolved_configuration_references.Endpoint }}</span
+									<span>{{
+										selectedTextEmbeddingProfile.resolved_configuration_references.Endpoint
+									}}</span
 									><br />
 									<span class="step-option__header">Deployment:</span>
 									<span>{{
-										textEmbeddingProfile.resolved_configuration_references.DeploymentName
+										selectedTextEmbeddingProfile.resolved_configuration_references.DeploymentName
 									}}</span>
 								</div>
-								<div v-if="textEmbeddingProfile.settings?.model_name">
+								<div v-if="selectedTextEmbeddingProfile.settings?.model_name">
 									<span class="step-option__header">Model Name:</span>
-									<span>{{ textEmbeddingProfile.settings.model_name }}</span>
+									<span>{{ selectedTextEmbeddingProfile.settings.model_name }}</span>
 								</div>
 							</div>
 							<div v-else>
 								<div class="step-container__header">DEFAULT</div>
-								{{ textEmbeddingProfile.name }}
+								{{ selectedTextEmbeddingProfile.name }}
 							</div>
-						</div>
-					</template>
-				</CreateAgentStepItem>
-				<div></div>
-
-				<template v-if="dedicated_pipeline">
-					<div class="step-header">How should the data be processed for indexing?</div>
-					<div class="step-header">When should the data be indexed?</div>
-
-					<!-- Process indexing -->
-
-					<CreateAgentStepItem>
-						<div class="step-container__header">Splitting & Chunking</div>
-
-						<div>
-							<span class="step-option__header">Chunk size:</span>
-							<span>{{ chunkSize }}</span>
-						</div>
-
-						<div>
-							<span class="step-option__header">Overlap size:</span>
-							<span>{{ overlapSize == 0 ? 'No Overlap' : overlapSize }}</span>
-						</div>
+						</template>
+						<template v-else>Please select text embedding profile.</template>
 
 						<template #edit>
-							<div class="step-container__header">Splitting & Chunking</div>
-
-							<div>
-								<span id="aria-chunk-size" class="step-option__header">Chunk size:</span>
-								<InputText
-									v-model="chunkSize"
-									type="number"
-									class="mt-2"
-									aria-label="aria-chunk-size"
-								/>
-							</div>
-
-							<div>
-								<span id="aria-overlap-size" class="step-option__header">Overlap size:</span>
-								<InputText
-									v-model="overlapSize"
-									type="number"
-									class="mt-2"
-									aria-label="aria-overlap-size"
-								/>
+							<div class="step-container__edit__header">Please select text embedding profile.</div>
+							<div
+								v-for="textEmbeddingProfile in textEmbeddingProfileSources"
+								:key="textEmbeddingProfile.name"
+								class="step-container__edit__option"
+								:class="{
+									'step-container__edit__option--selected':
+										textEmbeddingProfile.name === selectedTextEmbeddingProfile?.name,
+								}"
+								@click.stop="handleTextEmbeddingProfileSelected(textEmbeddingProfile)"
+							>
+								<div v-if="textEmbeddingProfile.object_id !== ''">
+									<div class="step-container__header">{{ textEmbeddingProfile.name }}</div>
+									<div v-if="textEmbeddingProfile.resolved_configuration_references?.Endpoint">
+										<span class="step-option__header">URL:</span>
+										<span>{{ textEmbeddingProfile.resolved_configuration_references.Endpoint }}</span
+										><br />
+										<span class="step-option__header">Deployment:</span>
+										<span>{{
+											textEmbeddingProfile.resolved_configuration_references.DeploymentName
+										}}</span>
+									</div>
+									<div v-if="textEmbeddingProfile.settings?.model_name">
+										<span class="step-option__header">Model Name:</span>
+										<span>{{ textEmbeddingProfile.settings.model_name }}</span>
+									</div>
+								</div>
+								<div v-else>
+									<div class="step-container__header">DEFAULT</div>
+									{{ textEmbeddingProfile.name }}
+								</div>
 							</div>
 						</template>
 					</CreateAgentStepItem>
+					<div></div>
 
-					<!-- Trigger -->
-					<CreateAgentStepItem>
-						<div class="step-container__header">Trigger</div>
-						<div>Runs every time a new item is added to the data source.</div>
+					<template v-if="dedicated_pipeline">
+						<div class="step-header">How should the data be processed for indexing?</div>
+						<div class="step-header">When should the data be indexed?</div>
 
-						<div class="mt-2">
-							<span class="step-option__header">Frequency:</span>
-							<span>{{ triggerFrequency }}</span>
-						</div>
+						<!-- Process indexing -->
 
-						<div v-if="triggerFrequency === 'Schedule' && triggerFrequencyScheduled">
-							<span class="step-option__header">Schedule:</span>
-							<span>{{ triggerFrequencyScheduled }}</span>
-						</div>
+						<CreateAgentStepItem>
+							<div class="step-container__header">Splitting & Chunking</div>
 
-						<template #edit>
+							<div>
+								<span class="step-option__header">Chunk size:</span>
+								<span>{{ chunkSize }}</span>
+							</div>
+
+							<div>
+								<span class="step-option__header">Overlap size:</span>
+								<span>{{ overlapSize == 0 ? 'No Overlap' : overlapSize }}</span>
+							</div>
+
+							<template #edit>
+								<div class="step-container__header">Splitting & Chunking</div>
+
+								<div>
+									<span id="aria-chunk-size" class="step-option__header">Chunk size:</span>
+									<InputText
+										v-model="chunkSize"
+										type="number"
+										class="mt-2"
+										aria-label="aria-chunk-size"
+									/>
+								</div>
+
+								<div>
+									<span id="aria-overlap-size" class="step-option__header">Overlap size:</span>
+									<InputText
+										v-model="overlapSize"
+										type="number"
+										class="mt-2"
+										aria-label="aria-overlap-size"
+									/>
+								</div>
+							</template>
+						</CreateAgentStepItem>
+
+						<!-- Trigger -->
+						<CreateAgentStepItem>
 							<div class="step-container__header">Trigger</div>
 							<div>Runs every time a new item is added to the data source.</div>
 
 							<div class="mt-2">
-								<span id="aria-frequency" class="step-option__header">Frequency:</span>
-								<Dropdown
-									v-model="triggerFrequency"
-									class="dropdown--agent"
-									:options="triggerFrequencyOptions"
-									placeholder="--Select--"
-									aria-label="aria-frequency"
-								/>
+								<span class="step-option__header">Frequency:</span>
+								<span>{{ triggerFrequency }}</span>
 							</div>
 
-							<div v-if="triggerFrequency === 'Schedule'" class="mt-2">
-								<CronLight
-									v-model="triggerFrequencyScheduled"
-									format="quartz"
-									@error="error = $event"
-								/>
-								<!-- editable cron expression -->
-								<InputText
-									class="mt-4"
-									label="cron expression"
-									:model-value="triggerFrequencyScheduled"
-									:error-messages="error"
-									aria-label="cron expression"
-									@update:model-value="triggerFrequencyNextScheduled = $event"
-									@blur="triggerFrequencyScheduled = triggerFrequencyNextScheduled"
-								/>
+							<div v-if="triggerFrequency === 'Schedule' && triggerFrequencyScheduled">
+								<span class="step-option__header">Schedule:</span>
+								<span>{{ triggerFrequencyScheduled }}</span>
 							</div>
-						</template>
-					</CreateAgentStepItem>
+
+							<template #edit>
+								<div class="step-container__header">Trigger</div>
+								<div>Runs every time a new item is added to the data source.</div>
+
+								<div class="mt-2">
+									<span id="aria-frequency" class="step-option__header">Frequency:</span>
+									<Dropdown
+										v-model="triggerFrequency"
+										class="dropdown--agent"
+										:options="triggerFrequencyOptions"
+										placeholder="--Select--"
+										aria-label="aria-frequency"
+									/>
+								</div>
+
+								<div v-if="triggerFrequency === 'Schedule'" class="mt-2">
+									<CronLight
+										v-model="triggerFrequencyScheduled"
+										format="quartz"
+										@error="error = $event"
+									/>
+									<!-- editable cron expression -->
+									<InputText
+										class="mt-4"
+										label="cron expression"
+										:model-value="triggerFrequencyScheduled"
+										:error-messages="error"
+										aria-label="cron expression"
+										@update:model-value="triggerFrequencyNextScheduled = $event"
+										@blur="triggerFrequencyScheduled = triggerFrequencyNextScheduled"
+									/>
+								</div>
+							</template>
+						</CreateAgentStepItem>
+					</template>
 				</template>
-			</template>
+			</section>
 			<!-- End of Knowledge Source -->
 
 			<!-- Agent configuration -->
-			<div class="step-section-header span-2">Agent Configuration</div>
+			<section aria-labelledby="agent-configuration" class="span-2 steps">
+				<h3 class="step-section-header span-2" id="agent-configuration">Agent Configuration</h3>
 
-			<div class="step-header">Should conversations be included in the context?</div>
-			<div class="step-header">How should user-agent interactions be gated?</div>
+				<div class="step-header">Should conversations be included in the context?</div>
+				<div class="step-header">How should user-agent interactions be gated?</div>
 
-			<!-- Conversation history -->
-			<CreateAgentStepItem>
-				<div class="step-container__header">Conversation History</div>
+				<!-- Conversation history -->
+				<CreateAgentStepItem>
+					<div class="step-container__header">Conversation History</div>
 
-				<div>
-					<span class="step-option__header">Enabled:</span>
-					<span>
-						<span>{{ conversationHistory ? 'Yes' : 'No' }}</span>
-						<span
-							v-if="conversationHistory"
-							class="pi pi-check-circle ml-1"
-							style="color: var(--green-400); font-size: 0.8rem"
-						></span>
-						<span
-							v-else
-							class="pi pi-times-circle ml-1"
-							style="color: var(--red-400); font-size: 0.8rem"
-						></span>
-					</span>
-				</div>
-
-				<div>
-					<span class="step-option__header">Max Messages:</span>
-					<span>{{ conversationMaxMessages }}</span>
-				</div>
-
-				<template #edit>
-					<div id="aria-conversation-history" class="step-container__header">
-						Conversation History
-					</div>
-
-					<div class="d-flex align-center mt-2">
-						<span id="aria-conversation-history-enabled" class="step-option__header">Enabled:</span>
+					<div>
+						<span class="step-option__header">Enabled:</span>
 						<span>
-							<ToggleButton
-								v-model="conversationHistory"
-								on-label="Yes"
-								on-icon="pi pi-check-circle"
-								off-label="No"
-								off-icon="pi pi-times-circle"
-								aria-labelledby="aria-conversation-history aria-conversation-history-enabled"
-							/>
+							<span>{{ conversationHistory ? 'Yes' : 'No' }}</span>
+							<span
+								v-if="conversationHistory"
+								class="pi pi-check-circle ml-1"
+								style="color: var(--green-400); font-size: 0.8rem"
+							></span>
+							<span
+								v-else
+								class="pi pi-times-circle ml-1"
+								style="color: var(--red-400); font-size: 0.8rem"
+							></span>
 						</span>
 					</div>
 
 					<div>
-						<span id="aria-max-messages" class="step-option__header">Max Messages:</span>
-						<InputText
-							v-model="conversationMaxMessages"
-							type="number"
-							class="mt-2"
-							aria-label="aria-max-messages"
-						/>
+						<span class="step-option__header">Max Messages:</span>
+						<span>{{ conversationMaxMessages }}</span>
 					</div>
-				</template>
-			</CreateAgentStepItem>
 
-			<!-- Gatekeeper -->
-			<CreateAgentStepItem>
-				<div class="step-container__header">Gatekeeper</div>
+					<template #edit>
+						<div id="aria-conversation-history" class="step-container__header">
+							Conversation History
+						</div>
 
-				<div>
-					<span class="step-option__header">Enabled:</span>
-					<span>
-						<span>{{ gatekeeperEnabled ? 'Yes' : 'No' }}</span>
-						<span
-							v-if="gatekeeperEnabled"
-							class="pi pi-check-circle ml-1"
-							style="color: var(--green-400); font-size: 0.8rem"
-						></span>
-						<span
-							v-else
-							class="pi pi-times-circle ml-1"
-							style="color: var(--red-400); font-size: 0.8rem"
-						></span>
-					</span>
-				</div>
+						<div class="d-flex align-center mt-2">
+							<span id="aria-conversation-history-enabled" class="step-option__header">Enabled:</span>
+							<span>
+								<ToggleButton
+									v-model="conversationHistory"
+									on-label="Yes"
+									on-icon="pi pi-check-circle"
+									off-label="No"
+									off-icon="pi pi-times-circle"
+									aria-labelledby="aria-conversation-history aria-conversation-history-enabled"
+								/>
+							</span>
+						</div>
 
-				<div>
-					<span class="step-option__header">Content Safety:</span>
-					<span>{{
-						Array.isArray(selectedGatekeeperContentSafety)
-							? selectedGatekeeperContentSafety.map((item) => item.name).join(', ')
-							: ''
-					}}</span>
-				</div>
-
-				<div>
-					<span class="step-option__header">Data Protection:</span>
-					<span>{{
-						Array.isArray(selectedGatekeeperDataProtection)
-							? selectedGatekeeperDataProtection.map((item) => item.name).join(', ')
-							: ''
-					}}</span>
-				</div>
-
-				<template #edit>
-					<div id="aria-gatekeeper" class="step-container__header">Gatekeeper</div>
-
-					<!-- Gatekeeper toggle -->
-					<div class="d-flex align-center mt-2">
-						<span id="aria-gatekeeper-enabled" class="step-option__header">Enabled:</span>
-						<span>
-							<ToggleButton
-								v-model="gatekeeperEnabled"
-								on-label="Yes"
-								on-icon="pi pi-check-circle"
-								off-label="No"
-								off-icon="pi pi-times-circle"
-								aria-labelledby="aria-gatekeeper aria-gatekeeper-enabled"
+						<div>
+							<span id="aria-max-messages" class="step-option__header">Max Messages:</span>
+							<InputText
+								v-model="conversationMaxMessages"
+								type="number"
+								class="mt-2"
+								aria-label="aria-max-messages"
 							/>
+						</div>
+					</template>
+				</CreateAgentStepItem>
+
+				<!-- Gatekeeper -->
+				<CreateAgentStepItem>
+					<div class="step-container__header">Gatekeeper</div>
+
+					<div>
+						<span class="step-option__header">Enabled:</span>
+						<span>
+							<span>{{ gatekeeperEnabled ? 'Yes' : 'No' }}</span>
+							<span
+								v-if="gatekeeperEnabled"
+								class="pi pi-check-circle ml-1"
+								style="color: var(--green-400); font-size: 0.8rem"
+							></span>
+							<span
+								v-else
+								class="pi pi-times-circle ml-1"
+								style="color: var(--red-400); font-size: 0.8rem"
+							></span>
 						</span>
 					</div>
 
-					<!-- Content safety -->
-					<div class="mt-2">
-						<span id="aria-content-safety" class="step-option__header">Content Safety:</span>
-						<MultiSelect
-							v-model="selectedGatekeeperContentSafety"
-							class="dropdown--agent"
-							:options="gatekeeperContentSafetyOptions"
-							option-label="name"
-							display="chip"
-							placeholder="--Select--"
-							aria-labelledby="aria-content-safety"
-						/>
+					<div>
+						<span class="step-option__header">Content Safety:</span>
+						<span>{{
+							Array.isArray(selectedGatekeeperContentSafety)
+								? selectedGatekeeperContentSafety.map((item) => item.name).join(', ')
+								: ''
+						}}</span>
 					</div>
 
-					<!-- Data protection -->
-					<div class="mt-2">
-						<span id="aria-data-prot" class="step-option__header">Data Protection:</span>
-						<!-- <span>Microsoft Presidio</span> -->
-						<MultiSelect
-							v-model="selectedGatekeeperDataProtection"
-							class="dropdown--agent"
-							:options="gatekeeperDataProtectionOptions"
-							option-label="name"
-							display="chip"
-							placeholder="--Select--"
-							aria-labelledby="aria-data-prot"
-						/>
+					<div>
+						<span class="step-option__header">Data Protection:</span>
+						<span>{{
+							Array.isArray(selectedGatekeeperDataProtection)
+								? selectedGatekeeperDataProtection.map((item) => item.name).join(', ')
+								: ''
+						}}</span>
 					</div>
-				</template>
-			</CreateAgentStepItem>
 
-			<!-- Orchestrator -->
-			<div id="aria-orchestrator" class="step-header span-2">
-				How should the agent communicate with the AI model?
-			</div>
-			<div class="span-2">
-				<Dropdown
-					v-model="orchestration_settings.orchestrator"
-					:options="orchestratorOptions"
-					option-label="label"
-					option-value="value"
-					class="dropdown--agent"
-					placeholder="--Select--"
-					aria-labelledby="aria-orchestrator"
-				/>
-			</div>
+					<template #edit>
+						<div id="aria-gatekeeper" class="step-container__header">Gatekeeper</div>
 
-			<div class="step-header">Which AI model should the orchestrator use?</div>
-			<div class="step-header">Which capabilities should the agent have?</div>
-
-			<!-- AI model -->
-			<CreateAgentStepItem v-model="editAIModel">
-				<template v-if="selectedAIModel">
-					<div v-if="selectedAIModel.object_id !== ''">
-						<div class="step-container__header">{{ selectedAIModel.name }}</div>
-						<div>
-							<span class="step-option__header">Deployment name:</span>
-							<span>{{ selectedAIModel.deployment_name }}</span>
+						<!-- Gatekeeper toggle -->
+						<div class="d-flex align-center mt-2">
+							<span id="aria-gatekeeper-enabled" class="step-option__header">Enabled:</span>
+							<span>
+								<ToggleButton
+									v-model="gatekeeperEnabled"
+									on-label="Yes"
+									on-icon="pi pi-check-circle"
+									off-label="No"
+									off-icon="pi pi-times-circle"
+									aria-labelledby="aria-gatekeeper aria-gatekeeper-enabled"
+								/>
+							</span>
 						</div>
-					</div>
-				</template>
-				<template v-else>Please select an AI model.</template>
 
-				<template #edit>
-					<div class="step-container__edit__header">Please select an AI model.</div>
-					<div
-						v-for="aiModel in aiModelOptions"
-						:key="aiModel.name"
-						class="step-container__edit__option"
-						:class="{
-							'step-container__edit__option--selected': aiModel.name === selectedAIModel?.name,
-						}"
-						@click.stop="handleAIModelSelected(aiModel)"
-					>
-						<div v-if="aiModel.object_id !== ''">
-							<div class="step-container__header">{{ aiModel.name }}</div>
-							<div v-if="aiModel.deployment_name">
-								<span class="step-option__header">Deployment name:</span>
-								<span>{{ aiModel.deployment_name }}</span>
-							</div>
+						<!-- Content safety -->
+						<div class="mt-2">
+							<span id="aria-content-safety" class="step-option__header">Content Safety:</span>
+							<MultiSelect
+								v-model="selectedGatekeeperContentSafety"
+								class="dropdown--agent"
+								:options="gatekeeperContentSafetyOptions"
+								option-label="name"
+								display="chip"
+								placeholder="--Select--"
+								aria-labelledby="aria-content-safety"
+							/>
 						</div>
-					</div>
-				</template>
-			</CreateAgentStepItem>
 
-			<!-- Agent capabilities -->
-			<CreateAgentStepItem>
-				<div>
-					<span class="step-option__header">Agent Capabilities:</span>
-					<span>{{
-						Array.isArray(selectedAgentCapabilities)
-							? selectedAgentCapabilities.map((item) => item.name).join(', ')
-							: ''
-					}}</span>
+						<!-- Data protection -->
+						<div class="mt-2">
+							<span id="aria-data-prot" class="step-option__header">Data Protection:</span>
+							<!-- <span>Microsoft Presidio</span> -->
+							<MultiSelect
+								v-model="selectedGatekeeperDataProtection"
+								class="dropdown--agent"
+								:options="gatekeeperDataProtectionOptions"
+								option-label="name"
+								display="chip"
+								placeholder="--Select--"
+								aria-labelledby="aria-data-prot"
+							/>
+						</div>
+					</template>
+				</CreateAgentStepItem>
+
+				<!-- Orchestrator -->
+				<div id="aria-orchestrator" class="step-header span-2">
+					How should the agent communicate with the AI model?
+				</div>
+				<div class="span-2">
+					<Dropdown
+						v-model="orchestration_settings.orchestrator"
+						:options="orchestratorOptions"
+						option-label="label"
+						option-value="value"
+						class="dropdown--agent"
+						placeholder="--Select--"
+						aria-labelledby="aria-orchestrator"
+					/>
 				</div>
 
-				<template #edit>
-					<div class="mt-2">
+				<div class="step-header">Which AI model should the orchestrator use?</div>
+				<div class="step-header">Which capabilities should the agent have?</div>
+
+				<!-- AI model -->
+				<CreateAgentStepItem v-model="editAIModel">
+					<template v-if="selectedAIModel">
+						<div v-if="selectedAIModel.object_id !== ''">
+							<div class="step-container__header">{{ selectedAIModel.name }}</div>
+							<div>
+								<span class="step-option__header">Deployment name:</span>
+								<span>{{ selectedAIModel.deployment_name }}</span>
+							</div>
+						</div>
+					</template>
+					<template v-else>Please select an AI model.</template>
+
+					<template #edit>
+						<div class="step-container__edit__header">Please select an AI model.</div>
+						<div
+							v-for="aiModel in aiModelOptions"
+							:key="aiModel.name"
+							class="step-container__edit__option"
+							:class="{
+								'step-container__edit__option--selected': aiModel.name === selectedAIModel?.name,
+							}"
+							@click.stop="handleAIModelSelected(aiModel)"
+						>
+							<div v-if="aiModel.object_id !== ''">
+								<div class="step-container__header">{{ aiModel.name }}</div>
+								<div v-if="aiModel.deployment_name">
+									<span class="step-option__header">Deployment name:</span>
+									<span>{{ aiModel.deployment_name }}</span>
+								</div>
+							</div>
+						</div>
+					</template>
+				</CreateAgentStepItem>
+
+				<!-- Agent capabilities -->
+				<CreateAgentStepItem>
+					<div>
 						<span class="step-option__header">Agent Capabilities:</span>
-						<MultiSelect
-							v-model="selectedAgentCapabilities"
-							class="dropdown--agent"
-							:options="agentCapabilitiesOptions"
-							option-label="name"
-							display="chip"
-							placeholder="--Select--"
-							aria-labelledby="aria-content-safety"
-						/>
+						<span>{{
+							Array.isArray(selectedAgentCapabilities)
+								? selectedAgentCapabilities.map((item) => item.name).join(', ')
+								: ''
+						}}</span>
 					</div>
-				</template>
-			</CreateAgentStepItem>
 
-			<!-- Cost center -->
-			<div id="aria-cost-center" class="step-header span-2">
-				Would you like to assign this agent to a cost center?
-			</div>
-			<div class="span-2">
-				<InputText
-					v-model="cost_center"
-					type="text"
-					class="w-50"
-					placeholder="Enter cost center name"
-					aria-labelledby="aria-cost-center"
-				/>
-			</div>
+					<template #edit>
+						<div class="mt-2">
+							<span class="step-option__header">Agent Capabilities:</span>
+							<MultiSelect
+								v-model="selectedAgentCapabilities"
+								class="dropdown--agent"
+								:options="agentCapabilitiesOptions"
+								option-label="name"
+								display="chip"
+								placeholder="--Select--"
+								aria-labelledby="aria-content-safety"
+							/>
+						</div>
+					</template>
+				</CreateAgentStepItem>
 
-			<!-- Expiration -->
-			<div class="step-header span-2">Would you like to set an expiration on this agent?</div>
-			<div class="span-2">
-				<Calendar
-					v-model="expirationDate"
-					show-icon
-					show-button-bar
-					placeholder="Enter expiration date"
-					type="text"
-				/>
-			</div>
+				<!-- Cost center -->
+				<div id="aria-cost-center" class="step-header span-2">
+					Would you like to assign this agent to a cost center?
+				</div>
+				<div class="span-2">
+					<InputText
+						v-model="cost_center"
+						type="text"
+						class="w-50"
+						placeholder="Enter cost center name"
+						aria-labelledby="aria-cost-center"
+					/>
+				</div>
+
+				<!-- Expiration -->
+				<div class="step-header span-2">Would you like to set an expiration on this agent?</div>
+				<div class="span-2">
+					<Calendar
+						v-model="expirationDate"
+						show-icon
+						show-button-bar
+						placeholder="Enter expiration date"
+						type="text"
+					/>
+				</div>
+			</section>
 
 			<!-- System prompt -->
-			<div class="step-section-header span-2">System Prompt</div>
+			<section aria-labelledby="system-prompt" class="span-2 steps">
+				<h3 class="step-section-header span-2" id="system-prompt">System Prompt</h3>
 
-			<div id="aria-persona" class="step-header">What is the persona of the agent?</div>
+				<div id="aria-persona" class="step-header">What is the persona of the agent?</div>
 
-			<div class="span-2">
-				<Textarea
-					v-model="systemPrompt"
-					class="w-100"
-					auto-resize
-					rows="5"
-					type="text"
-					placeholder="You are an analytic agent named Khalil that helps people find information about FoundationaLLM. Provide concise answers that are polite and professional."
-					aria-labelledby="aria-persona"
-				/>
-			</div>
+				<div class="span-2">
+					<Textarea
+						v-model="systemPrompt"
+						class="w-100"
+						auto-resize
+						rows="5"
+						type="text"
+						placeholder="You are an analytic agent named Khalil that helps people find information about FoundationaLLM. Provide concise answers that are polite and professional."
+						aria-labelledby="aria-persona"
+					/>
+				</div>
+			</section>
 			<div class="button-container column-2 justify-self-end">
 				<!-- Create agent -->
 				<Button
@@ -723,7 +729,7 @@
 				/>
 			</div>
 		</div>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">
@@ -1381,6 +1387,7 @@ export default {
 }
 
 .step-section-header {
+	margin: 0px;
 	background-color: rgba(150, 150, 150, 1);
 	color: white;
 	font-size: 1rem;

--- a/src/ui/ManagementPortal/pages/agents/private.vue
+++ b/src/ui/ManagementPortal/pages/agents/private.vue
@@ -81,13 +81,16 @@
 				>
 					<template #body="{ data }">
 						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
-								:aria-label="`Edit ${data.resource.name}`"
-							>
-								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
+							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+								<Button
+									link
+									:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
+									:aria-label="`Edit ${data.resource.name}`"
+								>
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
+								</Button>
+								<template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
+							</VTooltip>
 						</NuxtLink>
 					</template>
 				</Column>
@@ -105,14 +108,17 @@
 					}"
 				>
 					<template #body="{ data }">
-						<Button
-							link
-							:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-							:aria-label="`Delete ${data.resource.name}`"
-							@click="agentToDelete = data.resource"
-						>
-							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
-						</Button>
+						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
+								:aria-label="`Delete ${data.resource.name}`"
+								@click="agentToDelete = data.resource"
+							>
+								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
+							</Button>
+							<template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
+						</VTooltip>
 					</template>
 				</Column>
 			</DataTable>

--- a/src/ui/ManagementPortal/pages/agents/private.vue
+++ b/src/ui/ManagementPortal/pages/agents/private.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<h2 class="page-header">My Agents</h2>
 		<div class="page-subheader">View your agents.</div>
 
@@ -80,7 +80,7 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button">
+						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
 							<Button
 								link
 								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
@@ -119,14 +119,14 @@
 		</div>
 
 		<!-- Delete agent dialog -->
-		<Dialog :visible="agentToDelete !== null" modal header="Delete Agent" :closable="false">
+		<Dialog :visible="agentToDelete !== null" modal v-focustrap header="Delete Agent" :closable="false">
 			<p>Do you want to delete the agent "{{ agentToDelete.name }}" ?</p>
 			<template #footer>
 				<Button label="Cancel" text @click="agentToDelete = null" />
-				<Button label="Delete" severity="danger" @click="handleDeleteAgent" />
+				<Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
 			</template>
 		</Dialog>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/agents/private.vue
+++ b/src/ui/ManagementPortal/pages/agents/private.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<h2 class="page-header">My Agents</h2>
 		<div class="page-subheader">View your agents.</div>
 

--- a/src/ui/ManagementPortal/pages/agents/private.vue
+++ b/src/ui/ManagementPortal/pages/agents/private.vue
@@ -6,7 +6,7 @@
 		<div :class="{ 'grid--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="grid__loading-overlay">
+				<div class="grid__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -15,8 +15,10 @@
 			<!-- Table -->
 			<DataTable :value="agents" striped-rows scrollable table-style="max-width: 100%" size="small">
 				<template #empty>
-					No agents found. Please use the menu on the left to create a new agent.</template
-				>
+					<div role="alert" aria-live="polite">
+						No agents found. Please use the menu on the left to create a new agent.
+					</div>
+				</template>
 				<template #loading>Loading agent data. Please wait.</template>
 
 				<!-- Name -->
@@ -84,7 +86,7 @@
 								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
 								:aria-label="`Edit ${data.resource.name}`"
 							>
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>
@@ -109,7 +111,7 @@
 							:aria-label="`Delete ${data.resource.name}`"
 							@click="agentToDelete = data.resource"
 						>
-							<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 						</Button>
 					</template>
 				</Column>

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -81,13 +81,16 @@
 				>
 					<template #body="{ data }">
 						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
-								:aria-label="`Edit ${data.resource.name}`"
-							>
-								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
+							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+								<Button
+									link
+									:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
+									:aria-label="`Edit ${data.resource.name}`"
+								>
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
+								</Button>
+								<template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
+							</VTooltip>
 						</NuxtLink>
 					</template>
 				</Column>
@@ -105,14 +108,17 @@
 					}"
 				>
 					<template #body="{ data }">
-						<Button
-							link
-							:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-							:aria-label="`Delete ${data.resource.name}`"
-							@click="agentToDelete = data.resource"
-						>
-							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
-						</Button>
+						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
+								:aria-label="`Delete ${data.resource.name}`"
+								@click="agentToDelete = data.resource"
+							>
+								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
+							</Button>
+							<template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
+						</VTooltip>
 					</template>
 				</Column>
 			</DataTable>

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<h2 class="page-header">All Agents</h2>
 		<div class="page-subheader">View your publicly accessible agents.</div>
 

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -6,7 +6,7 @@
 		<div :class="{ 'grid--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="grid__loading-overlay">
+				<div class="grid__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -15,8 +15,10 @@
 			<!-- Table -->
 			<DataTable :value="agents" striped-rows scrollable table-style="max-width: 100%" size="small">
 				<template #empty>
-					No agents found. Please use the menu on the left to create a new agent.</template
-				>
+					<div role="alert" aria-live="polite">
+						No agents found. Please use the menu on the left to create a new agent.
+					</div>
+				</template>
 				<template #loading>Loading agent data. Please wait.</template>
 
 				<!-- Name -->
@@ -84,7 +86,7 @@
 								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
 								:aria-label="`Edit ${data.resource.name}`"
 							>
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>
@@ -109,7 +111,7 @@
 							:aria-label="`Delete ${data.resource.name}`"
 							@click="agentToDelete = data.resource"
 						>
-							<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 						</Button>
 					</template>
 				</Column>

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<h2 class="page-header">All Agents</h2>
 		<div class="page-subheader">View your publicly accessible agents.</div>
 
@@ -80,7 +80,7 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button">
+						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
 							<Button
 								link
 								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
@@ -119,14 +119,14 @@
 		</div>
 
 		<!-- Delete agent dialog -->
-		<Dialog :visible="agentToDelete !== null" modal header="Delete Agent" :closable="false">
+		<Dialog :visible="agentToDelete !== null" modal v-focustrap header="Delete Agent" :closable="false">
 			<p>Do you want to delete the agent "{{ agentToDelete.name }}" ?</p>
 			<template #footer>
 				<Button label="Cancel" text @click="agentToDelete = null" />
-				<Button label="Delete" severity="danger" @click="handleDeleteAgent" />
+				<Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
 			</template>
 		</Dialog>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/auth/index.vue
+++ b/src/ui/ManagementPortal/pages/auth/index.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="login-page">
 		<div class="login-container">
-			<img :src="$appConfigStore.logoUrl" class="login__logo" alt="Logo" />
+			<img :src="$appConfigStore.logoUrl" class="login__logo" :alt="$appConfigStore.logoText || 'Company Logo'" />
 			<Button icon="pi pi-microsoft" label="Sign in" size="large" @click="signIn"></Button>
-			<div v-if="$route.query.message" class="login__message">{{ $route.query.message }}</div>
+			<div v-if="$route.query.message" class="login__message" role="alert" aria-live="polite">{{ $route.query.message }}</div>
 		</div>
 	</div>
 </template>

--- a/src/ui/ManagementPortal/pages/branding.vue
+++ b/src/ui/ManagementPortal/pages/branding.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<template v-if="loading">
-			<div class="grid__loading-overlay">
+			<div class="grid__loading-overlay" role="status" aria-live="polite">
 				<LoadingGrid />
 				<div>{{ loadingStatusText }}</div>
 			</div>
@@ -11,7 +11,7 @@
 			<p>Customize the look and feel of your UI.</p>
 			<div style="display: flex; flex-direction: row; align-items: center; gap: 0.5rem">
 				<p>Show contrast information</p>
-				<InputSwitch v-model="showContrastInfo" />
+				<InputSwitch v-model="showContrastInfo" aria-label="Toggle to show or hide contrast information" />
 			</div>
 		</div>
 		<div class="steps">
@@ -50,7 +50,11 @@
 					:style="{ backgroundColor: getBrandingValue('FoundationaLLM:Branding:PrimaryColor') }"
 					class="logo-preview"
 				>
-					<img :src="$filters.publicDirectory(getBrandingValue(key))" class="logo-image" />
+					<img 
+						:src="$filters.publicDirectory(getBrandingValue(key))"
+						alt="Logo Preview"
+						class="logo-image" 
+					/>
 				</div>
 			</div>
 			<div class="divider" />
@@ -175,7 +179,11 @@
 					severity="secondary"
 					@click="cancelBrandingChanges"
 				/>
-				<Button label="Set Default" @click="setDefaultBranding" />
+				<Button
+					label="Set Default"
+					aria-label="Reset branding values to their default settings"
+					@click="setDefaultBranding"
+				/>
 				<Button label="Save" severity="primary" @click="saveBranding" />
 			</div>
 		</div>

--- a/src/ui/ManagementPortal/pages/branding.vue
+++ b/src/ui/ManagementPortal/pages/branding.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<template v-if="loading">
 			<div class="grid__loading-overlay" role="status" aria-live="polite">
 				<LoadingGrid />
@@ -21,6 +21,7 @@
 				<InputSwitch
 					v-if="key === 'FoundationaLLM:Branding:KioskMode'"
 					v-model:modelValue="kioskMode"
+					:aria-labelledby="key.split(':').pop()"
 					@change="updateBrandingValue(key, JSON.stringify(kioskMode))"
 				/>
 				<CustomQuillEditor
@@ -30,6 +31,7 @@
 						key === 'FoundationaLLM:Branding:DefaultAgentWelcomeMessage'
 					"
 					:id="key.split(':').pop()"
+					:aria-labelledby="key.split(':').pop()"
 					:initial-content="JSON.parse(JSON.stringify(getBrandingValue(key)))"
 					@content-update="updateHtmlText(key, $event)"
 				/>
@@ -177,17 +179,41 @@
 					:disabled="JSON.stringify(branding) === JSON.stringify(brandingOriginal)"
 					label="Reset"
 					severity="secondary"
-					@click="cancelBrandingChanges"
+					@click="resetBrandingDialog = true"
 				/>
 				<Button
 					label="Set Default"
 					aria-label="Reset branding values to their default settings"
-					@click="setDefaultBranding"
+					@click="setBrandingDefaultDialog = true"
 				/>
 				<Button label="Save" severity="primary" @click="saveBranding" />
 			</div>
+			<Dialog
+				:visible="resetBrandingDialog"
+				modal
+				header="Reset Branding"
+				:closable="false"
+			>
+				<p>Are you sure you want to reset all branding values to their previous values?</p>
+				<template #footer>
+					<Button label="Cancel" text @click="resetBrandingDialog = false" />
+					<Button label="Reset" severity="danger" autofocus @click="cancelBrandingChanges" />
+				</template>
+			</Dialog>
+			<Dialog
+				:visible="setBrandingDefaultDialog"
+				modal
+				header="Set Default Branding"
+				:closable="false"
+			>
+				<p>Are you sure you want to reset all branding values to their default settings?</p>
+				<template #footer>
+					<Button label="Cancel" text @click="setBrandingDefaultDialog = false" />
+					<Button label="Set Default" severity="danger" autofocus @click="setDefaultBranding" />
+				</template>
+			</Dialog>
 		</div>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">
@@ -412,6 +438,8 @@ export default {
 			showQuillrawHTMLDialog: false,
 			loading: true,
 			loadingStatusText: 'Retrieving data...' as string,
+			resetBrandingDialog: false,
+			setBrandingDefaultDialog: false,
 		};
 	},
 
@@ -570,10 +598,12 @@ export default {
 					brand.resource.value = defaultBrand.value;
 				}
 			});
+			this.setBrandingDefaultDialog = false;
 		},
 
 		cancelBrandingChanges() {
 			this.branding = JSON.parse(JSON.stringify(this.brandingOriginal));
+			this.resetBrandingDialog = false;
 		},
 
 		saveBranding() {

--- a/src/ui/ManagementPortal/pages/branding.vue
+++ b/src/ui/ManagementPortal/pages/branding.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<template v-if="loading">
 			<div class="grid__loading-overlay" role="status" aria-live="polite">
 				<LoadingGrid />

--- a/src/ui/ManagementPortal/pages/data-sources/create.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<div style="display: flex">
 			<!-- Title -->
 			<div style="flex: 1">

--- a/src/ui/ManagementPortal/pages/data-sources/create.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/create.vue
@@ -24,7 +24,7 @@
 		<div class="steps" :class="{ 'steps--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="steps__loading-overlay">
+				<div class="steps__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -51,6 +51,7 @@
 						v-if="nameValidationStatus === 'valid'"
 						class="icon valid"
 						title="Name is available"
+						aria-label="Name is available"
 					>
 						✔️
 					</span>
@@ -58,6 +59,7 @@
 						v-else-if="nameValidationStatus === 'invalid'"
 						:title="validationMessage"
 						class="icon invalid"
+						:aria-label="validationMessage"
 					>
 						❌
 					</span>

--- a/src/ui/ManagementPortal/pages/data-sources/create.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<div style="display: flex">
 			<!-- Title -->
 			<div style="flex: 1">
@@ -175,7 +175,8 @@
 						v-create-chip-on-blur:folders
 						class="w-100"
 						separator=","
-						aria-labelledby="aria-folders aria-folders-desc"
+						aria-labelledby="aria-folders"
+						aria-describedby="aria-folders-desc"
 						:pt="{ input: { 'aria-labelledby': 'aria-folders aria-folders-desc' } }"
 					/>
 				</div>
@@ -390,7 +391,7 @@
 				/>
 			</div>
 		</div>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/data-sources/index.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<div style="display: flex">
 			<div style="flex: 1">
 				<h2 class="page-header">Data Sources</h2>

--- a/src/ui/ManagementPortal/pages/data-sources/index.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<div style="display: flex">
 			<div style="flex: 1">
 				<h2 class="page-header">Data Sources</h2>
@@ -7,7 +7,7 @@
 			</div>
 
 			<div style="display: flex; align-items: center">
-				<NuxtLink to="/data-sources/create">
+				<NuxtLink to="/data-sources/create" tabindex="-1">
 					<Button aria-label="Create data source">
 						<i class="pi pi-plus" style="color: var(--text-primary); margin-right: 8px"></i>
 						Create Data Source
@@ -82,7 +82,7 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/data-sources/edit/' + data.resource.name" class="table__button">
+						<NuxtLink :to="'/data-sources/edit/' + data.resource.name" class="table__button" tabindex="-1">
 							<Button link :aria-label="`Edit ${data.resource.name}`">
 								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
@@ -119,16 +119,17 @@
 		<Dialog
 			:visible="dataSourceToDelete !== null"
 			modal
+			v-focustrap
 			header="Delete Data Source"
 			:closable="false"
 		>
 			<p>Do you want to delete the data source "{{ dataSourceToDelete.name }}" ?</p>
 			<template #footer>
 				<Button label="Cancel" text @click="dataSourceToDelete = null" />
-				<Button label="Delete" severity="danger" @click="handleDeleteDataSource" />
+				<Button label="Delete" severity="danger" autofocus @click="handleDeleteDataSource" />
 			</template>
 		</Dialog>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/data-sources/index.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/index.vue
@@ -83,9 +83,12 @@
 				>
 					<template #body="{ data }">
 						<NuxtLink :to="'/data-sources/edit/' + data.resource.name" class="table__button" tabindex="-1">
-							<Button link :aria-label="`Edit ${data.resource.name}`">
-								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
+							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+								<Button link :aria-label="`Edit ${data.resource.name}`">
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
+								</Button>
+								<template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
+							</VTooltip>
 						</NuxtLink>
 					</template>
 				</Column>
@@ -103,13 +106,16 @@
 					}"
 				>
 					<template #body="{ data }">
-						<Button
-							link
-							:aria-label="`Delete ${data.resource.name}`"
-							@click="dataSourceToDelete = data.resource"
-						>
-							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
-						</Button>
+						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+							<Button
+								link
+								:aria-label="`Delete ${data.resource.name}`"
+								@click="dataSourceToDelete = data.resource"
+							>
+								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
+							</Button>
+							<template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
+						</VTooltip>
 					</template>
 				</Column>
 			</DataTable>

--- a/src/ui/ManagementPortal/pages/data-sources/index.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/index.vue
@@ -19,7 +19,7 @@
 		<div :class="{ 'grid--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="grid__loading-overlay">
+				<div class="grid__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -33,7 +33,11 @@
 				table-style="max-width: 100%"
 				size="small"
 			>
-				<template #empty> No data sources found. </template>
+				<template #empty>
+					<div role="alert" aria-live="polite">
+						No data sources found.
+					</div>
+				</template>
 
 				<template #loading>Loading data sources. Please wait.</template>
 
@@ -80,7 +84,7 @@
 					<template #body="{ data }">
 						<NuxtLink :to="'/data-sources/edit/' + data.resource.name" class="table__button">
 							<Button link :aria-label="`Edit ${data.resource.name}`">
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+								<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>
@@ -104,7 +108,7 @@
 							:aria-label="`Delete ${data.resource.name}`"
 							@click="dataSourceToDelete = data.resource"
 						>
-							<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 						</Button>
 					</template>
 				</Column>

--- a/src/ui/ManagementPortal/pages/index/index.vue
+++ b/src/ui/ManagementPortal/pages/index/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main id="main-content">
 		<h2 class="page-header">Welcome to the Management Portal</h2>
 		<div class="page-subheader">Browse the available configuration options in the sidebar.</div>
 
@@ -11,7 +11,7 @@
 				link="/info"
 			/>
 		</div> -->
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/info.vue
+++ b/src/ui/ManagementPortal/pages/info.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<h1>Deployment Information</h1>
 		<p>This page provides information about the FoundationaLLM deployment.</p>
 		<p><strong>Instance ID:</strong> {{ $appConfigStore.instanceId }}</p>

--- a/src/ui/ManagementPortal/pages/info.vue
+++ b/src/ui/ManagementPortal/pages/info.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<h1>Deployment Information</h1>
 		<p>This page provides information about the FoundationaLLM deployment.</p>
 		<p><strong>Instance ID:</strong> {{ $appConfigStore.instanceId }}</p>
@@ -26,7 +26,7 @@
 				:description="api.description"
 			/>
 		</div>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -16,7 +16,7 @@
 		<div class="steps" :class="{ 'steps--loading': loading }">
 			<!-- Loading overlay -->
 			<template v-if="loading">
-				<div class="steps__loading-overlay">
+				<div class="steps__loading-overlay" role="status" aria-live="polite">
 					<LoadingGrid />
 					<div>{{ loadingStatusText }}</div>
 				</div>
@@ -106,7 +106,12 @@
 						class="w-50"
 						aria-labelledby="aria-principal-id"
 					/>
-					<Button label="Browse" severity="primary" @click="selectPrincipalDialogOpen = true" />
+					<Button 
+						label="Browse"
+						aria-label="Browse for principals"
+						severity="primary"
+						@click="selectPrincipalDialogOpen = true"
+					/>
 				</div>
 
 				<!-- Browse principals dialog -->

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<!-- Header -->
 		<template v-if="!headless">
 			<h2 class="page-header">{{ editId ? 'Edit Role Assignment' : 'Create Role Assignment' }}</h2>

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<!-- Header -->
 		<template v-if="!headless">
 			<h2 class="page-header">{{ editId ? 'Edit Role Assignment' : 'Create Role Assignment' }}</h2>
@@ -125,6 +125,7 @@
 					<div id="aria-principal-search-type" class="mb-2">Search type</div>
 					<Dropdown
 						v-model="principalSearchType"
+						id="principal-search-type"
 						:options="principalTypeOptions"
 						placeholder="--Select--"
 						class="mb-2 w-100"
@@ -193,7 +194,7 @@
 				/>
 			</div>
 		</div>
-	</div>
+	</main>
 </template>
 
 <script lang="ts">
@@ -265,6 +266,14 @@ export default {
 	watch: {
 		principalSearchType() {
 			this.dialogPrincipal = null;
+		},
+		selectPrincipalDialogOpen(value) {
+			if (value) {
+				this.$nextTick(() => {
+					const input = document.querySelector('#principal-search-type span');
+					input?.focus();
+				});
+			}
 		},
 	},
 

--- a/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<main>
 		<div style="display: flex">
 			<div style="flex: 1">
 				<h2 class="page-header">Role Assignments</h2>
@@ -7,8 +7,8 @@
 			</div>
 
 			<div style="display: flex; align-items: center">
-				<NuxtLink to="/security/role-assignments/create">
-					<Button>
+				<NuxtLink to="/security/role-assignments/create" tabindex="-1">
+					<Button aria-label="Create Role Assignment">
 						<i class="pi pi-plus" style="color: var(--text-primary); margin-right: 8px" aria-hidden="true"></i>
 						Create Role Assignment
 					</Button>
@@ -17,7 +17,7 @@
 		</div>
 
 		<RoleAssignmentsTable />
-	</div>
+	</main>
 </template>
 
 <script lang="ts">

--- a/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
@@ -9,7 +9,7 @@
 			<div style="display: flex; align-items: center">
 				<NuxtLink to="/security/role-assignments/create">
 					<Button>
-						<i class="pi pi-plus" style="color: var(--text-primary); margin-right: 8px"></i>
+						<i class="pi pi-plus" style="color: var(--text-primary); margin-right: 8px" aria-hidden="true"></i>
 						Create Role Assignment
 					</Button>
 				</NuxtLink>

--- a/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<main>
+	<main id="main-content">
 		<div style="display: flex">
 			<div style="flex: 1">
 				<h2 class="page-header">Role Assignments</h2>


### PR DESCRIPTION
# Management Portal VPAT Accessibility Changes

## The issue or feature being addressed

Accessibility improvements for Management Portal based on VPAT requirements.

## Details on the issue fix or feature implementation

- Ensured logical focus navigation for custom components (e.g., Quill Editor, modals, dialogs).
- Prevented focus from reverting to the Quill Editor unintentionally.
- Implemented custom @keydown handlers for seamless focus shifts
- Applied ARIA attributes (e.g., aria-label, aria-labelledby) and semantic roles to define interactive elements' purposes.
- Verified no complex gestures are required for functionality (WCAG 2.5.1).
- Ensured pointer cancellation for draggable elements (releasing outside a target reverses the action).
- Maintained logical and expected focus navigation (WCAG 2.4.3), especially in dialogs and editors.
- Enhanced focus indicators for interactive elements (e.g., buttons, links) to ensure state visibility.
- Ensured all visible labels match programmatically determined names for interactive elements (WCAG 2.5.3).
- Added roles (region, status, alert, etc.) and dynamic ARIA live regions (polite, assertive) for dynamic content updates.
- Introduced a "Skip to Main Content" button for quick access to the primary content.
- Enabled interactive elements to respond to both Enter and Space.
- Prevented focus traps within certain components, allowing smooth navigation.
- Added role="status" and aria-live="polite" for spinners and loading messages.
- Improved Sidebar navigation with semantic h3 headings and ARIA roles.
- Refined focusable child elements in CreateAgentStepItem and CustomQuillEditor.
- Implemented accessible tooltips using role="tooltip" via VTooltip.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable