### PR TITLE
User Portal: Handling cached responses

### DIFF
--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -203,7 +203,11 @@ export default {
 			// 	this.longRunningOperations.set(this.currentSession.id, true);
 			// 	await this.pollForCompletion(this.currentSession.id, operationId);
 			// } else {
-			await this.$appStore.sendMessage(text);
+			let waitForPolling = await this.$appStore.sendMessage(text);
+
+			if (!waitForPolling) {
+				this.isMessagePending = false;
+			}
 			// console.log(message);
 			// await this.$appStore.getMessages();
 			// }


### PR DESCRIPTION
# User Portal: Handling cached responses

## The issue or feature being addressed

When receiving a cached response to a completion request, save the cached message to the conversation's messages list and bypass the polling operation.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
