### PR TITLE
Populate OpenAI Assistant information in workflow

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -17,6 +17,7 @@ using FoundationaLLM.Common.Models.Events;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentAccessTokens;
+using FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentWorkflows;
 using FoundationaLLM.Common.Models.ResourceProviders.AIModel;
 using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
 using FoundationaLLM.Common.Models.ResourceProviders.Prompt;
@@ -220,7 +221,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
                             DataSourceObjectId = kmAgent.Vectorization.DataSourceObjectId!,
                             TextPartitioningProfileObjectId = kmAgent.Vectorization.TextPartitioningProfileObjectId!,
                             TextEmbeddingProfileObjectId = kmAgent.Vectorization.TextEmbeddingProfileObjectId!,
-                            IndexingProfileObjectId = kmAgent.Vectorization.IndexingProfileObjectIds[0]!,
+                            IndexingProfileObjectId = kmAgent.Vectorization.IndexingProfileObjectIds![0]!,
                             TriggerType = (VectorizationPipelineTriggerType)kmAgent.Vectorization.TriggerType!,
                             TriggerCronSchedule = kmAgent.Vectorization.TriggerCronSchedule
                         }),
@@ -235,12 +236,51 @@ namespace FoundationaLLM.Agent.ResourceProviders
                         StatusCodes.Status500InternalServerError);
             }
 
-            if (agent.HasCapability(AgentCapabilityCategoryNames.OpenAIAssistants))
+            if (agent.HasCapability(AgentCapabilityCategoryNames.OpenAIAssistants)
+                || (agent.Workflow != null && agent.Workflow is AzureOpenAIAssistantsAgentWorkflow))
             {
                 agent.Properties ??= [];
 
                 var openAIAssistantId = agent.Properties.GetValueOrDefault(
                     AgentPropertyNames.AzureOpenAIAssistantId);
+
+                var workflow = agent.Workflow as AzureOpenAIAssistantsAgentWorkflow;
+
+                if (workflow != null)
+                {
+                        openAIAssistantId = workflow.AssistantId;
+                }
+
+                #region Resolve various agent properties
+
+                AIModelBase agentAIModel = null!;
+                APIEndpointConfiguration agentAIModelAPIEndpoint = null!;
+                PromptBase agentPrompt = null!;
+
+                if (workflow == null)
+                {
+                    // Legacy path
+                    agentAIModel = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_AIModel)
+                        .GetResourceAsync<AIModelBase>(agent.AIModelObjectId!, userIdentity);
+                    agentPrompt = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_Prompt)
+                        .GetResourceAsync<PromptBase>(agent.PromptObjectId!, userIdentity);
+                }
+                else
+                {
+                    agentAIModel = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_AIModel)
+                                .GetResourceAsync<AIModelBase>(workflow.MainAIModelObjectId!, userIdentity);
+                    agentPrompt = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_Prompt)
+                                .GetResourceAsync<PromptBase>(workflow.MainPromptObjectId!, userIdentity);
+                }
+                agentAIModelAPIEndpoint = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_Configuration)
+                        .GetResourceAsync<APIEndpointConfiguration>(agentAIModel.EndpointObjectId!, userIdentity);
+
+                #endregion
+
+                var gatewayClient = new GatewayServiceClient(
+                   await _serviceProvider.GetRequiredService<IHttpClientFactoryService>()
+                       .CreateClient(HttpClientNames.GatewayAPI, userIdentity),
+                   _serviceProvider.GetRequiredService<ILogger<GatewayServiceClient>>());
 
                 if (string.IsNullOrWhiteSpace(openAIAssistantId))
                 {
@@ -252,23 +292,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
                         "Starting to create the Azure OpenAI assistant for agent {AgentName}",
                         agent.Name);
 
-                    #region Resolve various agent properties
-
-                    var agentAIModel = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_AIModel)
-                        .GetResourceAsync<AIModelBase>(agent.AIModelObjectId!, userIdentity);
-                    var agentAIModelAPIEndpoint = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_Configuration)
-                        .GetResourceAsync<APIEndpointConfiguration>(agentAIModel.EndpointObjectId!, userIdentity);
-                    var agentPrompt = await GetResourceProviderServiceByName(ResourceProviderNames.FoundationaLLM_Prompt)
-                        .GetResourceAsync<PromptBase>(agent.PromptObjectId!, userIdentity);
-
-                    #endregion
-
-                    #region Create Azure OpenAI Assistants assistant
-
-                    var gatewayClient = new GatewayServiceClient(
-                       await _serviceProvider.GetRequiredService<IHttpClientFactoryService>()
-                           .CreateClient(HttpClientNames.GatewayAPI, userIdentity),
-                       _serviceProvider.GetRequiredService<ILogger<GatewayServiceClient>>());
+                    #region Create Azure OpenAI Assistants assistant                                        
 
                     Dictionary<string, object> parameters = new()
                         {
@@ -297,8 +321,17 @@ namespace FoundationaLLM.Agent.ResourceProviders
                     _logger.LogInformation(
                         "The Azure OpenAI assistant {AssistantId} for agent {AgentName} was created successfuly.",
                         newOpenAIAssistantId, agent.Name);
-                    agent.Properties[AgentPropertyNames.AzureOpenAIAssistantId] = newOpenAIAssistantId;
 
+                    if (workflow == null)
+                    {
+                        // Legacy path
+                        agent.Properties[AgentPropertyNames.AzureOpenAIAssistantId] = newOpenAIAssistantId;                       
+                    }
+                    else
+                    {
+                        // Workflow path                        
+                        workflow.AssistantId = newOpenAIAssistantId;
+                    }
                     #endregion
                 }
             }

--- a/src/dotnet/Common/Models/ResourceProviders/Agent/AgentWorkflows/AgentWorkflowBase.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Agent/AgentWorkflows/AgentWorkflowBase.cs
@@ -60,5 +60,15 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentWorkflows
                 .FirstOrDefault(
                     roid => roid.HasObjectRole(ResourceObjectIdPropertyValues.MainModel))
                 ?.ObjectId;
+
+        /// <summary>
+        /// Gets the main prompt object identifier.
+        /// </summary>
+        [JsonIgnore]
+        public string? MainPromptObjectId =>
+            ResourceObjectIds.Values
+                .FirstOrDefault(
+                    roid => roid.HasObjectRole(ResourceObjectIdPropertyValues.MainPrompt))
+                ?.ObjectId;
     }
 }


### PR DESCRIPTION
# Populate OpenAI Assistant information in workflow

## The issue or feature being addressed

When an OpenAI-enabled assistant is created the assistant_id property of the workflow needs to be set to the value passed back from the assistant created in the OpenAI service.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable


