### PR TITLE
Add semantic search and reranker to Azure AI Search retriever

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
+++ b/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
@@ -78,7 +78,11 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
 
             endpoint = index_config.api_endpoint_configuration.url
 
-            top_n = self.top_n_override or int(index_config.indexing_profile.settings.top_n)
+            if self.use_top_n_override:
+                top_n = self.top_n_override
+            else:
+                top_n = int(index_config.indexing_profile.settings.top_n)
+
 
             search_client = SearchClient(endpoint, index_config.indexing_profile.settings.index_name, credential)
             vector_query = VectorizedQuery(vector=self.__get_embeddings(query),

--- a/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
+++ b/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
@@ -47,7 +47,10 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
     index_configurations: List[KnowledgeManagementIndexConfiguration]
     gateway_text_embedding_service: GatewayTextEmbeddingService
     search_results: Optional[VectorDocument] = [] # Tuple of document id and document
-
+    query_type: Optional[str] = "simple"
+    semantic_configuration_name: Optional[str] = None
+    top_n_override: Optional[int] = None
+    
     def __get_embeddings(self, text: str) -> List[float]:
         """
         Returns embeddings vector for a given text.
@@ -63,7 +66,7 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
         """
 
         self.search_results.clear()
-
+        
         #search each indexing profile
         for index_config in self.index_configurations:
 
@@ -75,6 +78,8 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
 
             endpoint = index_config.api_endpoint_configuration.url
 
+            top_n = self.top_n_override or int(index_config.indexing_profile.settings.top_n)
+
             search_client = SearchClient(endpoint, index_config.indexing_profile.settings.index_name, credential)
             vector_query = VectorizedQuery(vector=self.__get_embeddings(query),
                                             k_nearest_neighbors=3,
@@ -84,11 +89,12 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
                 search_text=query,
                 filter=index_config.indexing_profile.settings.filters,
                 vector_queries=[vector_query],
-                #query_type="semantic",
-                #semantic_configuration_name = "fllm",
-                top=index_config.indexing_profile.settings.top_n,
-                #select=[self.id_field_name, self.text_field_name, self.metadata_field_name]
+                query_type=self.query_type,
+                semantic_configuration_name = self.semantic_configuration_name,
+                top=index_config.indexing_profile.settings.top_n                
             )
+
+            rerank_available = False
 
             #load search results into VectorDocument objects for score processing
             for result in results:
@@ -105,16 +111,23 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
                         id=result[index_config.indexing_profile.settings.id_field_name],
                         page_content=result[index_config.indexing_profile.settings.text_field_name],
                         metadata=metadata,
-                        score=result["@search.score"]
+                        score=result["@search.score"],
+                        rerank_score=result.get("@search.rerankScore", 0.0)
                 )
+                if('@search.rerankScore' in result):                    
+                    rerank_available = True
+                    
                 document.score = result["@search.score"]
                 self.search_results.append(document)
 
         #sort search results by score
-        self.search_results.sort(key=lambda x: x.score, reverse=True)
+        if(rerank_available):
+            self.search_results.sort(key=lambda x: (x.rerank_score, x.score), reverse=True)
+        else:
+            self.search_results.sort(key=lambda x: x.score, reverse=True)
 
-        #take top n of search_results
-        self.search_results = self.search_results[:int(index_config.indexing_profile.settings.top_n)]
+        #take top n of search_results          
+        self.search_results = self.search_results[:top_n]
 
         return self.search_results
 

--- a/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
+++ b/src/python/PythonSDK/foundationallm/langchain/retrievers/azure_ai_search_service_retriever.py
@@ -91,7 +91,7 @@ class AzureAISearchServiceRetriever(BaseRetriever, ContentArtifactRetrievalBase)
                 vector_queries=[vector_query],
                 query_type=self.query_type,
                 semantic_configuration_name = self.semantic_configuration_name,
-                top=index_config.indexing_profile.settings.top_n                
+                top=top_n                
             )
 
             rerank_available = False

--- a/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
+++ b/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
@@ -1,4 +1,3 @@
-from typing import Any, List
 from langchain_core.documents import Document
 
 class VectorDocument(Document):

--- a/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
+++ b/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
@@ -5,3 +5,7 @@ class VectorDocument(Document):
 
     id : str
     score: float
+    rerank_score: float
+    
+    class Config:
+        extra = "allow"

--- a/src/python/PythonSDK/pyproject.toml
+++ b/src/python/PythonSDK/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foundationallm"
-version = "0.9.1-a2"
+version = "0.9.1a2"
 authors = [
   { name="FoundationaLLM", email="dev@foundationallm.ai" },
 ]

--- a/src/python/PythonSDK/pyproject.toml
+++ b/src/python/PythonSDK/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foundationallm"
-version = "0.9.0-rc4"
+version = "0.9.1-a2"
 authors = [
   { name="FoundationaLLM", email="dev@foundationallm.ai" },
 ]


### PR DESCRIPTION
# Add semantic search and reranker to Azure AI Search retriever

## Details on the issue fix or feature implementation

Adds query_type, semantic_configuration_name, and top_n_override as properties of the Azure AI search retriever.

Adds allow extra fields on VectorDocument so tools can add fields at run-time for further processing.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
