### PR TITLE
Make sure we hide the rendering message when completion finishes

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -409,7 +409,7 @@ export default {
 		messageDisplayStatus() {
 			if (
 				this.message.status === 'Failed' ||
-				(this.message.status === 'Completed' && !this.isRenderingMessage)
+				(this.message.status === 'Completed')
 			)
 				return null;
 


### PR DESCRIPTION
# Make sure we hide the rendering message when completion finishes

## The issue or feature being addressed

Ensures the rendering message disappears after the completion ends (fails or completes). The "Rendering" status no longer appears as the message animates, rendering the response when the completed message returns. The "Thinking" status still appears while the completion request is still processing.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
