### PR TITLE
Set default agent and other resources

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -129,6 +129,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
                     ResourceProviderActions.CheckName => await CheckResourceName<AgentBase>(
                         JsonSerializer.Deserialize<ResourceName>(serializedAction)!),
                     ResourceProviderActions.Purge => await PurgeResource<AgentBase>(resourcePath),
+                    ResourceProviderActions.SetDefault => await SetDefaultResource<AgentBase>(resourcePath),
                     _ => throw new ResourceProviderException($"The action {resourcePath.Action} is not supported by the {_name} resource provider.",
                         StatusCodes.Status400BadRequest)
                 },
@@ -584,19 +585,19 @@ namespace FoundationaLLM.Agent.ResourceProviders
 
         private async Task<List<ResourceProviderGetResult<AgentFile>>> LoadAgentFiles(string agentName) =>
             (await _resourceReferenceStore!.GetAllResourceReferences<AgentFile>())
-            .Where(r => r.Name.StartsWith(agentName))
-            .Select(r => (r, r.Name.Split("|").Last()))
-            .Select(x => new ResourceProviderGetResult<AgentFile>()
-            {
-                Actions = [],
-                Roles = [],
-                Resource = new AgentFile()
+                .Where(r => r.Name.StartsWith(agentName))
+                .Select(r => (r, r.Name.Split("|").Last()))
+                .Select(x => new ResourceProviderGetResult<AgentFile>()
                 {
-                    Name = x.Item2,
-                    DisplayName = x.Item2,
-                    ObjectId = ResourcePath.GetObjectId(_instanceSettings.Id, _name, AgentResourceTypeNames.Agents, agentName, AgentResourceTypeNames.Files, x.Item2)
-                }
-            }).ToList();
+                    Actions = [],
+                    Roles = [],
+                    Resource = new AgentFile()
+                    {
+                        Name = x.Item2,
+                        DisplayName = x.Item2,
+                        ObjectId = ResourcePath.GetObjectId(_instanceSettings.Id, _name, AgentResourceTypeNames.Agents, agentName, AgentResourceTypeNames.Files, x.Item2)
+                    }
+                }).ToList();
 
         private async Task<ResourceProviderUpsertResult> UpdateAgentFile(ResourcePath resourcePath, ResourceProviderFormFile formFile, UnifiedUserIdentity userIdentity)
         {

--- a/src/dotnet/Common/Constants/ResourceProviders/AgentResourceProviderMetadata.cs
+++ b/src/dotnet/Common/Constants/ResourceProviders/AgentResourceProviderMetadata.cs
@@ -32,6 +32,9 @@ namespace FoundationaLLM.Common.Constants.ResourceProviders
                         ]),
                         new ResourceTypeAction(ResourceProviderActions.Purge, true, false, [
                             new ResourceTypeAllowedTypes(HttpMethod.Post.Method, AuthorizableOperations.Delete, [], [], [typeof(ResourceProviderActionResult)])
+                        ]),
+                        new ResourceTypeAction(ResourceProviderActions.SetDefault, true, false, [
+                            new ResourceTypeAllowedTypes(HttpMethod.Post.Method, AuthorizableOperations.Write, [], [], [typeof(ResourceProviderActionResult)])
                         ])
                     ],
                     SubTypes = new()

--- a/src/dotnet/Common/Constants/ResourceProviders/ResourcePropertyNames.cs
+++ b/src/dotnet/Common/Constants/ResourceProviders/ResourcePropertyNames.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FoundationaLLM.Common.Constants.ResourceProviders
+{
+    /// <summary>
+    /// Common property names for resources.
+    /// </summary>
+    public class ResourcePropertyNames
+    {
+        /// <summary>
+        /// Key in the property bag for indicating whether the resource is the default for this resource type.
+        /// </summary>
+        public const string DefaultResource = "default_resource";
+    }
+}

--- a/src/dotnet/Common/Constants/ResourceProviders/ResourceProviderActions.cs
+++ b/src/dotnet/Common/Constants/ResourceProviders/ResourceProviderActions.cs
@@ -29,5 +29,10 @@
         /// Validate resources.
         /// </summary>
         public const string Validate = "validate";
+
+        /// <summary>
+        /// Set the resource as the default.
+        /// </summary>
+        public const string SetDefault = "set-default";
     }
 }

--- a/src/dotnet/Common/Models/ResourceProviders/Configuration/APIEndpointSubcategory.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Configuration/APIEndpointSubcategory.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Denotes the subcategory for indexing services.
         /// </summary>
-        IndexingService,
+        Indexing,
 
         /// <summary>
         /// Denotes the subcategory for AI model endpoints, such as Azure OpenAI.

--- a/src/dotnet/Common/Models/ResourceProviders/Configuration/APIEndpointSubcategory.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Configuration/APIEndpointSubcategory.cs
@@ -8,6 +8,16 @@
         /// <summary>
         /// Denotes the subcategory for OneDrive Work or School for the FileStoreConnector category.
         /// </summary>
-        OneDriveWorkSchool
+        OneDriveWorkSchool,
+
+        /// <summary>
+        /// Denotes the subcategory for indexing services.
+        /// </summary>
+        IndexingService,
+
+        /// <summary>
+        /// Denotes the subcategory for AI model endpoints, such as Azure OpenAI.
+        /// </summary>
+        AIModel
     }
 }

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -1540,11 +1540,18 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
             if (!string.IsNullOrWhiteSpace(_resourceReferenceStore?.DefaultResourceName) && results
                     .Any(a => a.Resource.Name == _resourceReferenceStore.DefaultResourceName))
             {
-                var resourceProperties = results.First(a => a.Resource.Name == _resourceReferenceStore.DefaultResourceName)
-                    .Resource.Properties;
-                if (resourceProperties != null)
+                var resource = results.First(a => a.Resource.Name == _resourceReferenceStore.DefaultResourceName)
+                    .Resource;
+                if (resource.Properties != null)
                 {
-                    resourceProperties[ResourcePropertyNames.DefaultResource] = true.ToString().ToLowerInvariant();
+                    resource.Properties[ResourcePropertyNames.DefaultResource] = true.ToString().ToLowerInvariant();
+                }
+                else
+                {
+                    resource.Properties = new Dictionary<string, string>
+                    {
+                        { ResourcePropertyNames.DefaultResource, true.ToString().ToLowerInvariant() }
+                    };
                 }
 
                 foreach (var result in results.Where(r => r.Resource.Name != _resourceReferenceStore.DefaultResourceName))

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
 using System.Text;
 using System.Text.Json;
-using static Microsoft.IO.RecyclableMemoryStreamManager;
 
 namespace FoundationaLLM.Common.Services.ResourceProviders
 {

--- a/src/ui/ManagementPortal/components/AgentsList.vue
+++ b/src/ui/ManagementPortal/components/AgentsList.vue
@@ -1,0 +1,283 @@
+<template>
+    <div :class="{ 'grid--loading': loading }">
+        <!-- Loading overlay -->
+        <template v-if="loading">
+            <div class="grid__loading-overlay" role="status" aria-live="polite">
+                <LoadingGrid />
+                <div>{{ loadingStatusText }}</div>
+            </div>
+        </template>
+
+        <!-- Table -->
+        <DataTable :value="agents" striped-rows scrollable table-style="max-width: 100%" size="small">
+            <template #empty>
+                <div role="alert" aria-live="polite">
+                    No agents found. Please use the menu on the left to create a new agent.
+                </div>
+            </template>
+            <template #loading>Loading agent data. Please wait.</template>
+
+            <!-- Name -->
+            <Column
+                field="resource.name"
+                header="Name"
+                sortable
+                style="min-width: 200px"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    sortIcon: { style: { color: 'var(--primary-text)' } },
+                }"
+            >
+                <template #body="{ data }">
+                    <span>{{ data.resource.name }}</span>
+                    <template v-if="data.resource.properties?.default_resource === 'true'">
+                        <Chip
+                            label="Default"
+                            icon="pi pi-star"
+                            style="margin-left: 8px"
+                        />
+                    </template>
+                </template>
+            </Column>
+
+            <!-- Description -->
+            <Column
+                field="resource.description"
+                header="Description"
+                sortable
+                style="min-width: 200px"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    sortIcon: { style: { color: 'var(--primary-text)' } },
+                }"
+            ></Column>
+
+            <!-- Expiration -->
+            <Column
+                field="resource.expiration_date"
+                header="Expiration Date"
+                sortable
+                style="min-width: 200px"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    sortIcon: { style: { color: 'var(--primary-text)' } },
+                }"
+            >
+                <template #body="{ data }">
+                    <span>{{ $filters.formatDate(data.resource.expiration_date) }}</span>
+                </template>
+            </Column>
+
+            <!-- Edit -->
+            <Column
+                header="Edit"
+                header-style="width:6rem"
+                style="text-align: center"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    headerContent: { style: { justifyContent: 'center' } },
+                }"
+            >
+                <template #body="{ data }">
+                    <NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
+                        <VTooltip :auto-hide="false" :popper-triggers="['hover']">
+                            <Button
+                                link
+                                :disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
+                                :aria-label="`Edit ${data.resource.name}`"
+                            >
+                                <i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
+                            </Button>
+                            <template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
+                        </VTooltip>
+                    </NuxtLink>
+                </template>
+            </Column>
+
+            <!-- Delete -->
+            <Column
+                header="Delete"
+                header-style="width:6rem"
+                style="text-align: center"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    headerContent: { style: { justifyContent: 'center' } },
+                }"
+            >
+                <template #body="{ data }">
+                    <VTooltip :auto-hide="false" :popper-triggers="['hover']">
+                        <Button
+                            link
+                            :disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
+                            :aria-label="`Delete ${data.resource.name}`"
+                            @click="agentToDelete = data.resource"
+                        >
+                            <i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
+                        </Button>
+                        <template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
+                    </VTooltip>
+                </template>
+            </Column>
+
+            <!-- Set Default -->
+            <Column
+                header="Set Default"
+                header-style="width:6rem"
+                style="text-align: center"
+                :pt="{
+                    headerCell: {
+                        style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+                    },
+                    headerContent: { style: { justifyContent: 'center' } },
+                }"
+            >
+                <template #body="{ data }">
+                    <VTooltip :auto-hide="false" :popper-triggers="['hover']">
+                        <Button
+                            link
+                            :disabled="!data.roles.includes('User Access Administrator')"
+                            :aria-label="`Set ${data.resource.name} as default`"
+                            @click="agentToSetAsDefault = data.resource"
+                        >
+                            <i class="pi pi-star" style="font-size: 1.2rem" aria-hidden="true"></i>
+                        </Button>
+                        <template #popper><div role="tooltip">Set {{data.resource.name}} as default agent</div></template>
+                    </VTooltip>
+                </template>
+            </Column>
+        </DataTable>
+
+        <!-- Delete agent dialog -->
+        <Dialog :visible="agentToDelete !== null" modal v-focustrap header="Delete Agent" :closable="false">
+            <p>Do you want to delete the agent "{{ agentToDelete.name }}" ?</p>
+            <template #footer>
+                <Button label="Cancel" text @click="agentToDelete = null" />
+                <Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
+            </template>
+        </Dialog>
+
+        <!-- Set default agent dialog -->
+        <Dialog :visible="agentToSetAsDefault !== null" modal v-focustrap header="Set Default Agent" :closable="false">
+            <p>Do you want to set the "{{ agentToSetAsDefault.name }}" agent as default?<br />Default agents are automatically
+                selected in the User Portal for new conversations.
+            </p>
+            <template #footer>
+                <Button label="Cancel" text @click="agentToSetAsDefault = null" />
+                <Button label="Set as Default" severity="info" autofocus @click="handleSetDefaultAgent" />
+            </template>
+        </Dialog>
+    </div>
+</template>
+
+<script lang="ts">
+import api from '@/js/api';
+import type {
+    Agent,
+    ResourceProviderGetResult,
+    ResourceProviderActionResult } from '@/js/types';
+
+export default {
+    name: 'AgentsList',
+
+    props: {
+        agents: {
+            type: Array as () => ResourceProviderGetResult<Agent>[],
+            required: true,
+        },
+        loading: {
+            type: Boolean,
+            required: true,
+        },
+        loadingStatusText: {
+            type: String,
+            required: true,
+        },
+    },
+
+    data() {
+        return {
+            agentToDelete: null as Agent | null,
+            agentToSetAsDefault: null as Agent | null,
+        };
+    },
+
+    methods: {
+        async handleDeleteAgent() {
+            try {
+                await api.deleteAgent(this.agentToDelete!.name);
+                this.agentToDelete = null;
+                this.$emit('refreshAgents');
+            } catch (error) {
+                this.$toast.add({
+                    severity: 'error',
+                    detail: error?.response?._data || error,
+                    life: 5000,
+                });
+            }
+        },
+
+        async handleSetDefaultAgent() {
+            try {
+                let result: ResourceProviderActionResult = await api.setDefaultAgent(this.agentToSetAsDefault!.name);
+                if (result.isSuccessResult) {
+                    this.$toast.add({
+                        severity: 'success',
+                        detail: `Agent "${this.agentToSetAsDefault!.name}" set as default.`,
+                        life: 5000,
+                    });
+                } else {
+                    this.$toast.add({
+                        severity: 'error',
+                        detail: "Could not set the default agent. Please try again.",
+                        life: 5000,
+                    });
+                }
+                this.agentToSetAsDefault = null;
+                this.$emit('refreshAgents');
+            } catch (error) {
+                this.$toast.add({
+                    severity: 'error',
+                    detail: error?.response?._data || error,
+                    life: 5000,
+                });
+            }
+        },
+    },
+};
+</script>
+
+<style lang="scss">
+.table__button {
+    color: var(--primary-button-bg);
+}
+
+.grid--loading {
+    pointer-events: none;
+}
+
+.grid__loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 16px;
+    z-index: 10;
+    background-color: rgba(255, 255, 255, 0.9);
+    pointer-events: none;
+}
+</style>

--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -542,15 +542,11 @@ export default {
 	},
 
 	async setDefaultAgent(agentId: string): Promise<ResourceProviderActionResult> {
-		const payload = {
-			agentId,
-		};
-
 		return await this.fetch(
 			`/instances/${this.instanceId}/providers/FoundationaLLM.Agent/agents/${agentId}/set-default?api-version=${this.apiVersion}`,
 			{
 				method: 'POST',
-				body: payload,
+				body: {},
 			}
 		) as ResourceProviderActionResult;
 	},

--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -8,6 +8,7 @@ import type {
 	// AgentGatekeeper,
 	AgentAccessToken,
 	ResourceProviderUpsertResult,
+	ResourceProviderActionResult,
 	AIModel,
 	FilterRequest,
 	CreateAgentRequest,
@@ -538,6 +539,20 @@ export default {
 				method: 'DELETE',
 			},
 		);
+	},
+
+	async setDefaultAgent(agentId: string): Promise<ResourceProviderActionResult> {
+		const payload = {
+			agentId,
+		};
+
+		return await this.fetch(
+			`/instances/${this.instanceId}/providers/FoundationaLLM.Agent/agents/${agentId}/set-default?api-version=${this.apiVersion}`,
+			{
+				method: 'POST',
+				body: payload,
+			}
+		) as ResourceProviderActionResult;
 	},
 
 	/*

--- a/src/ui/ManagementPortal/js/types.ts
+++ b/src/ui/ManagementPortal/js/types.ts
@@ -46,6 +46,13 @@ export type ResourceProviderUpsertResult = {
     resource?: any;
 };
 
+export type ResourceProviderActionResult = {
+	/**
+	 * Represents the result of an action.
+	 */
+	isSuccessResult: boolean;
+};
+
 export type AgentTool = {
 	name: string;
 	description: string;

--- a/src/ui/ManagementPortal/pages/agents/private.vue
+++ b/src/ui/ManagementPortal/pages/agents/private.vue
@@ -1,274 +1,61 @@
 <template>
-	<main id="main-content">
-		<h2 class="page-header">My Agents</h2>
-		<div class="page-subheader">View your agents.</div>
+    <main id="main-content">
+        <h2 class="page-header">My Agents</h2>
+        <div class="page-subheader">View your agents.</div>
 
-		<div :class="{ 'grid--loading': loading }">
-			<!-- Loading overlay -->
-			<template v-if="loading">
-				<div class="grid__loading-overlay" role="status" aria-live="polite">
-					<LoadingGrid />
-					<div>{{ loadingStatusText }}</div>
-				</div>
-			</template>
-
-			<!-- Table -->
-			<DataTable :value="agents" striped-rows scrollable table-style="max-width: 100%" size="small">
-				<template #empty>
-					<div role="alert" aria-live="polite">
-						No agents found. Please use the menu on the left to create a new agent.
-					</div>
-				</template>
-				<template #loading>Loading agent data. Please wait.</template>
-
-				<!-- Name -->
-				<Column
-					field="resource.name"
-					header="Name"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				>
-					<template #body="{ data }">
-						<span>{{ data.resource.name }}</span>
-						<template v-if="data.resource.properties?.default_resource === 'true'">
-							<Chip
-								label="Default"
-								icon="pi pi-star"
-								style="margin-left: 8px"
-							/>
-						</template>
-					</template>
-				</Column>
-
-				<!-- Description -->
-				<Column
-					field="resource.description"
-					header="Description"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				></Column>
-
-				<!-- Expiration -->
-				<Column
-					field="resource.expiration_date"
-					header="Expiration Date"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				>
-					<template #body="{ data }">
-						<span>{{ $filters.formatDate(data.resource.expiration_date) }}</span>
-					</template>
-				</Column>
-
-				<!-- Edit -->
-				<Column
-					header="Edit"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
-							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-								<Button
-									link
-									:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
-									:aria-label="`Edit ${data.resource.name}`"
-								>
-									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
-								</Button>
-								<template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
-							</VTooltip>
-						</NuxtLink>
-					</template>
-				</Column>
-
-				<!-- Delete -->
-				<Column
-					header="Delete"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-								:aria-label="`Delete ${data.resource.name}`"
-								@click="agentToDelete = data.resource"
-							>
-								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
-							<template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
-						</VTooltip>
-					</template>
-				</Column>
-
-				<!-- Set Default -->
-				<Column
-					header="Set Default"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-								:aria-label="`Set ${data.resource.name} as default`"
-								@click="agentToSetAsDefault = data.resource"
-							>
-								<i class="pi pi-star" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
-							<template #popper><div role="tooltip">Set {{data.resource.name}} as default agent</div></template>
-						</VTooltip>
-					</template>
-				</Column>
-			</DataTable>
-		</div>
-
-		<!-- Delete agent dialog -->
-		<Dialog :visible="agentToDelete !== null" modal v-focustrap header="Delete Agent" :closable="false">
-			<p>Do you want to delete the agent "{{ agentToDelete.name }}" ?</p>
-			<template #footer>
-				<Button label="Cancel" text @click="agentToDelete = null" />
-				<Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
-			</template>
-		</Dialog>
-
-		<!-- Set default agent dialog -->
-		<Dialog :visible="agentToSetAsDefault !== null" modal v-focustrap header="Set Default Agent" :closable="false">
-			<p>Do you want to set the "{{ agentToSetAsDefault.name }}" agent as default?<br />Default agents are automatically
-				selected in the User Portal for new conversations.
-			</p>
-			<template #footer>
-				<Button label="Cancel" text @click="agentToSetAsDefault = null" />
-				<Button label="Set as Default" severity="info" autofocus @click="handleSetDefaultAgent" />
-			</template>
-		</Dialog>
-	</main>
+        <AgentsList
+            :agents="agents"
+            :loading="loading"
+            :loadingStatusText="loadingStatusText"
+            @refreshAgents="getAgents"
+        />
+    </main>
 </template>
 
 <script lang="ts">
 import api from '@/js/api';
+import AgentsList from '@/components/AgentsList.vue';
 import type {
-	Agent,
-	ResourceProviderGetResult,
-	ResourceProviderActionResult } from '@/js/types';
+    Agent,
+    ResourceProviderGetResult,
+} from '@/js/types';
 
 export default {
-	name: 'PrivateAgents',
+    name: 'PrivateAgents',
 
-	data() {
-		return {
-			agents: [] as ResourceProviderGetResult<Agent>[],
-			loading: false as boolean,
-			loadingStatusText: 'Retrieving data...' as string,
-			agentToDelete: null as Agent | null,
-			agentToSetAsDefault: null as Agent | null,
-			accessControlModalOpen: false,
-		};
-	},
+    components: {
+        AgentsList,
+    },
 
-	async created() {
-		await this.getAgents();
-	},
+    data() {
+        return {
+            agents: [] as ResourceProviderGetResult<Agent>[],
+            loading: false as boolean,
+            loadingStatusText: 'Retrieving data...' as string,
+        };
+    },
 
-	methods: {
-		async getAgents() {
-			this.loading = true;
-			try {
-				const agents = await api.getAgents();
-				// Only retrieve agents where the user is an owner.
-				this.agents = agents.filter((agent) => agent.roles.includes('Owner'));
-			} catch (error) {
-				this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-			this.loading = false;
-		},
+    async created() {
+        await this.getAgents();
+    },
 
-		async handleDeleteAgent() {
-			try {
-				await api.deleteAgent(this.agentToDelete!.name);
-				this.agentToDelete = null;
-			} catch (error) {
-				return this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-
-			await this.getAgents();
-		},
-
-		async handleSetDefaultAgent() {
-			try {
-				let result: ResourceProviderActionResult = await api.setDefaultAgent(this.agentToSetAsDefault!.name);
-				if (result.isSuccessResult) {
-					this.$toast.add({
-						severity: 'success',
-						detail: `Agent "${this.agentToSetAsDefault!.name}" set as default.`,
-						life: 5000,
-					});
-				} else {
-					this.$toast.add({
-						severity: 'error',
-						detail: "Could not set the default agent. Please try again.",
-						life: 5000,
-					});
-				}
-				this.agentToSetAsDefault = null;
-			} catch (error) {
-				return this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-
-			await this.getAgents();
-		},
-	},
+    methods: {
+        async getAgents() {
+            this.loading = true;
+            try {
+                const agents = await api.getAgents();
+                // Only retrieve agents where the user is an owner.
+                this.agents = agents.filter((agent) => agent.roles.includes('Owner'));
+            } catch (error) {
+                this.$toast.add({
+                    severity: 'error',
+                    detail: error?.response?._data || error,
+                    life: 5000,
+                });
+            }
+            this.loading = false;
+        },
+    },
 };
 </script>
 

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -33,7 +33,18 @@
 						},
 						sortIcon: { style: { color: 'var(--primary-text)' } },
 					}"
-				></Column>
+				>
+					<template #body="{ data }">
+						<span>{{ data.resource.name }}</span>
+						<template v-if="data.resource.properties?.default_resource === 'true'">
+							<Chip
+								label="Default"
+								icon="pi pi-star"
+								style="margin-left: 8px"
+							/>
+						</template>
+					</template>
+				</Column>
 
 				<!-- Description -->
 				<Column
@@ -121,6 +132,33 @@
 						</VTooltip>
 					</template>
 				</Column>
+
+				<!-- Set Default -->
+				<Column
+					header="Set Default"
+					header-style="width:6rem"
+					style="text-align: center"
+					:pt="{
+						headerCell: {
+							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
+						},
+						headerContent: { style: { justifyContent: 'center' } },
+					}"
+				>
+					<template #body="{ data }">
+						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
+								:aria-label="`Set ${data.resource.name} as default`"
+								@click="agentToSetAsDefault = data.resource"
+							>
+								<i class="pi pi-star" style="font-size: 1.2rem" aria-hidden="true"></i>
+							</Button>
+							<template #popper><div role="tooltip">Set {{data.resource.name}} as default agent</div></template>
+						</VTooltip>
+					</template>
+				</Column>
 			</DataTable>
 		</div>
 
@@ -132,12 +170,26 @@
 				<Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
 			</template>
 		</Dialog>
+
+		<!-- Set default agent dialog -->
+		<Dialog :visible="agentToSetAsDefault !== null" modal v-focustrap header="Set Default Agent" :closable="false">
+			<p>Do you want to set the "{{ agentToSetAsDefault.name }}" agent as default?<br />Default agents are automatically
+				selected in the User Portal for new conversations.
+			</p>
+			<template #footer>
+				<Button label="Cancel" text @click="agentToSetAsDefault = null" />
+				<Button label="Set as Default" severity="info" autofocus @click="handleSetDefaultAgent" />
+			</template>
+		</Dialog>
 	</main>
 </template>
 
 <script lang="ts">
 import api from '@/js/api';
-import type { Agent, ResourceProviderGetResult } from '@/js/types';
+import type {
+	Agent,
+	ResourceProviderGetResult,
+	ResourceProviderActionResult } from '@/js/types';
 
 export default {
 	name: 'PublicAgents',
@@ -148,6 +200,7 @@ export default {
 			loading: false as boolean,
 			loadingStatusText: 'Retrieving data...' as string,
 			agentToDelete: null as Agent | null,
+			agentToSetAsDefault: null as Agent | null,
 			accessControlModalOpen: false,
 		};
 	},
@@ -175,6 +228,34 @@ export default {
 			try {
 				await api.deleteAgent(this.agentToDelete!.name);
 				this.agentToDelete = null;
+			} catch (error) {
+				return this.$toast.add({
+					severity: 'error',
+					detail: error?.response?._data || error,
+					life: 5000,
+				});
+			}
+
+			await this.getAgents();
+		},
+
+		async handleSetDefaultAgent() {
+			try {
+				let result: ResourceProviderActionResult = await api.setDefaultAgent(this.agentToSetAsDefault!.name);
+				if (result.isSuccessResult) {
+					this.$toast.add({
+						severity: 'success',
+						detail: `Agent "${this.agentToSetAsDefault!.name}" set as default.`,
+						life: 5000,
+					});
+				} else {
+					this.$toast.add({
+						severity: 'error',
+						detail: "Could not set the default agent. Please try again.",
+						life: 5000,
+					});
+				}
+				this.agentToSetAsDefault = null;
 			} catch (error) {
 				return this.$toast.add({
 					severity: 'error',

--- a/src/ui/ManagementPortal/pages/agents/public.vue
+++ b/src/ui/ManagementPortal/pages/agents/public.vue
@@ -1,304 +1,60 @@
 <template>
-	<main id="main-content">
-		<h2 class="page-header">All Agents</h2>
-		<div class="page-subheader">View your publicly accessible agents.</div>
+    <main id="main-content">
+        <h2 class="page-header">All Agents</h2>
+        <div class="page-subheader">View your publicly accessible agents.</div>
 
-		<div :class="{ 'grid--loading': loading }">
-			<!-- Loading overlay -->
-			<template v-if="loading">
-				<div class="grid__loading-overlay" role="status" aria-live="polite">
-					<LoadingGrid />
-					<div>{{ loadingStatusText }}</div>
-				</div>
-			</template>
-
-			<!-- Table -->
-			<DataTable :value="agents" striped-rows scrollable table-style="max-width: 100%" size="small">
-				<template #empty>
-					<div role="alert" aria-live="polite">
-						No agents found. Please use the menu on the left to create a new agent.
-					</div>
-				</template>
-				<template #loading>Loading agent data. Please wait.</template>
-
-				<!-- Name -->
-				<Column
-					field="resource.name"
-					header="Name"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				>
-					<template #body="{ data }">
-						<span>{{ data.resource.name }}</span>
-						<template v-if="data.resource.properties?.default_resource === 'true'">
-							<Chip
-								label="Default"
-								icon="pi pi-star"
-								style="margin-left: 8px"
-							/>
-						</template>
-					</template>
-				</Column>
-
-				<!-- Description -->
-				<Column
-					field="resource.description"
-					header="Description"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				></Column>
-
-				<!-- Expiration -->
-				<Column
-					field="resource.expiration_date"
-					header="Expiration Date"
-					sortable
-					style="min-width: 200px"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						sortIcon: { style: { color: 'var(--primary-text)' } },
-					}"
-				>
-					<template #body="{ data }">
-						<span>{{ $filters.formatDate(data.resource.expiration_date) }}</span>
-					</template>
-				</Column>
-
-				<!-- Edit -->
-				<Column
-					header="Edit"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
-							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-								<Button
-									link
-									:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
-									:aria-label="`Edit ${data.resource.name}`"
-								>
-									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
-								</Button>
-								<template #popper><div role="tooltip">Edit {{data.resource.name}}</div></template>
-							</VTooltip>
-						</NuxtLink>
-					</template>
-				</Column>
-
-				<!-- Delete -->
-				<Column
-					header="Delete"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-								:aria-label="`Delete ${data.resource.name}`"
-								@click="agentToDelete = data.resource"
-							>
-								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
-							<template #popper><div role="tooltip">Delete {{data.resource.name}}</div></template>
-						</VTooltip>
-					</template>
-				</Column>
-
-				<!-- Set Default -->
-				<Column
-					header="Set Default"
-					header-style="width:6rem"
-					style="text-align: center"
-					:pt="{
-						headerCell: {
-							style: { backgroundColor: 'var(--primary-color)', color: 'var(--primary-text)' },
-						},
-						headerContent: { style: { justifyContent: 'center' } },
-					}"
-				>
-					<template #body="{ data }">
-						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-							<Button
-								link
-								:disabled="!data.actions.includes('FoundationaLLM.Agent/agents/delete')"
-								:aria-label="`Set ${data.resource.name} as default`"
-								@click="agentToSetAsDefault = data.resource"
-							>
-								<i class="pi pi-star" style="font-size: 1.2rem" aria-hidden="true"></i>
-							</Button>
-							<template #popper><div role="tooltip">Set {{data.resource.name}} as default agent</div></template>
-						</VTooltip>
-					</template>
-				</Column>
-			</DataTable>
-		</div>
-
-		<!-- Delete agent dialog -->
-		<Dialog :visible="agentToDelete !== null" modal v-focustrap header="Delete Agent" :closable="false">
-			<p>Do you want to delete the agent "{{ agentToDelete.name }}" ?</p>
-			<template #footer>
-				<Button label="Cancel" text @click="agentToDelete = null" />
-				<Button label="Delete" severity="danger" autofocus @click="handleDeleteAgent" />
-			</template>
-		</Dialog>
-
-		<!-- Set default agent dialog -->
-		<Dialog :visible="agentToSetAsDefault !== null" modal v-focustrap header="Set Default Agent" :closable="false">
-			<p>Do you want to set the "{{ agentToSetAsDefault.name }}" agent as default?<br />Default agents are automatically
-				selected in the User Portal for new conversations.
-			</p>
-			<template #footer>
-				<Button label="Cancel" text @click="agentToSetAsDefault = null" />
-				<Button label="Set as Default" severity="info" autofocus @click="handleSetDefaultAgent" />
-			</template>
-		</Dialog>
-	</main>
+        <AgentsList
+            :agents="agents"
+            :loading="loading"
+            :loadingStatusText="loadingStatusText"
+            @refreshAgents="getAgents"
+        />
+    </main>
 </template>
 
 <script lang="ts">
 import api from '@/js/api';
+import AgentsList from '@/components/AgentsList.vue';
 import type {
-	Agent,
-	ResourceProviderGetResult,
-	ResourceProviderActionResult } from '@/js/types';
+    Agent,
+    ResourceProviderGetResult,
+} from '@/js/types';
 
 export default {
-	name: 'PublicAgents',
+    name: 'PublicAgents',
 
-	data() {
-		return {
-			agents: [] as ResourceProviderGetResult<Agent>[],
-			loading: false as boolean,
-			loadingStatusText: 'Retrieving data...' as string,
-			agentToDelete: null as Agent | null,
-			agentToSetAsDefault: null as Agent | null,
-			accessControlModalOpen: false,
-		};
-	},
+    components: {
+        AgentsList,
+    },
 
-	async created() {
-		await this.getAgents();
-	},
+    data() {
+        return {
+            agents: [] as ResourceProviderGetResult<Agent>[],
+            loading: false as boolean,
+            loadingStatusText: 'Retrieving data...' as string,
+        };
+    },
 
-	methods: {
-		async getAgents() {
-			this.loading = true;
-			try {
-				this.agents = await api.getAgents();
-			} catch (error) {
-				this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-			this.loading = false;
-		},
+    async created() {
+        await this.getAgents();
+    },
 
-		async handleDeleteAgent() {
-			try {
-				await api.deleteAgent(this.agentToDelete!.name);
-				this.agentToDelete = null;
-			} catch (error) {
-				return this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-
-			await this.getAgents();
-		},
-
-		async handleSetDefaultAgent() {
-			try {
-				let result: ResourceProviderActionResult = await api.setDefaultAgent(this.agentToSetAsDefault!.name);
-				if (result.isSuccessResult) {
-					this.$toast.add({
-						severity: 'success',
-						detail: `Agent "${this.agentToSetAsDefault!.name}" set as default.`,
-						life: 5000,
-					});
-				} else {
-					this.$toast.add({
-						severity: 'error',
-						detail: "Could not set the default agent. Please try again.",
-						life: 5000,
-					});
-				}
-				this.agentToSetAsDefault = null;
-			} catch (error) {
-				return this.$toast.add({
-					severity: 'error',
-					detail: error?.response?._data || error,
-					life: 5000,
-				});
-			}
-
-			await this.getAgents();
-		},
-	},
+    methods: {
+        async getAgents() {
+            this.loading = true;
+            try {
+                this.agents = await api.getAgents();
+            } catch (error) {
+                this.$toast.add({
+                    severity: 'error',
+                    detail: error?.response?._data || error,
+                    life: 5000,
+                });
+            }
+            this.loading = false;
+        },
+    },
 };
 </script>
 
-<style lang="scss">
-.table__button {
-	color: var(--primary-button-bg);
-}
-
-.steps {
-	display: grid;
-	grid-template-columns: minmax(auto, 50%) minmax(auto, 50%);
-	gap: 24px;
-	position: relative;
-}
-
-.grid--loading {
-	pointer-events: none;
-}
-
-.grid__loading-overlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	gap: 16px;
-	z-index: 10;
-	background-color: rgba(255, 255, 255, 0.9);
-	pointer-events: none;
-}
-</style>
+<style lang="scss"></style>

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -351,8 +351,12 @@ export const useAppStore = defineStore('app', {
 					// Default to the last selected agent to make the selection "sticky" across sessions.
 					selectedAgent = this.lastSelectedAgent;
 				} else {
-					// Default to the first agent in the list.
-					selectedAgent = this.agents[0];
+					// Find an agent in the list that is configured as the default agent.
+					selectedAgent = this.agents.find((agent) => agent.resource.properties?.default_resource);
+					if (!selectedAgent || selectedAgent.resource.properties?.default_resource !== 'true') {
+						// Default to the first agent in the list.
+						selectedAgent = this.agents[0];
+					}
 				}
 			}
 			return selectedAgent;


### PR DESCRIPTION
# Set default agent and other resources

## The issue or feature being addressed

Provides functionality to define a default resource at the resource provider references level. Uses this capability to set a default agent in the Management Portal and automatically selects it in the User Portal if no other agent is selected when starting a new conversation.

## Details on the issue fix or feature implementation

- Uses the `DefaultResourceName` on the Resource Provider reference store.
- Adds a standard resource provider Action to set the default resource name.
- Implements UX to set the default agent in the Management Portal.
- Adds a standard `default_resource` key to the top-level resource `properties` to a resource when retrieving a list of resources and a default resource name is defined.
- Updates the User Portal to select the default agent, if defined.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
