### PR TITLE
User Portal processing time and message timestamps

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -864,7 +864,8 @@ public partial class CoreService(
                     { "/contentArtifacts", completionResponse.ContentArtifacts },
                     { "/content", newContent },
                     { "/analysisResults", completionResponse.AnalysisResults },
-                    { "/status", operationStatus }
+                    { "/status", operationStatus },
+                    { "/timeStamp", DateTime.UtcNow }
                 }
             },
             new PatchOperationItem<CompletionPrompt>

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -276,7 +276,8 @@ public partial class CoreService(
                         PropertyValues = new Dictionary<string, object?>
                         {
                             { "/status", OperationStatus.Failed },
-                            { "/text", "The completion operation has exceeded the maximum time allowed." }
+                            { "/text", "The completion operation has exceeded the maximum time allowed." },
+                            { "/timeStamp", DateTime.UtcNow }
                         }
                     }
                 };
@@ -294,7 +295,9 @@ public partial class CoreService(
                     {
                         OperationId = operationId,
                         Status = OperationStatus.Failed,
-                        Text = "The completion operation has exceeded the maximum time allowed."
+                        Text = "The completion operation has exceeded the maximum time allowed.",
+                        TimeStamp = DateTime.UtcNow,
+                        SenderDisplayName = operationContext.AgentName
                     },
                     Status = OperationStatus.Failed
                 };
@@ -330,7 +333,9 @@ public partial class CoreService(
             {
                 OperationId = operationId,
                 Status = operationStatus.Status,
-                Text = operationStatus.StatusMessage ?? "The completion operation is in progress."
+                Text = operationStatus.StatusMessage ?? "The completion operation is in progress.",
+                TimeStamp = DateTime.UtcNow,
+                SenderDisplayName = operationContext.AgentName
             };
 
             return operationStatus;
@@ -347,7 +352,8 @@ public partial class CoreService(
                 {
                     OperationId = operationId,
                     Status = OperationStatus.Failed,
-                    Text = "Could not retrieve the status of the operation due to an internal error."
+                    Text = "Could not retrieve the status of the operation due to an internal error.",
+                    TimeStamp = DateTime.UtcNow
                 },
                 Status = OperationStatus.Failed
             };

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -29,9 +29,9 @@
 							}"
 						/>
 						<VTooltip :auto-hide="isMobile" :popper-triggers="isMobile ? [] : ['hover']">
-							<span class="time-stamp" tabindex="0" @keydown.esc="hideAllPoppers">{{
-								$filters.timeAgo(new Date(message.timeStamp))
-							}}</span>
+							<span class="time-stamp" tabindex="0" @keydown.esc="hideAllPoppers">
+								<TimeAgo :date="new Date(message.timeStamp)" />
+							</span>
 							<template #popper>
 								<div role="tooltip">
 									{{ buildTimeStampTooltip(message.timeStamp, message.processingTime) }}
@@ -186,7 +186,7 @@
 
 		<!-- Date Divider -->
 		<Divider v-if="message.sender == 'User'" align="center" type="solid" class="date-separator">
-			{{ $filters.timeAgo(new Date(message.timeStamp)) }}
+			<TimeAgo :date="new Date(message.timeStamp)" />
 		</Divider>
 
 		<!-- Analysis Modal -->
@@ -297,6 +297,7 @@ import { hideAllPoppers } from 'floating-vue';
 import type { Message, MessageContent, CompletionPrompt } from '@/js/types';
 import api from '@/js/api';
 import { fetchBlobUrl } from '@/js/fileService';
+import TimeAgo from '~/components/TimeAgo.vue';
 
 function processLatex(content) {
 	const blockLatexPattern = /\\\[\s*([\s\S]+?)\s*\\\]/g;
@@ -683,8 +684,9 @@ export default {
 
 		buildTimeStampTooltip(timeStamp: string, processingTime: number) {
 			const date = this.formatTimeStamp(timeStamp);
+			if (!processingTime) return date;
 			const processingTimeSeconds = processingTime / 1000;
-			return `Message sent at ${date}\nProcessing time: ${processingTimeSeconds.toFixed(2)} seconds`;
+			return `${date}\n(${processingTimeSeconds.toFixed(2)} seconds)`;
 		},
 
 		getDisplayName() {

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -34,7 +34,7 @@
 							}}</span>
 							<template #popper>
 								<div role="tooltip">
-									{{ formatTimeStamp(message.timeStamp) }}
+									{{ buildTimeStampTooltip(message.timeStamp, message.processingTime) }}
 								</div>
 							</template>
 						</VTooltip>
@@ -409,7 +409,7 @@ export default {
 		messageDisplayStatus() {
 			if (
 				this.message.status === 'Failed' ||
-				(this.message.status === 'Completed' && !this.isRenderingMessage)
+				(this.message.status === 'Completed')
 			)
 				return null;
 
@@ -679,6 +679,12 @@ export default {
 				timeZoneName: 'short',
 			};
 			return date.toLocaleString(undefined, options);
+		},
+
+		buildTimeStampTooltip(timeStamp: string, processingTime: number) {
+			const date = this.formatTimeStamp(timeStamp);
+			const processingTimeSeconds = processingTime / 1000;
+			return `Message sent at ${date}\nProcessing time: ${processingTimeSeconds.toFixed(2)} seconds`;
 		},
 
 		getDisplayName() {

--- a/src/ui/UserPortal/components/TimeAgo.vue
+++ b/src/ui/UserPortal/components/TimeAgo.vue
@@ -1,0 +1,42 @@
+<template>
+    <span>{{ formattedTime }}</span>
+  </template>
+  
+  <script setup>
+  import { ref, onMounted, onUnmounted, watchEffect } from 'vue';
+  import TimeAgo from 'javascript-time-ago';
+  
+  const props = defineProps({
+    date: {
+      type: Date,
+      required: true,
+    },
+    interval: {
+      type: Number,
+      default: 60000, // Update every 60 seconds
+    },
+  });
+  
+  const formattedTime = ref('');
+  const timeAgo = new TimeAgo('en-US');
+  
+  const updateFormattedTime = () => {
+    formattedTime.value = timeAgo.format(props.date);
+  };
+  
+  let timer;
+  onMounted(() => {
+    updateFormattedTime();
+    timer = setInterval(updateFormattedTime, props.interval);
+  });
+  
+  onUnmounted(() => {
+    clearInterval(timer);
+  });
+  
+  // Recompute if the date prop changes
+  watchEffect(() => {
+    updateFormattedTime();
+  });
+  </script>
+  

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -53,7 +53,7 @@ export interface Message {
 	type: string;
 	sessionId: string;
 	timeStamp: string;
-	sender: 'User' | 'Assistant';
+	sender: 'User' | 'Agent';
 	senderDisplayName: string | null;
 	tokens: number;
 	text: string;

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -66,6 +66,7 @@ export interface Message {
 	attachments: Array<string>;
 	attachmentDetails: Array<AttachmentDetail>;
 	analysisResults: Array<AnalysisResult>;
+	processingTime: number; // Calculated in milliseconds - not from the API
 }
 
 export interface MessageRatingRequest

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -298,6 +298,10 @@ export const useAppStore = defineStore('app', {
 				}
 			}
 
+			this.calculateMessageProcessingTime();
+		},
+
+		calculateMessageProcessingTime() {
 			// Calculate the processing time for each message
 			this.currentMessages.forEach((message, index) => {
 				if (message.sender === 'Agent' && this.currentMessages[index - 1]?.sender === 'User') {
@@ -483,6 +487,8 @@ export const useAppStore = defineStore('app', {
 					) {
 						userMessage.tokens = statusResponse.prompt_tokens;
 					}
+
+					this.calculateMessageProcessingTime();
 
 					if (updatedMessage.status === 'Completed' || updatedMessage.status === 'Failed') {
 						this.stopPolling(sessionId);

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -297,6 +297,15 @@ export const useAppStore = defineStore('app', {
 					this.startPolling(latestMessage, this.currentSession.id);
 				}
 			}
+
+			// Calculate the processing time for each message
+			this.currentMessages.forEach((message, index) => {
+				if (message.sender === 'Agent' && this.currentMessages[index - 1]?.sender === 'User') {
+					const previousMessageTimeStamp = new Date(this.currentMessages[index - 1].timeStamp).getTime();
+					const currentMessageTimeStamp = new Date(message.timeStamp).getTime();
+					message.processingTime = currentMessageTimeStamp - previousMessageTimeStamp;
+				}
+			});
 		},
 
 		async getMessage(messageId: string) {


### PR DESCRIPTION
# User Portal processing time and message timestamps

## The issue or feature being addressed

Improvements to processing time tracking and displaying message timestamps.

## Details on the issue fix or feature implementation

- Update agent message timestamps during processing to show an accurate message time on the User Portal
- Add the agent name to the message sent back wtih an operation context when checking status updates so the agent name correctly appears on the User Portal while waiting for a completion message to complete
- Calculate the processing time by comparing the timestamp on the user prompt to the agent response (messages) and display when hovering over the agent message timestamp
- Create TimeAgo component to better handle automatic updates of the human-friendly timestamp display (eg. "2 minutes ago")

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
