### PR TITLE
Python package versioning and publishing

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,10 +1,11 @@
-name: Publish NuGet Packages
+name: Publish NuGet & PyPi Packages
 
 on:
   workflow_dispatch:
 
 env:
   DOTNET_VERSION: '8.0.x'
+  PYTHON_VERSION: '3.11.x'
 
 jobs:
   build-and-publish:
@@ -27,10 +28,16 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
     - name: Run versioning script
       run: bash ./versioning.sh
       id: versioning
 
+    # .NET Build and Pack Steps
     - name: Build Common
       working-directory: ./src/dotnet/Common
       run: dotnet build --configuration Release -p:GITHUB_ACTIONS=true
@@ -63,6 +70,7 @@ jobs:
       working-directory: ./src/dotnet/ManagementClient
       run: dotnet pack --configuration Release /p:PackageVersion=${{ steps.versioning.outputs.version }} -p:GITHUB_ACTIONS=true --output ./nupkg
 
+    # .NET Publish Steps
     - name: Publish Common to NuGet
       working-directory: ./src/dotnet/Common
       run: dotnet nuget push ./nupkg/*.Common.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
@@ -78,3 +86,19 @@ jobs:
     - name: Publish ManagementClient to NuGet
       working-directory: ./src/dotnet/ManagementClient
       run: dotnet nuget push ./nupkg/*.Client.Management.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    # Python Build and Publish Steps
+    - name: Build Python Package
+      run: |
+        cd ./src/python/PythonSDK
+        python -m pip install --upgrade build
+        python -m build
+
+    - name: Publish Python Package to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        cd ./src/python/PythonSDK
+        python -m pip install --upgrade twine
+        python -m twine upload --repository-url https://upload.pypi.org/legacy/ *.tar.gz *.whl

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -95,10 +95,10 @@ jobs:
         python -m build
 
     - name: Publish Python Package to PyPI
+      working-directory: ./src/python/PythonSDK/dist
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
       run: |
-        cd ./src/python/PythonSDK
         python -m pip install --upgrade twine
         python -m twine upload --repository-url https://upload.pypi.org/legacy/ *.tar.gz *.whl

--- a/src/python/PythonSDK/pyproject.toml
+++ b/src/python/PythonSDK/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foundationallm"
-version = "0.9.1a2"
+version = "0.0.0"
 authors = [
   { name="FoundationaLLM", email="dev@foundationallm.ai" },
 ]

--- a/versioning.sh
+++ b/versioning.sh
@@ -10,13 +10,31 @@ else
   VERSION="0.0.0"
 fi
 
-# Output version for GitHub Actions or other CI systems
-echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-echo "Version: $VERSION"
+# Convert .NET versioning to Python versioning
+PYTHON_VERSION="$VERSION"
+if [[ "$VERSION" =~ ([0-9]+\.[0-9]+\.[0-9]+)-alpha([0-9]+)$ ]]; then
+  PYTHON_VERSION="${BASH_REMATCH[1]}a${BASH_REMATCH[2]}"
+elif [[ "$VERSION" =~ ([0-9]+\.[0-9]+\.[0-9]+)-beta([0-9]+)$ ]]; then
+  PYTHON_VERSION="${BASH_REMATCH[1]}b${BASH_REMATCH[2]}"
+elif [[ "$VERSION" =~ ([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+  PYTHON_VERSION="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"
+fi
 
-# Replace the version placeholders in the .csproj files
+# Output versions for GitHub Actions
+echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+echo "python_version=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+
+echo "NuGet Version: $VERSION"
+echo "Python Version: $PYTHON_VERSION"
+
+# Replace the version placeholders in the .csproj files for .NET projects
 for csproj in $(find . -name '*.csproj'); do
   sed -i "s/<Version>0.0.0<\/Version>/<Version>$VERSION<\/Version>/" "$csproj"
   sed -i "s/<FileVersion>0.0.0<\/FileVersion>/<FileVersion>${VERSION%-*}<\/FileVersion>/" "$csproj"
   sed -i "s/<AssemblyVersion>0.0.0<\/AssemblyVersion>/<AssemblyVersion>${VERSION%-*}<\/AssemblyVersion>/" "$csproj"
+done
+
+# Replace the version in pyproject.toml files for Python projects
+for toml in $(find . -name 'pyproject.toml'); do
+  sed -i "s/^version = \".*\"/version = \"$PYTHON_VERSION\"/" "$toml"
 done


### PR DESCRIPTION
# Python package versioning and publishing

## The issue or feature being addressed

Includes Python packages in the GitHub Action that versions and publishes .NET NuGet packages. This allows for automatic package versioning and deployments from release branches to keep all NuGet and PyPi packages aligned with FLLM platform build versions.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
