### PR TITLE
Fix cache settings and add content artifacts to message history

### DIFF
--- a/src/dotnet/Common/Models/Conversation/MessageHistoryItem.cs
+++ b/src/dotnet/Common/Models/Conversation/MessageHistoryItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using FoundationaLLM.Common.Models.Orchestration.Response;
+using System.Text.Json.Serialization;
 
 namespace FoundationaLLM.Common.Models.Conversation
 {
@@ -17,6 +18,16 @@ namespace FoundationaLLM.Common.Models.Conversation
         /// </summary>
         [JsonPropertyName("text")]
         public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list <see cref="ContentArtifact"/> objects.
+        /// </summary>
+        /// <remarks>
+        /// Not all content artifacts are loaded.
+        /// The content of the list depends on the content artifact types configured in the message history settings of the agent.
+        /// </remarks>
+        [JsonPropertyName("content_artifacts")]
+        public List<ContentArtifact>? ContentArtifacts { get; set; }
 
         /// <summary>
         /// Message history item

--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentConversationHistorySettings.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentConversationHistorySettings.cs
@@ -18,5 +18,11 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent
         /// </summary>
         [JsonPropertyName("max_history")]
         public int MaxHistory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comma separated list of content artifact types to store in the conversation history.
+        /// </summary>
+        [JsonPropertyName("history_content_artifact_types")]
+        public string? HistoryContentArtifactTypes { get; set; }
     }
 }

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -175,14 +175,15 @@ public partial class CoreService(
             ArgumentNullException.ThrowIfNull(completionRequest.SessionId);
             var operationStartTime = DateTime.UtcNow;
 
-            completionRequest = await PrepareCompletionRequest(completionRequest, true);
-
-            var conversationItems = await CreateConversationItemsAsync(instanceId, completionRequest, _userIdentity);
-
             var agentBase = await _agentResourceProvider.GetResourceAsync<AgentBase>(
                 instanceId,
                 completionRequest.AgentName!,
                 _userIdentity);
+
+            completionRequest = await PrepareCompletionRequest(completionRequest, agentBase, true);
+
+            var conversationItems = await CreateConversationItemsAsync(instanceId, completionRequest, _userIdentity);
+
             var agentOption = GetGatekeeperOption(instanceId, agentBase, completionRequest);
 
             await _cosmosDBService.UpsertLongRunningOperationContextAsync(new LongRunningOperationContext
@@ -195,7 +196,9 @@ public partial class CoreService(
                 AgentMessageId = conversationItems.AgentMessage.Id,
                 CompletionPromptId = conversationItems.CompletionPrompt.Id,
                 GatekeeperOverride = agentOption,
-                SemanticCacheSettings = agentBase.CacheSettings?.SemanticCacheSettings,
+                SemanticCacheSettings = (agentBase.CacheSettings?.SemanticCacheEnabled ?? false)
+                    ? agentBase.CacheSettings?.SemanticCacheSettings
+                    : null,
                 StartTime = operationStartTime,
                 UPN = _userIdentity.UPN!
             });
@@ -378,14 +381,15 @@ public partial class CoreService(
             ArgumentNullException.ThrowIfNull(completionRequest.SessionId);
             var operationStartTime = DateTime.UtcNow;
 
-            completionRequest = await PrepareCompletionRequest(completionRequest);
-
-            var conversationItems = await CreateConversationItemsAsync(instanceId, completionRequest, _userIdentity);
-
             var agentBase = await _agentResourceProvider.GetResourceAsync<AgentBase>(
                 instanceId,
                 completionRequest.AgentName!,
                 _userIdentity);
+
+            completionRequest = await PrepareCompletionRequest(completionRequest, agentBase);
+
+            var conversationItems = await CreateConversationItemsAsync(instanceId, completionRequest, _userIdentity);
+
             var agentOption = GetGatekeeperOption(instanceId, agentBase, completionRequest);
 
             // Generate the completion to return to the user.
@@ -429,12 +433,13 @@ public partial class CoreService(
     {
         try
         {
-            directCompletionRequest = await PrepareCompletionRequest(directCompletionRequest);
-
             var agentBase = await _agentResourceProvider.GetResourceAsync<AgentBase>(
                 instanceId,
                 directCompletionRequest.AgentName!,
                 _userIdentity);
+
+            directCompletionRequest = await PrepareCompletionRequest(directCompletionRequest, agentBase);
+
             var agentOption = GetGatekeeperOption(instanceId, agentBase, directCompletionRequest);
 
             // Generate the completion to return to the user.
@@ -912,13 +917,17 @@ public partial class CoreService(
     /// Pre-processing of incoming completion request.
     /// </summary>
     /// <param name="request">The completion request.</param>
+    /// <param name="agent">The <see cref="AgentBase"/> resource object.</param>
     /// <param name="longRunningOperation">Indicates whether this is a long-running operation.</param>
     /// <returns>The updated completion request with pre-processing applied.</returns>
-    private async Task<CompletionRequest> PrepareCompletionRequest(CompletionRequest request, bool longRunningOperation = false)
+    private async Task<CompletionRequest> PrepareCompletionRequest(CompletionRequest request, AgentBase agent, bool longRunningOperation = false)
     {
         request.OperationId = Guid.NewGuid().ToString();
         request.LongRunningOperation = longRunningOperation;
         List<MessageHistoryItem> messageHistoryList = [];
+        List<string> contentArtifactTypes = (agent.ConversationHistorySettings?.Enabled ?? false)
+            ? [.. (agent.ConversationHistorySettings.HistoryContentArtifactTypes ?? string.Empty).Split(",", StringSplitOptions.RemoveEmptyEntries)]
+            : [];
 
         // Retrieve conversation, including latest prompt.
         var messages = await _cosmosDBService.GetSessionMessagesAsync(request.SessionId!, _userIdentity.UPN!);
@@ -937,7 +946,11 @@ public partial class CoreService(
 
             if (!string.IsNullOrWhiteSpace(messageText))
             {
-                messageHistoryList.Add(new MessageHistoryItem(message.Sender, messageText));
+                var messageHistoryItem = new MessageHistoryItem(message.Sender, messageText)
+                {
+                    ContentArtifacts = message.ContentArtifacts?.Where(ca => contentArtifactTypes.Contains(ca.Type ?? string.Empty)).ToList()
+                };
+                messageHistoryList.Add(messageHistoryItem);
             }
         }
 

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -406,7 +406,9 @@ public partial class CoreService(
                     AgentMessageId = conversationItems.AgentMessage.Id,
                     CompletionPromptId = conversationItems.CompletionPrompt.Id,
                     GatekeeperOverride = agentOption,
-                    SemanticCacheSettings = agentBase.CacheSettings?.SemanticCacheSettings,
+                    SemanticCacheSettings = (agentBase.CacheSettings?.SemanticCacheEnabled ?? false)
+                        ? agentBase.CacheSettings?.SemanticCacheSettings
+                        : null,
                     StartTime = operationStartTime,
                     UPN = _userIdentity.UPN!
                 },


### PR DESCRIPTION
# Fix cache settings and add content artifacts to message history

## The issue or feature being addressed

Cache settings are incorrectly set in the long-running operation context.
The types of content artifacts included in the message history must be configurable.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
