### PR TITLE
User Portal: Handle null titles in content artifacts

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -106,7 +106,7 @@
 							@click="selectedContentArtifact = artifact"
 						>
 							<i class="pi pi-file"></i>
-							{{ artifact.title.split('/').pop() }}
+							{{ artifact.title ? artifact.title?.split('/').pop() : '(No Title)' }}
 						</span>
 					</div>
 


### PR DESCRIPTION
# User Portal: Handle null titles in content artifacts

## The issue or feature being addressed

Fixes error thrown when the title of a content artifact is null.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
