### PR TITLE
Add configuration for PollingHttpClient polling interval

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -19,6 +19,7 @@ The following new App Configuration settings are required:
 |`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Storage:AuthenticationType` | `-` | `-` |
 |`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:RootStorageContainer` | `-` | `-` |
 |`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:ExternalModules:Modules` | `-` | `-` |
+|`FoundationaLLM:APIEndpoints:LangChainAPI:Configuration:PollingIntervalSeconds` | `10` | The interval in seconds at which the LangChain API will be polled for status. |
 |`FoundationaLLM:UserPortal:Configuration:ShowMessageRating` | `true` | If `true`, rating options on agent messages will appear. |
 |`FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup` | `false` | If `true`, the last conversation will be displayed when the user logs in. Otherwise, a new conversation placeholder appears on page load. |
 |`FoundationaLLM:UserPortal:Configuration:ShowMessageTokens` | `true` | If `true`, the number of consumed tokens on agent and user messages will appear. |

--- a/src/dotnet/Orchestration/Models/ConfigurationOptions/LangChainServiceSettings.cs
+++ b/src/dotnet/Orchestration/Models/ConfigurationOptions/LangChainServiceSettings.cs
@@ -5,6 +5,10 @@
     /// </summary>
     public class LangChainServiceSettings
     {
-        
+        /// <summary>
+        /// The polling interval in seconds to check the status of the LangChain service.
+        /// </summary>
+        public int PollingIntervalSeconds { get; set; } = 10;
+
     }
 }

--- a/src/dotnet/Orchestration/Services/LangChainService.cs
+++ b/src/dotnet/Orchestration/Services/LangChainService.cs
@@ -128,7 +128,7 @@ namespace FoundationaLLM.Orchestration.Core.Services
                 client,
                 request,
                 $"instances/{instanceId}/async-completions",
-                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(_settings.PollingIntervalSeconds),
                 client.Timeout.Subtract(TimeSpan.FromSeconds(1)),
                 _logger);
         }


### PR DESCRIPTION
# Add configuration for PollingHttpClient polling interval

## The issue or feature being addressed

The `PollingHttpClient` uses a fixed 10 second polling interval which prevents the completion of very short requests.

## Details on the issue fix or feature implementation

Add a configuration entry to control the size of the polling interval.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
