### PR TITLE
(0.9.1-alpha1) Fix issue where info tooltip not accessible to screen readers

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -6,7 +6,7 @@
 					<i
 						class="pi pi-info-circle"
 						tabindex="0"
-						aria-label="info icon"
+						aria-hidden
 						@keydown.esc="hideAllPoppers"
 					></i>
 					<template #popper>
@@ -278,6 +278,7 @@
 			>
 				<p id="chat-input-label" class="sr-only">
 					The agent can make mistakes. Please check important information carefully.
+					Use Shift+Enter to add a new line.
 				</p>
 				<textarea
 					id="chat-input"


### PR DESCRIPTION
# (0.9.1-alpha1) Fix issue where info tooltip not accessible to screen readers

## The issue or feature being addressed

Cherry-pick for #2053 

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable