### PR TITLE
Enable optional persistence of completion requests

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -3,7 +3,32 @@
 > [!NOTE]
 > This section is for changes that are not yet released but will affect future releases.
 
-## Starting with 0.9.1
+## Starting with 0.9.1-rc102
+
+### Configuration changes
+
+The following new App Configuration settings are required:
+
+|Name | Default value | Description |
+|--- | --- | --- |
+|`FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AccountName` | `<main_storage_account_name>` | Provides the storage account used by the Orchestration API to persist completion requests. |
+|`FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AuthenticationType` | `AzureIdentity` | Indicates that managed identity authentication should be used to access the storage account. |
+|`FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:ContainerName` | `orchestration-completion-requests` | Provides the storage container name used by the Orchestration API to persist completion requests. Should always be `orchestration-completion-requests` |
+
+### User profile changes
+
+A new flag named `persistOrchestrationCompletionRequests` is added to the user profile. This flag is used to determine whether the user's completion requests should be persisted in the storage account. The default value is `false`.
+
+Sample configuration:
+
+```json
+"flags": {
+        "oneDriveWorkSchoolEnabled": true,
+        "persistOrchestrationCompletionRequests": true
+    },
+```
+
+## Starting with 0.9.1-rc101
 
 ### Configuration changes
 

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -752,6 +752,39 @@
 		]
 	},
 	{
+		"namespace": "APIEndpoints:OrchestrationAPI:Configuration",
+		"dependency_injection_key": null,
+		"configuration_section": {
+			"description": "Configuration section used to identify the settings for storing persisted completion requests."
+		},
+		"configuration_keys": [
+			{
+				"name": "CompletionRequestsStorage:AccountName",
+				"description": "The Azure Storage account for persisted completion requests.",
+				"secret": "",
+				"value": "${env:AZURE_STORAGE_ACCOUNT_NAME}",
+				"content_type": "",
+				"first_version": "0.9.1"
+			},
+			{
+				"name": "CompletionRequestsStorage:AuthenticationType",
+				"description": "The type of authentication used to connect to the Azure Storage account. Can be one of: AzureIdentity, AccountKey, or ConnectionString.",
+				"secret": "",
+				"value": "AzureIdentity",
+				"content_type": "",
+				"first_version": "0.9.0"
+			},
+			{
+				"name": "CompletionRequestsStorage:ContainerName",
+				"description": "The name of the root container in the Azure Storage account.",
+				"secret": "",
+				"value": "orchestration-completion-requests",
+				"content_type": "",
+				"first_version": "0.9.1"
+			}
+		]
+	},
+	{
 		"namespace": "APIEndpoints:LangChainAPI:Essentials",
 		"dependency_injection_key": null,
 		"configuration_section": {

--- a/src/dotnet/Common/Constants/UserProfileFlags.cs
+++ b/src/dotnet/Common/Constants/UserProfileFlags.cs
@@ -11,10 +11,16 @@
         public const string OneDriveWorkSchoolEnabled = "oneDriveWorkSchoolEnabled";
 
         /// <summary>
+        /// Indicates whether completion requests created by the Orchestration API should be persisted or not.
+        /// </summary>
+        public const string PersistOrchestrationCompletionRequests = "persistOrchestrationCompletionRequests";
+
+        /// <summary>
         /// All user profile flags.
         /// </summary>
         public readonly static string[] All = [
-            OneDriveWorkSchoolEnabled
+            OneDriveWorkSchoolEnabled,
+            PersistOrchestrationCompletionRequests
         ];
     }
 }

--- a/src/dotnet/Common/Interfaces/IStorageService.cs
+++ b/src/dotnet/Common/Interfaces/IStorageService.cs
@@ -13,7 +13,12 @@
         /// <summary>
         /// The name of the storage account.
         /// </summary>
-        string StorageAccountName { get; }
+        string? StorageAccountName { get; }
+
+        /// <summary>
+        /// The name of the storage container.
+        /// </summary>
+        string? StorageContainerName { get; }
 
         /// <summary>
         /// Reads the binary content of a specified file from the storage.

--- a/src/dotnet/Common/Interfaces/IUserProfileService.cs
+++ b/src/dotnet/Common/Interfaces/IUserProfileService.cs
@@ -1,6 +1,6 @@
 ﻿using FoundationaLLM.Common.Models.Configuration.Users;
 
-namespace FoundationaLLM.Core.Interfaces
+namespace FoundationaLLM.Common.Interfaces
 {
     /// <summary>
     /// Provides methods for working with user profiles.

--- a/src/dotnet/Common/Models/Configuration/Storage/BlobStorageServiceSettings.cs
+++ b/src/dotnet/Common/Models/Configuration/Storage/BlobStorageServiceSettings.cs
@@ -30,5 +30,10 @@ namespace FoundationaLLM.Common.Models.Configuration.Storage
         /// This value should be set only if AuthenticationType has a value of ConnectionString.
         /// </summary>
         public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// The name of the container within the blob storage account.
+        /// </summary>
+        public string? ContainerName { get; set; }
     }
 }

--- a/src/dotnet/Common/Services/Storage/BlobStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/BlobStorageService.cs
@@ -31,11 +31,6 @@ namespace FoundationaLLM.Common.Services.Storage
     {
         private BlobServiceClient _blobServiceClient;
 
-        /// <summary>
-        /// The name of the storage account.
-        /// </summary>
-        public string StorageAccountName => _blobServiceClient.AccountName;
-
         /// <inheritdoc/>
         public async Task<BinaryData> ReadFileAsync(
             string containerName,

--- a/src/dotnet/Common/Services/Storage/NullStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/NullStorageService.cs
@@ -14,7 +14,10 @@ namespace FoundationaLLM.Common.Services.Storage
         public string? InstanceName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         /// <inheritdoc/>
-        public string StorageAccountName => throw new NotImplementedException();
+        public string? StorageAccountName => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public string? StorageContainerName => throw new NotImplementedException();
 
         /// <inheritdoc/>
         public Task DeleteFileAsync(string containerName, string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/src/dotnet/Common/Services/Storage/StorageServiceBase.cs
+++ b/src/dotnet/Common/Services/Storage/StorageServiceBase.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using System.ComponentModel;
 using FoundationaLLM.Common.Models.Configuration.Storage;
 using FoundationaLLM.Common.Constants.Authentication;
+using Azure.Storage.Blobs;
 
 namespace FoundationaLLM.Common.Services.Storage
 {
@@ -12,7 +13,10 @@ namespace FoundationaLLM.Common.Services.Storage
     /// </summary>
     public abstract class StorageServiceBase
     {
-        private readonly BlobStorageServiceSettings _settings;
+        /// <summary>
+        /// The <see cref="BlobStorageServiceSettings"/> used to configure the storage service.
+        /// </summary>
+        protected readonly BlobStorageServiceSettings _settings;
         /// <summary>
         /// The logger used for logging.
         /// </summary>
@@ -22,6 +26,14 @@ namespace FoundationaLLM.Common.Services.Storage
         /// The optional instance name of the storage service.
         /// </summary>
         public string? InstanceName { get; set; }
+
+        /// <summary>
+        /// The name of the storage account.
+        /// </summary>
+        public string? StorageAccountName => _settings.AccountName;
+
+        /// <inheritdoc/>
+        public string? StorageContainerName => _settings.ContainerName;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="StorageServiceBase"/> with the specified options and logger.

--- a/src/dotnet/Common/Services/Users/DependencyInjection.cs
+++ b/src/dotnet/Common/Services/Users/DependencyInjection.cs
@@ -1,0 +1,29 @@
+﻿using FoundationaLLM.Common.Interfaces;
+using FoundationaLLM.Common.Services.Users;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FoundationaLLM
+{
+    /// <summary>
+    /// General purpose dependency injection extensions.
+    /// </summary>
+    public static partial class DependencyInjection
+    {
+         /// <summary>
+        /// Registers the <see cref="IUserProfileService"/> implementation with the dependency injection container.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHostApplicationBuilder"/> application builder managing the dependency injection container.</param>
+        public static void AddUserProfileService(this IHostApplicationBuilder builder) =>
+            builder.Services.AddUserProfileService(builder.Configuration);
+
+        /// <summary>
+        /// Registers the <see cref="IUserProfileService"/> implementation with the dependency injection container.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> dependency injection container service collection.</param>
+        /// <param name="configuration">The <see cref="IConfigurationManager"/> application configuration manager.</param>
+        public static void AddUserProfileService(this IServiceCollection services, IConfigurationManager configuration) =>
+            services.AddScoped<IUserProfileService, UserProfileService>();
+    }
+}

--- a/src/dotnet/Common/Services/Users/UserProfileService.cs
+++ b/src/dotnet/Common/Services/Users/UserProfileService.cs
@@ -1,15 +1,14 @@
 ﻿using FoundationaLLM.Common.Interfaces;
-using FoundationaLLM.Core.Interfaces;
-using Microsoft.Extensions.Logging;
 using FoundationaLLM.Common.Models.Configuration.Users;
+using Microsoft.Extensions.Logging;
 
-namespace FoundationaLLM.Core.Services
+namespace FoundationaLLM.Common.Services.Users
 {
     /// <inheritdoc/>
     public class UserProfileService : IUserProfileService
     {
         private readonly IAzureCosmosDBService _cosmosDbService;
-        private readonly ILogger<CoreService> _logger;
+        private readonly ILogger<UserProfileService> _logger;
         private readonly ICallContext _callContext;
 
         /// <summary>
@@ -21,7 +20,7 @@ namespace FoundationaLLM.Core.Services
         /// <see cref="UserProfileService"/> type name.</param>
         /// <param name="callContext">Contains contextual data for the calling service.</param>
         public UserProfileService(IAzureCosmosDBService cosmosDbService,
-            ILogger<CoreService> logger,
+            ILogger<UserProfileService> logger,
             ICallContext callContext)
         {
             _cosmosDbService = cosmosDbService;

--- a/src/dotnet/Common/Templates/AppConfigurationKeyFilters.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeyFilters.cs
@@ -151,6 +151,12 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:APIEndpoints:OrchestrationAPI:Essentials:*";
         
         /// <summary>
+        /// Filter for the configuration section used to identify the settings for storing persisted completion requests.
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration =
+            "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:*";
+        
+        /// <summary>
         /// Filter for the configuration section used to identify the essential settings for the LangChain API.
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_LangChainAPI_Essentials =

--- a/src/dotnet/Common/Templates/AppConfigurationKeySections.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeySections.cs
@@ -151,6 +151,12 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:APIEndpoints:OrchestrationAPI:Essentials";
         
         /// <summary>
+        /// Configuration section used to identify the settings for storing persisted completion requests.
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration =
+            "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration";
+        
+        /// <summary>
         /// Configuration section used to identify the essential settings for the LangChain API.
         /// </summary>
         public const string FoundationaLLM_APIEndpoints_LangChainAPI_Essentials =

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -556,6 +556,31 @@ namespace FoundationaLLM.Common.Constants.Configuration
 
         #endregion
 
+        #region FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AccountName setting.
+        /// <para>Value description:<br/>The Azure Storage account for persisted completion requests.</para>
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration_CompletionRequestsStorage_AccountName =
+            "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AccountName";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AuthenticationType setting.
+        /// <para>Value description:<br/>The type of authentication used to connect to the Azure Storage account. Can be one of: AzureIdentity, AccountKey, or ConnectionString.</para>
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration_CompletionRequestsStorage_AuthenticationType =
+            "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AuthenticationType";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:ContainerName setting.
+        /// <para>Value description:<br/>The name of the root container in the Azure Storage account.</para>
+        /// </summary>
+        public const string FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration_CompletionRequestsStorage_ContainerName =
+            "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:ContainerName";
+
+        #endregion
+
         #region FoundationaLLM:APIEndpoints:LangChainAPI:Essentials
         
         /// <summary>

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -428,6 +428,27 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AccountName",
+            "value": "${env:AZURE_STORAGE_ACCOUNT_NAME}",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:AuthenticationType",
+            "value": "AzureIdentity",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:APIEndpoints:OrchestrationAPI:Configuration:CompletionRequestsStorage:ContainerName",
+            "value": "orchestration-completion-requests",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:APIEndpoints:LangChainAPI:Essentials:APIKey",
             "value": "{\"uri\":\"${env:AZURE_KEY_VAULT_ENDPOINT}secrets/foundationallm-apiendpoints-langchainapi-apikey\"}",
             "label": null,

--- a/src/dotnet/Core/Services/OneDriveWorkSchoolService.cs
+++ b/src/dotnet/Core/Services/OneDriveWorkSchoolService.cs
@@ -1,4 +1,5 @@
 ﻿using FoundationaLLM.Common.Constants;
+using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using FoundationaLLM.Core.Interfaces;

--- a/src/dotnet/CoreAPI/Controllers/UserProfilesController.cs
+++ b/src/dotnet/CoreAPI/Controllers/UserProfilesController.cs
@@ -1,5 +1,5 @@
 ﻿using FoundationaLLM.Common.Constants.Authorization;
-using FoundationaLLM.Core.Interfaces;
+using FoundationaLLM.Common.Interfaces;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -7,6 +7,7 @@ using FoundationaLLM.Common.Middleware;
 using FoundationaLLM.Common.Models.Configuration.Branding;
 using FoundationaLLM.Common.Models.Context;
 using FoundationaLLM.Common.OpenAPI;
+using FoundationaLLM.Common.Services.Users;
 using FoundationaLLM.Common.Validation;
 using FoundationaLLM.Core.Interfaces;
 using FoundationaLLM.Core.Models.Configuration;
@@ -111,7 +112,7 @@ namespace FoundationaLLM.Core.API
 
             builder.AddAzureCosmosDBService();
             builder.Services.AddScoped<ICoreService, CoreService>();
-            builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+            builder.AddUserProfileService();
             builder.Services.AddScoped<IOneDriveWorkSchoolService, OneDriveWorkSchoolService>();
 
             builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();

--- a/src/dotnet/Orchestration/Models/ConfigurationOptions/OrchestrationServiceSettings.cs
+++ b/src/dotnet/Orchestration/Models/ConfigurationOptions/OrchestrationServiceSettings.cs
@@ -1,0 +1,15 @@
+﻿using FoundationaLLM.Common.Models.Configuration.Storage;
+
+namespace FoundationaLLM.Orchestration.Core.Models.ConfigurationOptions
+{
+    /// <summary>
+    /// Provides settings for the orchestration service.
+    /// </summary>
+    public class OrchestrationServiceSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="BlobStorageServiceSettings"/> used to store exported completion requests.
+        /// </summary>
+        public required BlobStorageServiceSettings CompletionRequestsStorage { get; set; }
+    }
+}

--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -44,6 +44,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
         /// <param name="codeExecutionService">The <see cref="ICodeExecutionService"/> used to execute code.</param>
         /// <param name="serviceProvider">The <see cref="IServiceProvider"/> provding dependency injection services for the current scope.</param>
         /// <param name="loggerFactory">The logger factory used to create new loggers.</param>
+        /// <param name="completionRequestObserver">An optional observer for completion requests.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
         public static async Task<OrchestrationBase?> Build(
@@ -58,7 +59,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             ITemplatingService templatingService,
             ICodeExecutionService codeExecutionService,
             IServiceProvider serviceProvider,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            Func<LLMCompletionRequest, Task>? completionRequestObserver = null)
         {
             var logger = loggerFactory.CreateLogger<OrchestrationBuilder>();
 
@@ -118,7 +120,8 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                     serviceProvider.GetRequiredService<IHttpClientFactoryService>(),
                     resourceProviderServices,
                     result.DataSourceAccessDenied,
-                    vectorStoreId);
+                    vectorStoreId,
+                    completionRequestObserver);
 
                 return kmOrchestration;
             }
@@ -170,6 +173,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                 loggerFactory.CreateLogger<OrchestrationBase>(),
                 serviceProvider.GetRequiredService<IHttpClientFactoryService>(),
                 resourceProviderServices,
+                null,
                 null,
                 null);
 

--- a/src/dotnet/Orchestration/Services/DependencyInjection.cs
+++ b/src/dotnet/Orchestration/Services/DependencyInjection.cs
@@ -1,4 +1,7 @@
-﻿using FoundationaLLM.Orchestration.Core.Interfaces;
+﻿using FoundationaLLM.Common.Constants.Configuration;
+using FoundationaLLM.Common.Models.Configuration.CodeExecution;
+using FoundationaLLM.Orchestration.Core.Interfaces;
+using FoundationaLLM.Orchestration.Core.Models.ConfigurationOptions;
 using FoundationaLLM.Orchestration.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -14,8 +17,13 @@ namespace FoundationaLLM
         /// Adds the Orchestration service to the dependency injection container.
         /// </summary>
         /// <param name="builder">The host application builder.</param>
-        public static void AddOrchestrationService(this IHostApplicationBuilder builder) =>
+        public static void AddOrchestrationService(this IHostApplicationBuilder builder)
+        {
+            builder.Services.AddOptions<OrchestrationServiceSettings>()
+                .Bind(builder.Configuration.GetSection(AppConfigurationKeySections.FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration));
+
             builder.Services.AddScoped<IOrchestrationService, OrchestrationService>();
+        }
 
         /// <summary>
         /// Adds all internal LLM orchestration services and the LLM orchestration service manager to the dependency injection container.

--- a/src/dotnet/OrchestrationAPI/Program.cs
+++ b/src/dotnet/OrchestrationAPI/Program.cs
@@ -64,6 +64,7 @@ namespace FoundationaLLM.Orchestration.API
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_AzureEventGrid_Essentials);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_AzureEventGrid_Configuration);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Code_CodeExecution);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_OrchestrationAPI_Configuration);
 
                 options.Select(AppConfigurationKeys.FoundationaLLM_Events_Profiles_OrchestrationAPI);
             }));
@@ -107,6 +108,7 @@ namespace FoundationaLLM.Orchestration.API
 
             builder.Services.AddScoped<ICallContext, CallContext>();
             builder.Services.AddScoped<IUserClaimsProviderService, NoOpUserClaimsProviderService>();
+            builder.AddUserProfileService();
 
             builder.Services.AddSingleton<ICacheService, MemoryCacheService>();
 

--- a/tests/dotnet/Orchestration.Tests/Services/OrchestrationServiceTests.cs
+++ b/tests/dotnet/Orchestration.Tests/Services/OrchestrationServiceTests.cs
@@ -32,9 +32,11 @@ namespace FoundationaLLM.Orchestration.Tests.Services
         public OrchestrationServiceTests()
         {
             _orchestrationService = new OrchestrationService(
+                null,
                 _resourceProviderServices,
                 null,
                 _cosmosDBService,
+                null,
                 null,
                 null,
                 _callContext,


### PR DESCRIPTION
# Enable optional persistence of completion requests

## The issue or feature being addressed

Tracking and analyzing completion requests sent to LangChain API is difficult and time consuming.

## Details on the issue fix or feature implementation

Provides a per-user option to persist completion requests generated by Orchestration API and sent to LangChain API.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
