### PR TITLE
Adds global and agent level settings for allowing file uploads in Chat

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -28,7 +28,7 @@ To support the event grid infrastructure, the following new App Configuration se
 	{
 		"key": "FoundationaLLM:Events:Profiles:GatewayAPI",
 		"label": null,
-		"value": "{\"EventProcessingCycleSeconds\":60,\"Topics\":[]}",
+		"value": "{\"EventProcessingCycleSeconds\": 5,\"Topics\": [{\"Name\": \"resource-providers\",\"SubscriptionPrefix\": \"rp-gateway\"}]}",
 		"content_type": "application/json",
 		"tags": {}
 	},
@@ -73,7 +73,8 @@ Added the following App Configuration value:
 
 |Name | Default value | Description |
 |--- | --- | --- |
-`FoundationaLLM:UserPortal:Authentication:Entra:TimeoutInMinutes` | `60` | The timeout in minutes for a user's auth token in the User Portal. |
+| `FoundationaLLM:UserPortal:Authentication:Entra:TimeoutInMinutes` | `60` | The timeout in minutes for a user's auth token in the User Portal. |
+| `FoundationaLLM:UserPortal:Configuration:ShowFileUpload` | `true` | Global setting to determine if file upload is allowed on chat messages. |
 
 ## Starting with 0.9.1-rc117
 

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -1626,6 +1626,14 @@
 				"value": "true",
 				"content_type": "",
 				"first_version": "0.9.0"
+			},
+			{
+				"name": "ShowFileUpload",
+				"description": "Global setting to determine if file upload is allowed on chat messages.",
+				"secret": "",
+				"value": "true",
+				"content_type": "",
+				"first_version": "0.9.0"
 			}
 		]
 	},

--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentBase.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentBase.cs
@@ -116,6 +116,12 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent
         public bool? ShowViewPrompt { get; set; } = true;
 
         /// <summary>
+        /// Indicates whether to show the file upload option on agent message input.
+        /// </summary>
+        [JsonPropertyName("show_file_upload")]
+        public bool? ShowFileUpload { get; set; } = true;
+
+        /// <summary>
         /// The object type of the agent.
         /// </summary>
         [JsonIgnore]

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -1212,6 +1212,13 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_UserPortal_Configuration_ShowViewPrompt =
             "FoundationaLLM:UserPortal:Configuration:ShowViewPrompt";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:UserPortal:Configuration:ShowFileUpload setting.
+        /// <para>Value description:<br/>Global setting to determine if file upload is allowed on chat messages.</para>
+        /// </summary>
+        public const string FoundationaLLM_UserPortal_Configuration_ShowFileUpload =
+            "FoundationaLLM:UserPortal:Configuration:ShowFileUpload";
 
         #endregion
 

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -967,6 +967,13 @@
             "tags": {}
         },
         {
+            "key": "FoundationaLLM:UserPortal:Configuration:ShowFileUpload",
+            "value": "true",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
             "key": "FoundationaLLM:ManagementPortal:Authentication:Entra:Instance",
             "value": "https://login.microsoftonline.com/",
             "label": null,

--- a/src/ui/ManagementPortal/js/types.ts
+++ b/src/ui/ManagementPortal/js/types.ts
@@ -68,6 +68,7 @@ export type Agent = ResourceBase & {
 	show_message_tokens?: boolean;
 	show_message_rating?: boolean;
 	show_view_prompt?: boolean;
+	show_file_upload?: boolean;
 
 	ai_model_object_id: string;
 
@@ -336,6 +337,7 @@ export type CreateAgentRequest = ResourceBase & {
 	show_message_tokens?: boolean;
 	show_message_rating?: boolean;
 	show_view_prompt?: boolean;
+	show_file_upload?: boolean;
 
 	ai_model_object_id: string;
 

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -727,10 +727,11 @@
 						aria-labelledby="aria-show-message-rating"
 					/>
 				</div>
-
+				
+				<div id="aria-show-view-prompt" class="step-header">Would you like to allow the user to see the message prompts?</div>
+				<div id="aria-show-file-upload" class="step-header">Would you like to allow the user to upload files?</div>
 				<!-- Show view prompt -->
-				<div id="aria-show-view-prompt" class="step-header span-2">Would you like to allow the user to see the message prompts?</div>
-				<div class="span-2">
+				<div>
 					<ToggleButton
 						v-model="showViewPrompt"
 						on-label="Yes"
@@ -738,6 +739,19 @@
 						off-label="No"
 						off-icon="pi pi-times-circle"
 						aria-labelledby="aria-show-view-prompt"
+					/>
+				</div>
+				
+				<!-- Show file upload -->
+				
+				<div>
+					<ToggleButton
+						v-model="showFileUpload"
+						on-label="Yes"
+						on-icon="pi pi-check-circle"
+						off-label="No"
+						off-icon="pi pi-times-circle"
+						aria-labelledby="aria-show-file-upload"
 					/>
 				</div>
 			</section>
@@ -897,6 +911,7 @@ const getDefaultFormValues = () => {
 		showMessageTokens: false as boolean,
 		showMessageRating: false as boolean,
 		showViewPrompt: false as boolean,
+		showFileUpload: false as boolean
 	};
 };
 
@@ -1187,6 +1202,7 @@ export default {
 			this.showMessageTokens = agent.show_message_tokens ?? false;
 			this.showMessageRating = agent.show_message_rating ?? false;
 			this.showViewPrompt = agent.show_view_prompt ?? false;
+			this.showFileUpload = agent.show_file_upload ?? false;
 		},
 
 		updateAgentWelcomeMessage(newContent: string) {
@@ -1324,7 +1340,7 @@ export default {
 			}
 
 			this.loading = true;
-			this.loadingStatusText = 'Creating agent...';
+			this.loadingStatusText = 'Saving agent...';
 
 			const promptRequest = {
 				type: 'multipart',
@@ -1401,6 +1417,7 @@ export default {
 					show_message_tokens: this.showMessageTokens,
 					show_message_rating: this.showMessageRating,
 					show_view_prompt: this.showViewPrompt,
+					show_file_upload: this.showFileUpload,
 
 					vectorization: {
 						dedicated_pipeline: this.dedicated_pipeline,

--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -28,6 +28,7 @@
 					style="height: 100%"
 					@click="toggle"
 					@keydown.esc="hideAllPoppers"
+					v-if="$appConfigStore.showFileUpload && $appStore.agentShowFileUpload"
 				/>
 				<OverlayPanel ref="menu" :dismissable="isMobile" style="max-width: 98%">
 					<div class="file-upload-header">

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -125,6 +125,7 @@ export interface Agent {
 	show_message_tokens?: boolean;
 	show_message_rating?: boolean;
 	show_view_prompt?: boolean;
+	show_file_upload?: boolean;
 }
 
 export interface CompletionRequest {

--- a/src/ui/UserPortal/server/api/config.ts
+++ b/src/ui/UserPortal/server/api/config.ts
@@ -40,6 +40,7 @@ const allowedKeys = [
 	'FoundationaLLM:UserPortal:Configuration:ShowMessageRating',
 	'FoundationaLLM:UserPortal:Configuration:ShowViewPrompt',
 	'FoundationaLLM:UserPortal:Configuration:ShowMessageTokens',
+	'FoundationaLLM:UserPortal:Configuration:ShowFileUpload',
 	'FoundationaLLM:APIEndpoints:CoreAPI:Configuration:AllowedUploadFileExtensions',
 ];
 

--- a/src/ui/UserPortal/stores/appConfigStore.ts
+++ b/src/ui/UserPortal/stores/appConfigStore.ts
@@ -37,6 +37,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 		showLastConversionOnStartup: null,
 		showMessageTokens: null,
 		showViewPrompt: null,
+		showFileUpload: null,
 
 		// Auth: These settings configure the MSAL authentication.
 		auth: {
@@ -92,6 +93,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				showLastConversionOnStartup,
 				showMessageTokens,
 				showViewPrompt,
+				showFileUpload,
 				authClientId,
 				authInstance,
 				authTenantId,
@@ -135,6 +137,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowLastConversationOnStartup', 'true'),
 				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowMessageTokens', 'true'),
 				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowViewPrompt', 'true'),
+				getConfigValueSafe('FoundationaLLM:UserPortal:Configuration:ShowFileUpload', 'true'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:ClientId'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:Instance'),
 				api.getConfigValue('FoundationaLLM:UserPortal:Authentication:Entra:TenantId'),
@@ -174,6 +177,7 @@ export const useAppConfigStore = defineStore('appConfig', {
 			this.showLastConversionOnStartup = JSON.parse(showLastConversionOnStartup.toLowerCase());
 			this.showMessageTokens = JSON.parse(showMessageTokens.toLowerCase());
 			this.showViewPrompt = JSON.parse(showViewPrompt.toLowerCase());
+			this.showFileUpload = JSON.parse(showFileUpload.toLowerCase());
 
 			this.auth.clientId = authClientId;
 			this.auth.instance = authInstance;

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -55,6 +55,10 @@ export const useAppStore = defineStore('app', {
 		agentShowViewPrompt(): boolean {
 			return this.lastSelectedAgent?.resource.show_view_prompt ?? true;
 		},
+
+		agentShowFileUpload(): boolean {
+			return this.lastSelectedAgent?.resource.show_file_upload ?? true;
+		}
 	},
 
 	actions: {


### PR DESCRIPTION
# Adds global and agent level settings for allowing file uploads in Chat

## The issue or feature being addressed

Addresses the need to enable or disable the file upload capabilities on a chat message.

Introduces a global system setting as well as agent-level property.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

