### PR TITLE
User Portal agent listing improvements

### DIFF
--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -155,72 +155,15 @@ export default {
 			},
 			deep: true,
 		},
-	},
-
-	async created() {
-		await this.$appStore.getAgents();
-
-		this.agentOptions = this.$appStore.agents.map((agent) => ({
-			label: agent.resource.name,
-			type: agent.resource.type,
-			object_id: agent.resource.object_id,
-			description: agent.resource.description,
-			my_agent: agent.roles.includes('Owner'),
-			value: agent,
-		}));
-
-		if (this.agentOptions.length === 0) {
-			this.emptyAgentsMessage = this.$appConfigStore.noAgentsMessage ?? null;
-		}
-
-		const publicAgentOptions = this.agentOptions.filter((agent) => !agent.my_agent);
-		const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
-		const noAgentOptions = [
-			{
-				label: 'None',
-				value: null,
-				disabled: true,
-				type: '',
-				object_id: '',
-				description: '',
+		'$appStore.agents': {
+			handler() {
+				this.setAgentOptions();
 			},
-		];
-		this.virtualUser = await this.$appStore.getVirtualUser();
-
-		this.agentOptionsGroup.push({
-			label: '',
-			items: [
-				{
-					label: '--select--',
-					value: null,
-					type: '',
-					object_id: '',
-					description: '',
-				},
-			],
-		});
-
-		if (this.agentOptions.length === 0) {
-			// Append noAgentOptions to the last entry in the agentOptionsGroup
-			this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items.push(...noAgentOptions);
-			return;
-		}
-
-		if (privateAgentOptions.length > 0) {
-			this.agentOptionsGroup.push({
-				label: 'My Agents',
-				items: privateAgentOptions,
-			});
-			this.agentOptionsGroup.push({
-				label: 'Other Agents',
-				items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
-			});
-		} else {
-			this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items.push(
-				...(publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions),
-			);
-		}
+			deep: true,
+		},
 	},
+
+	async created() {},
 
 	mounted() {
 		this.updateAgentSelection();
@@ -248,6 +191,69 @@ export default {
 
 		async handleLogout() {
 			await this.$authStore.logout();
+		},
+
+		async setAgentOptions() {
+			this.agentOptions = this.$appStore.agents.map((agent) => ({
+				label: agent.resource.name,
+				type: agent.resource.type,
+				object_id: agent.resource.object_id,
+				description: agent.resource.description,
+				my_agent: agent.roles.includes('Owner'),
+				value: agent,
+			}));
+
+			if (this.agentOptions.length === 0) {
+				this.emptyAgentsMessage = this.$appConfigStore.noAgentsMessage ?? null;
+			}
+
+			const publicAgentOptions = this.agentOptions.filter((agent) => !agent.my_agent);
+			const privateAgentOptions = this.agentOptions.filter((agent) => agent.my_agent);
+			const noAgentOptions = [
+				{
+					label: 'None',
+					value: null,
+					disabled: true,
+					type: '',
+					object_id: '',
+					description: '',
+				},
+			];
+			this.virtualUser = await this.$appStore.getVirtualUser();
+
+			this.agentOptionsGroup.push({
+				label: '',
+				items: [
+					{
+						label: '--select--',
+						value: null,
+						type: '',
+						object_id: '',
+						description: '',
+					},
+				],
+			});
+
+			if (this.agentOptions.length === 0) {
+				// Append noAgentOptions to the last entry in the agentOptionsGroup
+				this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items.push(...noAgentOptions);
+				return;
+			}
+
+			if (privateAgentOptions.length > 0) {
+				this.agentOptionsGroup.push({
+					label: 'My Agents',
+					items: privateAgentOptions,
+				});
+				this.agentOptionsGroup.push({
+					label: 'Other Agents',
+					items: publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions,
+				});
+			} else {
+				this.agentOptionsGroup[this.agentOptionsGroup.length - 1].items.push(
+					...(publicAgentOptions.length > 0 ? publicAgentOptions : noAgentOptions),
+				);
+			}
 		},
 
 		// handleCopySession() {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -48,6 +48,7 @@ export const useAppStore = defineStore('app', {
 	actions: {
 		async init(sessionId: string) {
 			const appConfigStore = useAppConfigStore();
+			await this.getAgents();
 
 			// Watch for changes in autoHideToasts and update sessionStorage
 			watch(


### PR DESCRIPTION
# User Portal agent listing improvements

## The issue or feature being addressed

Fixes issues related to the order in which the User Portal retrieves agents and conversations (sessions). Issues include:

- Improperly deriving the agent and setting it to the selected agent when refreshing the browser while looking at a specific conversation
- Allowing the user to enter a prompt before the list of agents is available when there is a large number of conversations
- Perceived delay in populating the agents list on page load

## Details on the issue fix or feature implementation

- Moved agent loading method call from the NavBar component to the `init` method of the app store
- Ensured the agent loading method call is moved to the top of the `init` method before session-loading logic occurs
- Updated the NavBar component to construct the agent options when the app store's `agents` collection has changed, rather than when the component is created

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
