### PR TITLE
Prompt form cleanup and content artifact style update

### DIFF
--- a/src/dotnet/Common/Services/Storage/BlobStorageService.cs
+++ b/src/dotnet/Common/Services/Storage/BlobStorageService.cs
@@ -70,7 +70,7 @@ namespace FoundationaLLM.Common.Services.Storage
             var blobClient = containerClient.GetBlobClient(filePath);
             var blobLeaseClient = blobClient.GetBlobLeaseClient();
 
-            // We are using pessimistic conccurency by default.
+            // We are using pessimistic concurrency by default.
             // For more details, see https://learn.microsoft.com/en-us/azure/storage/blobs/concurrency-manage.
 
             BlobLease? blobLease = default;

--- a/src/ui/ManagementPortal/pages/prompts/create.vue
+++ b/src/ui/ManagementPortal/pages/prompts/create.vue
@@ -26,8 +26,8 @@
 			</template>
 
 			<div class="span-2">
-				<div id="aria-agent-name" class="step-header mb-2">Prompt name:</div>
-				<div id="aria-agent-name-desc" class="mb-2">
+				<div id="aria-prompt-name" class="step-header mb-2">Prompt name:</div>
+				<div id="aria-prompt-name-desc" class="mb-2">
 					No special characters or spaces, use letters and numbers with dashes and underscores only.
 				</div>
 				<div class="input-wrapper">
@@ -37,7 +37,7 @@
 						type="text"
 						class="w-100"
 						placeholder="Enter prompt name"
-						aria-labelledby="aria-agent-name aria-agent-name-desc"
+						aria-labelledby="aria-prompt-name aria-prompt-name-desc"
 						@input="handleNameInput"
 					/>
 					<span
@@ -88,8 +88,6 @@
 			<section aria-labelledby="system-prompt" class="span-2 steps">
 				<h3 class="step-section-header span-2" id="system-prompt">Prompt Prefix</h3>
 
-				<div id="aria-persona" class="step-header">What is the persona of the agent?</div>
-
 				<div class="span-2">
 					<Textarea
 						v-model="prompt.prefix"
@@ -104,9 +102,9 @@
 			</section>
 
 			<div class="span-2 d-flex justify-content-end" style="gap: 16px">
-				<!-- Create agent -->
+				<!-- Create prompt -->
 				<Button
-					:label="editPrompt ? 'Save Changes' : 'Create Agent Prompt'"
+					:label="editPrompt ? 'Save Changes' : 'Create Prompt'"
 					severity="primary"
 					:disabled="editable === false"
 					@click="handleCreatePrompt"

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -921,7 +921,7 @@ $textColor: #131833;
 	padding: 4px 8px;
 	cursor: pointer;
 	white-space: nowrap;
-	max-width: 20rem;
+	max-width: 25rem;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -921,6 +921,10 @@ $textColor: #131833;
 	padding: 4px 8px;
 	cursor: pointer;
 	white-space: nowrap;
+	max-width: 20rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .ratings {


### PR DESCRIPTION
# Prompt form cleanup and content artifact style update

## The issue or feature being addressed

Removes any agent references from the prompt form and restricts the width of the content artifact items so the text does not overflow.

## Details on the issue fix or feature implementation

{Detail}

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
