### PR TITLE
Constrain content artifact dialog width

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -203,7 +203,7 @@
 			modal
 			style="max-width: 85%;"
 		>
-			<p tabindex="0" style="overflow-x: scroll;">
+			<p tabindex="0" style="overflow-x: auto;">
 				<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
 			</p>
 

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -201,8 +201,9 @@
 			v-model:visible="selectedContentArtifact"
 			:header="selectedContentArtifact?.title"
 			modal
+			style="max-width: 85%;"
 		>
-			<p tabindex="0">
+			<p tabindex="0" style="overflow-x: scroll;">
 				<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
 			</p>
 


### PR DESCRIPTION
# Constrain content artifact dialog width

## The issue or feature being addressed

The modal dialog expands beyond the screen's width when the JSON content includes extremely long values, such as video URLs. This PR constrains the dialog's width to a maximum of 85% and sets the content's X overflow to display a scrollbar as necessary automatically.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
