### PR TITLE
Limit session messages by default from completion requests

### DIFF
--- a/src/dotnet/Common/Interfaces/IAzureCosmosDBService.cs
+++ b/src/dotnet/Common/Interfaces/IAzureCosmosDBService.cs
@@ -92,13 +92,15 @@ public interface IAzureCosmosDBService
 
     /// <summary>
     /// Gets a list of all current chat messages for a specified session identifier.
+    /// Messages are always sorted by TimeStamp in ascending order.
     /// </summary>
     /// <param name="sessionId">Chat session identifier used to filter messages.</param>
     /// <param name="upn">The user principal name used for retrieving the messages for
     /// the signed in user.</param>
+    /// <param name="max">If provided, limits the number of messages.</param>
     /// <param name="cancellationToken">Cancellation token for async calls.</param>
     /// <returns>List of chat message items for the specified session.</returns>
-    Task<List<Message>> GetSessionMessagesAsync(string sessionId, string upn, CancellationToken cancellationToken = default);
+    Task<List<Message>> GetSessionMessagesAsync(string sessionId, string upn, int? max = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a single conversation message by its identifier.


### PR DESCRIPTION
# Limit session messages by default from completion requests

## The issue or feature being addressed

Limits the number of messages to retrieve from a conversation when the conversation is enabled. Furthermore, it does not retrieve any messages when the conversation history is disabled or session ID is null.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
