### PR TITLE
Add property to conditionally set the LangGraph recursion limit

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentWorkflows/LangGraphReactAgentWorkflow.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentWorkflows/LangGraphReactAgentWorkflow.cs
@@ -10,5 +10,12 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentWorkflows
         /// <inheritdoc/>
         [JsonIgnore]
         public override string Type => AgentWorkflowTypes.LangGraphReactAgent;
+
+        /// <summary>
+        /// When using LangGraph, the recursion limit sets the number of supersteps that the graph is allowed
+        /// to execute before it raises an error. The default value is 25. Set this value to null to use the default.
+        /// </summary>
+        [JsonPropertyName("graph_recursion_limit")]
+        public int? GraphRecursionLimit { get; set; }
     }
 }

--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -456,7 +456,11 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
             graph = create_react_agent(llm, tools=tools, state_modifier=self.prompt.prefix)
             messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
             messages.append(HumanMessage(content=request.user_prompt))
-            response = await graph.ainvoke({'messages': messages}, config={"configurable": {"original_user_prompt": request.user_prompt}})
+
+            response = await graph.ainvoke(
+                {'messages': messages}, 
+                config={"configurable": {"original_user_prompt": request.user_prompt, **({"recursion_limit": agent.workflow.graph_recursion_limit} if agent.workflow.graph_recursion_limit is not None else {})}}
+            )
             # TODO: process tool messages with analysis results AIMessage with content='' but has addition_kwargs={'tool_calls';[...]}
 
             # Get ContentArtifact items from ToolMessages

--- a/src/python/PythonSDK/foundationallm/models/agents/agent_workflows/langgraph_react_agent_workflow.py
+++ b/src/python/PythonSDK/foundationallm/models/agents/agent_workflows/langgraph_react_agent_workflow.py
@@ -1,4 +1,5 @@
-from typing import Any, Self, Literal
+from pydantic import Field
+from typing import Any, Self, Optional, Literal
 from foundationallm.langchain.exceptions import LangChainException
 from foundationallm.utils import object_utils
 from .agent_workflow_base import AgentWorkflowBase
@@ -7,7 +8,8 @@ class LangGraphReactAgentWorkflow(AgentWorkflowBase):
     """
     The configuration for a LangGraph ReAct agent workflow.
     """
-    type: Literal["langgraph-react-agent-workflow"] = "langgraph-react-agent-workflow"    
+    type: Literal["langgraph-react-agent-workflow"] = "langgraph-react-agent-workflow"
+    graph_recursion_limit: Optional[int] = Field(None, alias="graph_recursion_limit")
    
     @staticmethod
     def from_object(obj: Any) -> Self:


### PR DESCRIPTION
# Add property to conditionally set the LangGraph recursion limit

## The issue or feature being addressed

Provides a property on the `LangGraphReactAgentWorkflow` to conditionally set the a limit to the number of supersteps a graph can execute before it raises an error.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
