### PR TITLE
Made rerank_score optional on VectorDocument

### DIFF
--- a/src/python/PythonSDK/PythonSDK.pyproj
+++ b/src/python/PythonSDK/PythonSDK.pyproj
@@ -32,7 +32,7 @@
     <Compile Include="foundationallm\langchain\common\foundationallm_tool_base.py" />
     <Compile Include="foundationallm\langchain\common\foundationallm_workflow_base.py" />
     <Compile Include="foundationallm\langchain\common\__init__.py" />
-    <Compile Include="foundationallm\langchain\workflows\external_workflow_factory.py" />
+    <Compile Include="foundationallm\langchain\workflows\workflow_factory.py" />
     <Compile Include="foundationallm\langchain\workflows\__init__.py" />
     <Compile Include="foundationallm\models\agents\agent_tool.py" />
     <Compile Include="foundationallm\models\agents\agent_workflows\agent_workflow_ai_model.py" />
@@ -58,6 +58,8 @@
     <Compile Include="foundationallm\models\resource_providers\vectorization\embedding_profiles\embedding_profile_settings_keys.py" />
     <Compile Include="foundationallm\models\services\gateway_text_embedding_response.py" />
     <Compile Include="foundationallm\models\services\openai_assistants_response.py" />
+    <Compile Include="foundationallm\models\vectors\vector_document.py" />
+    <Compile Include="foundationallm\models\vectors\__init__.py" />
     <Compile Include="foundationallm\plugins\external_module.py" />
     <Compile Include="foundationallm\plugins\plugin_manager.py" />
     <Compile Include="foundationallm\plugins\plugin_manager_types.py" />
@@ -197,6 +199,7 @@
     <Folder Include="foundationallm\models\constants\" />
     <Folder Include="foundationallm\event_handlers\" />
     <Folder Include="foundationallm\models\messages\" />
+    <Folder Include="foundationallm\models\vectors\" />
     <Folder Include="foundationallm\plugins\" />
     <Folder Include="foundationallm\plugins\workflows\" />
     <Folder Include="foundationallm\plugins\tools\" />

--- a/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
+++ b/src/python/PythonSDK/foundationallm/models/vectors/vector_document.py
@@ -1,10 +1,11 @@
+from typing import Optional
 from langchain_core.documents import Document
 
 class VectorDocument(Document):
 
     id : str
     score: float
-    rerank_score: float
+    rerank_score: Optional[float]
     
     class Config:
         extra = "allow"


### PR DESCRIPTION
# Made rerank_score optional on VectorDocument

## The issue or feature being addressed

Azure AI Index doesn't always return re-rank score. Setting this property to Optional on VectorDocument class to fix this bug.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
