### PR TITLE
Fix orchestration selection logic and add Workflow prompt category

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/Prompt/PromptCategory.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/Prompt/PromptCategory.cs
@@ -11,6 +11,11 @@
         Agent,
 
         /// <summary>
+        /// Workflow prompt.
+        /// </summary>
+        Workflow,
+
+        /// <summary>
         /// Tool prompt.
         /// </summary>
         Tool

--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -92,11 +92,9 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
 
             if (result.Agent.AgentType == typeof(KnowledgeManagementAgent))
             {
-                var orchestrator = string.IsNullOrWhiteSpace(
-                    result.Agent.Workflow?.WorkflowHost
-                    ?? result.Agent.OrchestrationSettings?.Orchestrator) // TODO: Remove this fallback path after all agents are upgraded.
-                    ? LLMOrchestrationServiceNames.LangChain
-                    : result.Agent.OrchestrationSettings?.Orchestrator;
+                var orchestrator = !string.IsNullOrWhiteSpace(result.Agent.Workflow?.WorkflowHost)
+                    ? result.Agent.Workflow.WorkflowHost
+                    : result.Agent.OrchestrationSettings?.Orchestrator ?? LLMOrchestrationServiceNames.LangChain;
 
                 if (originalRequest.LongRunningOperation)
                 {

--- a/src/ui/ManagementPortal/components/Sidebar.vue
+++ b/src/ui/ManagementPortal/components/Sidebar.vue
@@ -43,7 +43,7 @@
 					<li><NuxtLink to="/agents/create" class="sidebar__item">Create New Agent</NuxtLink></li>
 					<li><NuxtLink to="/agents/public" class="sidebar__item">All Agents</NuxtLink></li>
 					<li><NuxtLink to="/agents/private" class="sidebar__item">My Agents</NuxtLink></li>
-					<li><NuxtLink to="/prompts" class="sidebar__item">Agent Prompts</NuxtLink></li>
+					<li><NuxtLink to="/prompts" class="sidebar__item">Prompts</NuxtLink></li>
 				</ul>
 				<!-- <div class="sidebar__item">Performance</div> -->
 

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -1666,7 +1666,7 @@ export default {
                 description: `System prompt for the ${this.agentName} agent`,
                 prefix: this.systemPrompt,
                 suffix: '',
-                category: 'Agent',
+                category: 'Workflow',
             };
 
 			const tokenTextPartitionRequest = {

--- a/src/ui/ManagementPortal/pages/prompts/create.vue
+++ b/src/ui/ManagementPortal/pages/prompts/create.vue
@@ -156,8 +156,8 @@ export default {
 
 			categoryOptions: [
 				{
-					label: 'Agent',
-					value: 'Agent',
+					label: 'Workflow',
+					value: 'Workflow',
 				},
 				{
 					label: 'Tool',


### PR DESCRIPTION
# Fix orchestration selection logic and add Workflow prompt category

## The issue or feature being addressed

Fixes a logic bug in the Orchestration API that is causing an issue when we use the new agent workflow approach and it attempts to select the orchestrator. Also adds the `Workflow` category to the Prompt resource and renames the Prompt menu item.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
