### PR TITLE
Auth and ratings improvements

### DIFF
--- a/src/dotnet/Core/Interfaces/ICoreService.cs
+++ b/src/dotnet/Core/Interfaces/ICoreService.cs
@@ -145,7 +145,7 @@ public interface ICoreService
     /// <param name="id">The message id to rate.</param>
     /// <param name="sessionId">The session id to which the message belongs.</param>
     /// <param name="rating">The rating and optional comments to assign to the message.</param>
-    Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating);
+    Task RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating);
 
     /// <summary>
     /// Returns the completion prompt for a given session and completion prompt id.

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -661,12 +661,12 @@ public partial class CoreService(
     }
 
     /// <inheritdoc/>
-    public async Task<Message> RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating)
+    public async Task RateMessageAsync(string instanceId, string id, string sessionId, MessageRatingRequest rating)
     {
         ArgumentNullException.ThrowIfNull(id);
         ArgumentNullException.ThrowIfNull(sessionId);
 
-        return await _cosmosDBService.PatchSessionsItemPropertiesAsync<Message>(
+        await _cosmosDBService.PatchSessionsItemPropertiesAsync<Message>(
             id,
             sessionId,
             new Dictionary<string, object?>

--- a/src/dotnet/CoreAPI/Controllers/SessionsController.cs
+++ b/src/dotnet/CoreAPI/Controllers/SessionsController.cs
@@ -59,7 +59,7 @@ namespace FoundationaLLM.Core.API.Controllers
         /// <param name="sessionId">The id of the session to which the message belongs.</param>
         /// <param name="ratingRequest">The rating and optional comments to assign to the message.</param>
         [HttpPost("{sessionId}/message/{messageId}/rate", Name = "RateMessage")]
-        public async Task<Message> RateMessage(string instanceId, string messageId, string sessionId, [FromBody] MessageRatingRequest ratingRequest) =>
+        public async Task RateMessage(string instanceId, string messageId, string sessionId, [FromBody] MessageRatingRequest ratingRequest) =>
             await _coreService.RateMessageAsync(instanceId, messageId, sessionId, ratingRequest);
 
         /// <summary>

--- a/src/dotnet/CoreClient/Clients/RESTClients/SessionRESTClient.cs
+++ b/src/dotnet/CoreClient/Clients/RESTClients/SessionRESTClient.cs
@@ -127,7 +127,7 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
         }
 
         /// <inheritdoc/>
-        public async Task<Message> RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating)
+        public async Task RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating)
         {
             if (string.IsNullOrWhiteSpace(sessionId))
             {
@@ -149,10 +149,6 @@ namespace FoundationaLLM.Client.Core.Clients.RESTClients
             {
                 throw new Exception($"Failed to rate message. Status code: {responseMessage.StatusCode}. Reason: {responseMessage.ReasonPhrase}");
             }
-
-            var responseContent = await responseMessage.Content.ReadAsStringAsync();
-            var message = JsonSerializer.Deserialize<Message>(responseContent, SerializerOptions);
-            return message ?? throw new InvalidOperationException("The returned Message is invalid.");
         }
 
         /// <inheritdoc/>

--- a/src/dotnet/CoreClient/CoreClient.cs
+++ b/src/dotnet/CoreClient/CoreClient.cs
@@ -63,7 +63,7 @@ namespace FoundationaLLM.Client.Core
             return sessionId;
         }
 
-        public async Task<Message> RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating)
+        public async Task RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating)
         {
             if (string.IsNullOrWhiteSpace(sessionId))
                 throw new ArgumentException("A session ID must be provided when rating a message.");
@@ -71,8 +71,7 @@ namespace FoundationaLLM.Client.Core
                 throw new ArgumentException("A message ID must be provided when rating a message.");
             if (rating == null)
                 throw new ArgumentException("A rating must be provided when rating a message.");
-            var message = await _coreRestClient.Sessions.RateMessageAsync(sessionId, messageId, rating);
-            return message;
+            await _coreRestClient.Sessions.RateMessageAsync(sessionId, messageId, rating);
         }
 
         /// <inheritdoc/>

--- a/src/dotnet/CoreClient/Interfaces/ICoreClient.cs
+++ b/src/dotnet/CoreClient/Interfaces/ICoreClient.cs
@@ -102,8 +102,7 @@ namespace FoundationaLLM.Client.Core.Interfaces
         /// <param name="sessionId">The chat session ID that contains the message to rate.</param>
         /// <param name="messageId">The ID of the message to rate.</param>
         /// <param name="rating">The rating and optional comments to assign to the message.</param>
-        /// <returns>Returns the Message object, including its updated rating.</returns>
-        Task<Message> RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating);
+        Task RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating);
 
         /// <summary>
         /// Retrieves agents available to the user for orchestration and session-based requests.

--- a/src/dotnet/CoreClient/Interfaces/ISessionRESTClient.cs
+++ b/src/dotnet/CoreClient/Interfaces/ISessionRESTClient.cs
@@ -19,8 +19,7 @@ namespace FoundationaLLM.Client.Core.Interfaces
         /// <param name="sessionId">The chat session ID that contains the message to rate.</param>
         /// <param name="messageId">The ID of the message to rate.</param>
         /// <param name="rating">The rating and optional comments to assign to the message.</param>
-        /// <returns>Returns the Message object, including its updated rating.</returns>
-        Task<Message> RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating);
+        Task RateMessageAsync(string sessionId, string messageId, MessageRatingRequest rating);
 
         /// <summary>
         /// Creates a new session with the specified name.

--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -690,6 +690,15 @@ export default {
 		);
 	},
 
+	async deleteRoleAssignment(roleAssignmentId): void {
+		return await this.fetch(
+			`/instances/${this.instanceId}/providers/FoundationaLLM.Authorization/roleAssignments/${roleAssignmentId}?api-version=${this.apiVersion}`,
+			{
+				method: 'DELETE',
+			},
+		);
+	},
+
 	/*
 		Role Definitions
 	 */
@@ -703,15 +712,6 @@ export default {
 		return (await this.fetch(
 			`/instances/${this.instanceId}/providers/FoundationaLLM.Authorization/roleDefinitions/${roleAssignmentId}?api-version=${this.apiVersion}`,
 		)) as RoleAssignment[];
-	},
-
-	async deleteRoleAssignment(roleAssignmentId): void {
-		return await this.fetch(
-			`/instances/${this.instanceId}/providers/FoundationaLLM.Authorization/roleDefinitions/${roleAssignmentId}?api-version=${this.apiVersion}`,
-			{
-				method: 'DELETE',
-			},
-		);
 	},
 
 	/*

--- a/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
+++ b/src/ui/ManagementPortal/pages/security/role-assignments/create.vue
@@ -59,12 +59,19 @@
 				<!-- Type -->
 				<div id="aria-principal-type" class="mb-2">Principal Type:</div>
 				<div style="display: flex; gap: 16px">
-					<InputText
+					<!-- <InputText
 						v-model="principal.object_type"
 						readonly
 						placeholder="Browse for selection"
 						type="text"
 						class="w-50"
+						aria-labelledby="aria-principal-type"
+					/> -->
+					<Dropdown
+						v-model="principal.object_type"
+						:options="principalTypeOptions"
+						placeholder="--Select--"
+						class="mb-2 w-100"
 						aria-labelledby="aria-principal-type"
 					/>
 				</div>
@@ -100,7 +107,6 @@
 				<div style="display: flex; gap: 16px">
 					<InputText
 						v-model="roleAssignment.principal_id"
-						readonly
 						placeholder="Browse for selection"
 						type="text"
 						class="w-50"
@@ -384,6 +390,14 @@ export default {
 				errors.push('Please specify a role.');
 			}
 
+			if (!this.roleAssignment.principal_type) {
+				if (this.principal.object_type) {
+					this.roleAssignment.principal_type = this.principal.object_type;
+				} else {
+					errors.push('Please specify a principal type.');
+				}
+			}
+
 			if (errors.length > 0) {
 				throw errors.join('\n');
 			}
@@ -392,6 +406,7 @@ export default {
 			let successMessage = null as null | string;
 			try {
 				this.loadingStatusText = 'Saving role assignment...';
+
 				await api.createRoleAssignment({
 					...this.roleAssignment,
 					name: uuidv4(),

--- a/tests/dotnet/Core.Client.Tests/CoreClientTests.cs
+++ b/tests/dotnet/Core.Client.Tests/CoreClientTests.cs
@@ -37,7 +37,7 @@ namespace FoundationaLLM.Client.Core.Tests
         }
 
         [Fact]
-        public async Task RateMessageAsync_ShouldReturnMessage_WhenSuccessful()
+        public async Task RateMessageAsync_ShouldSucceed()
         {
             // Arrange
             var sessionId = "test-session-id";
@@ -47,26 +47,11 @@ namespace FoundationaLLM.Client.Core.Tests
                 Rating = true,
                 Comments = "Great response!"
             };
-            var expectedMessage = new Message
-            {
-                Id = messageId,
-                RatingComments = "This is a test message.",
-                Rating = ratingRequest.Rating
-            };
-
-            _coreRestClient.Sessions
-                .RateMessageAsync(sessionId, messageId, ratingRequest)
-                .Returns(Task.FromResult(expectedMessage));
 
             // Act
-            var result = await _coreClient.RateMessageAsync(sessionId, messageId, ratingRequest);
+            await _coreClient.RateMessageAsync(sessionId, messageId, ratingRequest);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedMessage.Id, result.Id);
-            Assert.Equal(expectedMessage.RatingComments, result.RatingComments);
-            Assert.Equal(expectedMessage.Rating, result.Rating);
-
             await _coreRestClient.Sessions.Received(1).RateMessageAsync(sessionId, messageId, ratingRequest);
         }
 


### PR DESCRIPTION
# Auth and ratings improvements

## The issue or feature being addressed

- No longer return an entire `Message` object when rating a message. This helps prevent unnecessary data being sent from the Core API
- Fix the inability to delete a role assignment in the Management Portal
- Enable manually selecting a principal type and manually entering a principal ID. This is useful when needing to assign a principal that does not exist in Entra ID, such as an agent's virtual security group

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
