### PR TITLE
Fix message history for LangGraphReactAgent and ExternalWorkflow path

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -462,7 +462,11 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
 
             # Define the graph
             graph = create_react_agent(llm, tools=tools, state_modifier=self.prompt.prefix)
-            messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
+            if agent.conversation_history_settings.enabled:
+                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
+            else:
+                messages = []
+                
             messages.append(HumanMessage(content=parsed_user_prompt))
 
             response = await graph.ainvoke(
@@ -526,8 +530,11 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
                 self.user_identity,
                 self.config)
            
-            # Get message history          
-            messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)            
+            # Get message history
+            if agent.conversation_history_settings.enabled:   
+                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
+            else:
+                messages = []
 
             response = await workflow.invoke_async(
                 operation_id=request.operation_id,


### PR DESCRIPTION
# Fix message history for LangGraphReactAgent and ExternalWorkflow path

## The issue or feature being addressed

The LangGraphReactAgent and ExternalWorkflow path execution was not taking into account the conversations enabled property and was always sending in conversation history.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
