### PR TITLE
Support passing of additional properties on exploded AI model objects

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -261,6 +261,23 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                                     foreach (var key in modelParamsDict!.Keys.Where(k => ModelParametersKeys.All.Contains(k)))
                                     {
                                         retrievedAIModel.ModelParameters[key] = modelParamsDict[key];
+                                    }                                  
+                                }
+
+                                // for every non-well known property, add it to the AIModel.Properties dictionary
+                                // Add non-well known properties to the AIModel.Properties dictionary
+                                retrievedAIModel.Properties ??= new Dictionary<string, string>();
+
+                                foreach (var (key, value) in resourceObjectId.Properties)
+                                {
+                                    if (key is ResourceObjectIdPropertyNames.ModelParameters or ResourceObjectIdPropertyNames.ObjectRole)
+                                    {
+                                        continue;
+                                    }
+
+                                    if (value != null)
+                                    {
+                                        retrievedAIModel.Properties[key] = value.ToString() ?? string.Empty;
                                     }
                                 }
 


### PR DESCRIPTION
# Support passing of additional properties on exploded AI model objects

## The issue or feature being addressed

Some external workflows depend on additional properties being passed into the AI Model in the exploded objects. This adds string properties to the retrieved ResourceBase.Properties dictionary for all non-well known keys.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
