### PR TITLE
Update Certbot to use Ubuntu 22.04 and use RSA when calling Certbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,4 @@ deploy/quick-start/tools
 dist
 **/foundationallm-certificates.SecretProviderClass.json
 **/foundationallm_external_modules**
+certs.zip

--- a/deploy/common/docker/certbot-app/Dockerfile
+++ b/deploy/common/docker/certbot-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+FROM ubuntu:22.04
 
 ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="true"
@@ -13,7 +13,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 RUN bash /tmp/library-scripts/azcli-debian.sh
-RUN bash /tmp/library-scripts/install-certbot.sh
+RUN export DEBIAN_FRONTEND=noninteractive && bash /tmp/library-scripts/install-certbot.sh
 RUN bash /tmp/library-scripts/pwsh-debian.sh
 
 RUN rm -rf /tmp/library-scripts

--- a/deploy/common/docker/certbot-app/Makefile
+++ b/deploy/common/docker/certbot-app/Makefile
@@ -8,4 +8,4 @@ prepare:
 	cp -v ../../scripts/Function-Library.ps1 .
 
 pull:
-	docker pull mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+	docker pull ubuntu:22.04

--- a/deploy/common/docker/certbot-app/New-LetsEncryptCertificates.ps1
+++ b/deploy/common/docker/certbot-app/New-LetsEncryptCertificates.ps1
@@ -98,6 +98,8 @@ foreach ($basename in $basenames.GetEnumerator()) {
             --email $email `
             --authenticator dns-azure `
             --config-dir $directories["config"] `
+            --key-type rsa `
+            --cert-name $fqdn `
             --dns-azure-config /app/config/certbot.ini `
             --domain $fqdn `
             --keep-until-expiring `

--- a/deploy/common/docker/certbot-app/library-scripts/pwsh-debian.sh
+++ b/deploy/common/docker/certbot-app/library-scripts/pwsh-debian.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 # https://learn.microsoft.com/en-us/powershell/scripting/install/install-debian?view=powershell-7.4
-
 ###################################
 # Prerequisites
 
@@ -10,18 +9,18 @@ set -euo pipefail
 sudo apt-get update
 
 # Install pre-requisite packages.
-sudo apt-get install -y wget
+sudo apt-get install -y wget apt-transport-https software-properties-common
 
-# Get the version of Debian
+# Get the version of Ubuntu
 source /etc/os-release
 
-# Download the Microsoft repository GPG keys
-wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+# Download the Microsoft repository keys
+wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
 
-# Register the Microsoft repository GPG keys
+# Register the Microsoft repository keys
 sudo dpkg -i packages-microsoft-prod.deb
 
-# Delete the Microsoft repository GPG keys file
+# Delete the Microsoft repository keys file
 rm packages-microsoft-prod.deb
 
 # Update the list of packages after we added packages.microsoft.com


### PR DESCRIPTION
Update Certbot to use Ubuntu 22.04 and use RSA when calling Certbot

## The issue or feature being addressed

ECDSA certificates are not compatible with Azure FrontDoor

## Details on the issue fix or feature implementation

Update certbot script to request RSA certificates.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable


