### PR TITLE
Transform polling interval to double for PollingHttpClient

### DIFF
--- a/src/dotnet/Common/Middleware/CallContextMiddleware.cs
+++ b/src/dotnet/Common/Middleware/CallContextMiddleware.cs
@@ -1,11 +1,8 @@
 ﻿using FoundationaLLM.Common.Authentication;
 using FoundationaLLM.Common.Constants.Instance;
-using FoundationaLLM.Common.Constants.ResourceProviders;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Configuration.Instance;
-using FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentAccessTokens;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using System.Text.Json;

--- a/src/dotnet/Orchestration/Models/ConfigurationOptions/LangChainServiceSettings.cs
+++ b/src/dotnet/Orchestration/Models/ConfigurationOptions/LangChainServiceSettings.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The polling interval in seconds to check the status of the LangChain service.
         /// </summary>
-        public int PollingIntervalSeconds { get; set; } = 10;
+        public double PollingIntervalSeconds { get; set; } = 10;
 
     }
 }


### PR DESCRIPTION
# Transform polling interval to double for PollingHttpClient

## The issue or feature being addressed

`PollingHttpClient` cannot be configured with a polling interval lower than one second.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
