### PR TITLE
Adjust Azure.OpenAI package version for Assistants API support

### DIFF
--- a/src/dotnet/AzureOpenAI/AzureOpenAI.csproj
+++ b/src/dotnet/AzureOpenAI/AzureOpenAI.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/dotnet/Core/Core.csproj
+++ b/src/dotnet/Core/Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
 	<ItemGroup>
-		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />

--- a/src/dotnet/CoreWorker/CoreWorker.csproj
+++ b/src/dotnet/CoreWorker/CoreWorker.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.1.0" />

--- a/src/dotnet/Gateway/Gateway.csproj
+++ b/src/dotnet/Gateway/Gateway.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
# Adjust Azure.OpenAI package version for Assistants API support

## Details on the issue fix or feature implementation

The GA release of Azure.OpenAI NuGet package does not contain preview bits to support the Assistants API. Need to downgrade to a pre-release version to obtain this functionality.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable