### PR TITLE
Update RBAC display name for unresolved identities and groups

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -30,6 +30,10 @@ Agent tools are now an array of AgentTool objects rather than a dictionary.
 
 When defining tools for an agent, each tool now requires a `package_name` property. This property is used to identify the package that contains the tool's implementation. If the tool is internal, the `package_name` should be set to `FoundationaLLM`, if the tool is external, the `package_name` should be set to the name of the external package.
 
+#### Security-related changes
+
+The **Authorization API** now requires the ability to write to the Key Vault account contained within the auth resource group. Currently, the Authorization APIs managed identity is assigned to the `Key Vault Secrets User` role on the Key Vault account. This role assignment must be updated to include the `Key Vault Secrets Officer` role in addition to the user role.
+
 #### Renamed classes
 
 The following classes have been renamed:
@@ -53,7 +57,6 @@ The `/instances/{instanceId}/sessions/{sessionId}/message/{id}/rate` endpoint ha
 
 > [!NOTE]
 > Please note that both properties are nullable. Set them to null to clear out the rating and comments.
-
 
 ## Starting with 0.8.4
 

--- a/src/dotnet/Common/Services/Security/MicrosoftGraphIdentityManagementService.cs
+++ b/src/dotnet/Common/Services/Security/MicrosoftGraphIdentityManagementService.cs
@@ -133,6 +133,20 @@ namespace FoundationaLLM.Common.Services.Security
                 });
             }
 
+            // Add to the results an `ObjectQueryResult` object for any `parameters.Ids` that are not in the results.
+            foreach (var id in parameters.Ids)
+            {
+                if (results.All(x => x.Id != id))
+                {
+                    results.Add(new ObjectQueryResult
+                    {
+                        Id = id,
+                        DisplayName = id,
+                        ObjectType = ObjectTypes.Other
+                    });
+                }
+            }
+
             return results;
         }
 

--- a/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
+++ b/src/ui/ManagementPortal/components/RoleAssignmentsTable.vue
@@ -138,7 +138,7 @@
 				<template #body="{ data }">
 					<Button
 						link
-						:aria-label="`Delete role assignment for ${data.principal.display_name}`"
+						:aria-label="`Delete role assignment ${data.principal?.display_name? 'for ' + data.principal?.display_name : ''}`"
 						@click="roleAssignmentToDelete = data"
 					>
 						<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>


### PR DESCRIPTION
# Update RBAC display name for unresolved identities and groups

## The issue or feature being addressed

When using virtual security groups or referencing users and roles that no longer exist, the identity information returned by Microsoft Graph is null. This causes an error when displaying the RBAC list within the Management Portal, plus one cannot tell which identity is listed within the RBAC list.

## Details on the issue fix or feature implementation

This PR ensures that unmatched Entra ID objects are returned when calling `GetObjectsByIds`, setting the display name to the object ID.

Also updated the breaking changes document to document a change in RBAC permissions required on the auth Key Vault account.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
