### PR TITLE
Handle invalid chat session query in url on startup + user portal toast improvements

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -603,11 +603,10 @@ export default {
 					currentFiles.uploadedFiles.push(file);
 				} catch (error) {
 					filesFailed += 1;
-					this.$toast.add({
+					this.$appStore.addToast({
 						severity: 'error',
 						summary: 'Error',
 						detail: `File upload failed for "${file.name}". ${error.message || error.title || ''}`,
-						life: this.$appStore.autoHideToasts ? 5000 : null,
 					});
 				} finally {
 					if (totalFiles === filesUploaded + filesFailed) {
@@ -618,11 +617,10 @@ export default {
 						this.alignOverlay();
 						this.toggle();
 						if (filesUploaded > 0) {
-							this.$toast.add({
+							this.$appStore.addToast({
 								severity: 'success',
 								summary: 'Success',
 								detail: `Successfully uploaded ${filesUploaded} file${totalFiles > 1 ? 's' : ''}.`,
-								life: this.$appStore.autoHideToasts ? 5000 : null,
 							});
 						}
 					}
@@ -721,11 +719,10 @@ export default {
 				if (fileAlreadyExists) return;
 
 				if (file.size > 536870912) {
-					this.$toast.add({
+					this.$appStore.addToast({
 						severity: 'error',
 						summary: 'Error',
 						detail: 'File size exceeds the limit of 512MB.',
-						life: this.$appStore.autoHideToasts ? 5000 : null,
 					});
 				} else if (allowedFileTypes && allowedFileTypes !== '') {
 					const fileExtension = file.name.split('.').pop()?.toLowerCase();
@@ -735,11 +732,10 @@ export default {
 						.includes(fileExtension);
 
 					if (!isFileTypeAllowed) {
-						this.$toast.add({
+						this.$appStore.addToast({
 							severity: 'error',
 							summary: 'Error',
 							detail: `File type not supported. File: ${file.name}`,
-							life: this.$appStore.autoHideToasts ? 5000 : null,
 						});
 					} else {
 						filteredFiles.push(file);
@@ -756,11 +752,10 @@ export default {
 					filteredFiles.length >
 				this.maxFiles
 			) {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'error',
 					summary: 'Error',
 					detail: `You can only upload a maximum of ${this.maxFiles} ${this.maxFiles === 1 ? 'file' : 'files'} at a time.`,
-					life: this.$appStore.autoHideToasts ? 5000 : null,
 				});
 				filteredFiles.splice(
 					this.maxFiles -
@@ -821,11 +816,10 @@ export default {
 		async oneDriveWorkSchoolConnect() {
 			this.connectingOneDrive = true;
 			await this.$appStore.oneDriveWorkSchoolConnect().then(() => {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'success',
 					summary: 'Success',
 					detail: `Your account is now connected to OneDrive.`,
-					life: this.$appStore.autoHideToasts ? 5000 : null,
 				});
 				this.connectingOneDrive = false;
 			});
@@ -834,11 +828,10 @@ export default {
 		async oneDriveWorkSchoolDisconnect() {
 			this.disconnectingOneDrive = true;
 			await this.$appStore.oneDriveWorkSchoolDisconnect().then(() => {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'success',
 					summary: 'Success',
 					detail: `Your account is now disconnected from OneDrive.`,
-					life: this.$appStore.autoHideToasts ? 5000 : null,
 				});
 				this.disconnectingOneDrive = false;
 			});

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -720,10 +720,9 @@ export default {
 			document.execCommand('copy');
 			document.body.removeChild(textarea);
 
-			this.$toast.add({
+			this.$appStore.addToast({
 				severity: 'success',
 				detail: 'Message copied to clipboard!',
-				life: this.$appStore.autoHideToasts ? 5000 : null,
 			});
 		},
 
@@ -734,10 +733,9 @@ export default {
 		handleRatingSubmit(message: Message) {
 			this.$emit('rate', { message });
 			this.isRatingModalVisible = false;
-			this.$toast.add({
+			this.$appStore.addToast({
 				severity: 'success',
 				detail: 'Rating submitted!',
-				life: this.$appStore.autoHideToasts ? 5000 : null,
 			});
 		},
 
@@ -762,7 +760,7 @@ export default {
 					fileName: link.dataset.filename || link.textContent,
 				};
 
-				fetchBlobUrl(content, this.$toast);
+				fetchBlobUrl(content);
 			}
 		},
 	},

--- a/src/ui/UserPortal/components/ChatMessageContentBlock.vue
+++ b/src/ui/UserPortal/components/ChatMessageContentBlock.vue
@@ -134,7 +134,7 @@ export default {
 		// },
 
 		async handleFileDownload(content) {
-			await fetchBlobUrl(content, this.$toast);
+			await fetchBlobUrl(content);
 		},
 	},
 };

--- a/src/ui/UserPortal/components/ChatSidebar.vue
+++ b/src/ui/UserPortal/components/ChatSidebar.vue
@@ -329,11 +329,11 @@ export default {
 			if (this.createProcessing) return;
 
 			if (this.debounceTimeout) {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'warn',
 					summary: 'Warning',
 					detail: 'Please wait before creating another session.',
-					life: this.$appStore.autoHideToasts ? 3000 : null,
+					life: 3000,
 				});
 				return;
 			}
@@ -348,11 +348,10 @@ export default {
 					this.debounceTimeout = null;
 				}, 2000);
 			} catch (error) {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'error',
 					summary: 'Error',
 					detail: 'Could not create a new session. Please try again.',
-					life: this.$appStore.autoHideToasts ? 5000 : null,
 				});
 			} finally {
 				this.createProcessing = false; // Re-enable the button
@@ -370,11 +369,10 @@ export default {
 				await this.$appStore.deleteSession(this.sessionToDelete!);
 				this.sessionToDelete = null;
 			} catch (error) {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'error',
 					summary: 'Error',
 					detail: 'Could not delete the session. Please try again.',
-					life: this.$appStore.autoHideToasts ? 5000 : null,
 				});
 			} finally {
 				this.deleteProcessing = false;

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -179,12 +179,12 @@ export default {
 
 			// Display an error toast message if agent is null or undefined.
 			if (!agent) {
-				this.$toast.add({
+				this.$appStore.addToast({
 					severity: 'info',
 					summary: 'Could not send message',
 					detail:
 						'Please select an agent and try again. If no agents are available, refresh the page.',
-					life: this.$appStore.autoHideToasts ? 8000 : null,
+					life: 8000,
 				});
 				this.isMessagePending = false;
 				return;

--- a/src/ui/UserPortal/components/CodeBlockHeader.vue
+++ b/src/ui/UserPortal/components/CodeBlockHeader.vue
@@ -35,10 +35,9 @@ export default {
 			document.execCommand('copy');
 			document.body.removeChild(textarea);
 
-			this.$toast.add({
+			this.$appStore.addToast({
 				severity: 'success',
 				detail: 'Copied to clipboard!',
-				life: this.$appStore.autoHideToasts ? 5000 : null,
 			});
 		},
 	},

--- a/src/ui/UserPortal/components/NavBar.vue
+++ b/src/ui/UserPortal/components/NavBar.vue
@@ -182,10 +182,9 @@ export default {
 				? `Agent changed to ${this.agentSelection!.label}`
 				: `Cleared agent hint selection`;
 
-			this.$toast.add({
+			this.$appStore.addToast({
 				severity: 'success',
 				detail: message,
-				life: this.$appStore.autoHideToasts ? 5000 : null,
 			});
 
 			if (this.$appStore.currentMessages?.length > 0) {
@@ -270,10 +269,9 @@ export default {
 		// 	const chatLink = `${window.location.origin}?chat=${this.currentSession!.id}`;
 		// 	navigator.clipboard.writeText(chatLink);
 
-		// 	this.$toast.add({
+		// 	this.$appStore.addToast({
 		// 		severity: 'success',
 		// 		detail: 'Chat link copied!',
-		// 		life: 5000,
 		// 	});
 		// },
 

--- a/src/ui/UserPortal/js/fileService.ts
+++ b/src/ui/UserPortal/js/fileService.ts
@@ -2,7 +2,7 @@ import { useAppStore } from '@/stores/appStore';
 import api from '@/js/api';
 import type { MessageContent } from '@/js/types';
 
-export async function fetchBlobUrl(content: MessageContent, toast: any) {
+export async function fetchBlobUrl(content: MessageContent) {
 	const appStore = useAppStore();
 	if (!content.blobUrl) {
 		content.loading = true;
@@ -12,11 +12,10 @@ export async function fetchBlobUrl(content: MessageContent, toast: any) {
 			content.blobUrl = URL.createObjectURL(blob);
 		} catch (error) {
 			console.error(`Failed to fetch content from ${content.value}`, error);
-			toast.add({
+			appStore.addToast({
 				severity: 'error',
 				summary: 'Error downloading file',
 				detail: `Failed to download "${content.fileName}". ${error.message || error}`,
-				life: appStore.autoHideToasts ? 5000 : null,
 			});
 			content.error = true;
 		} finally {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -100,9 +100,10 @@ export const useAppStore = defineStore('app', {
 
 			await this.getSessions();
 
-			// The session id may not correspond to an existing session, handle that case
+			// If the portal is configured to create a new session on startup, and there are
+			// no sessions (including if the requested session does not exist), create a temporary
+			// session.
 			const sessionExists = this.sessions.find((s: Session) => s.id === sessionId);
-
 			if (!appConfigStore.showLastConversionOnStartup && !sessionExists) {
 				this.sessions.unshift({
 					...this.getDefaultChatSessionProperties(),

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -117,9 +117,9 @@ export const useAppStore = defineStore('app', {
 
 			const requestedSession = this.sessions.find((s: Session) => s.id === sessionId);
 
-			// If there is an existing session matching the one requested in the url, select it
-			// otherwise, if showLastConversionOnStartup is true and there is a session available to show, select it
-			// otherwise, create a new session
+			// If there is an existing session matching the one requested in the url, select it.
+			// otherwise, if the portal is configured to show the previous session and it exists, select it.
+			// otherwise, (if there are no sessions) create a temporary session.
 			if (requestedSession) {
 				this.changeSession(requestedSession);
 			} else if (appConfigStore.showLastConversionOnStartup && this.sessions.length > 0) {

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -124,10 +124,9 @@ export const useAppStore = defineStore('app', {
 			} else if (appConfigStore.showLastConversionOnStartup && this.sessions.length > 0) {
 				this.changeSession(this.sessions[0]);
 			} else {
-				useNuxtApp().vueApp.config.globalProperties.$toast.add({
+				this.addToast({
 					severity: 'error',
-					summary: 'The requested session was not found.',
-					life: this.autoHideToasts ? 5000 : null,
+					detail: 'The requested session was not found.',
 				});
 
 				this.addTemporarySession();
@@ -720,6 +719,15 @@ export const useAppStore = defineStore('app', {
 
 		async getVirtualUser() {
 			return await api.getVirtualUser();
+		},
+
+		addToast(toastProperties: any) {
+			const lifeSeconds = toastProperties?.life ?? 5000;
+
+			useNuxtApp().vueApp.config.globalProperties.$toast.add({
+				...toastProperties,
+				life: this.autoHideToasts ? lifeSeconds : null,
+			});
 		},
 	},
 });

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -98,8 +98,13 @@ export const useAppStore = defineStore('app', {
 				return;
 			}
 
+			await this.getSessions();
+
+			// The session id may not correspond to an existing session, handle that case
 			const sessionIdQuery = useNuxtApp().$router.currentRoute.value.query.chat;
-			if (!appConfigStore.showLastConversionOnStartup && !sessionIdQuery) {
+			const sessionExists = this.sessions.find((s: Session) => s.id === sessionIdQuery);
+
+			if (!appConfigStore.showLastConversionOnStartup && !sessionExists) {
 				this.sessions.unshift({
 					...this.getDefaultChatSessionProperties(),
 					id: 'new',
@@ -109,14 +114,10 @@ export const useAppStore = defineStore('app', {
 
 				this.changeSession(this.sessions[0]);
 
-				this.sessions.push(...(await api.getSessions()));
-
 				await this.getUserProfiles();
 
 				return;
 			}
-
-			await this.getSessions();
 
 			// If there is an existing session matching the one requested in the url, select it
 			// otherwise, if showLastConversionOnStartup is true there is a session available to show, select it

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import type { ToastMessageOptions } from 'primevue/toast';
 import { useAppConfigStore } from './appConfigStore';
 import { useAuthStore } from './authStore';
 import type {
@@ -130,7 +131,7 @@ export const useAppStore = defineStore('app', {
 				});
 
 				this.addTemporarySession();
-				this.changeSession(this.sessions[0]);				
+				this.changeSession(this.sessions[0]);
 			}
 
 			await this.getUserProfiles();
@@ -721,12 +722,12 @@ export const useAppStore = defineStore('app', {
 			return await api.getVirtualUser();
 		},
 
-		addToast(toastProperties: any) {
+		addToast(toastProperties: ToastMessageOptions) {
 			const lifeSeconds = toastProperties?.life ?? 5000;
 
 			useNuxtApp().vueApp.config.globalProperties.$toast.add({
 				...toastProperties,
-				life: this.autoHideToasts ? lifeSeconds : null,
+				life: this.autoHideToasts ? lifeSeconds : undefined,
 			});
 		},
 	},

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -101,8 +101,7 @@ export const useAppStore = defineStore('app', {
 			await this.getSessions();
 
 			// The session id may not correspond to an existing session, handle that case
-			const sessionIdQuery = useNuxtApp().$router.currentRoute.value.query.chat;
-			const sessionExists = this.sessions.find((s: Session) => s.id === sessionIdQuery);
+			const sessionExists = this.sessions.find((s: Session) => s.id === sessionId);
 
 			if (!appConfigStore.showLastConversionOnStartup && !sessionExists) {
 				this.sessions.unshift({


### PR DESCRIPTION
# Handle invalid chat session query in url on startup

## The issue or feature being addressed
- If the session id in the url on startup is invalid, the user portal will be frozen in a loading state rather than creating a new session as intended.
- Move creation of toasts to appStore.addToast method so that user preferences relating to toasts (currently just whether or not to hide toasts after a timeout and what the default timeout is) are applied automatically, and to make it easier to create toasts outside of a component scope.

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
