### PR TITLE
Remove identity name from the cache key

### DIFF
--- a/src/dotnet/Common/Services/Cache/AuthorizationServiceClientCacheService.cs
+++ b/src/dotnet/Common/Services/Cache/AuthorizationServiceClientCacheService.cs
@@ -79,7 +79,7 @@ namespace FoundationaLLM.Common.Services.Cache
         {
             var resourcePaths = string.Join(",", authorizationRequest.ResourcePaths);
             var groupIds = string.Join(",", authorizationRequest.UserContext.SecurityGroupIds);
-            var userIdentity = $"{authorizationRequest.UserContext.SecurityPrincipalId}:{authorizationRequest.UserContext.UserPrincipalName}:{groupIds}";
+            var userIdentity = $"{authorizationRequest.UserContext.SecurityPrincipalId}:{groupIds}";
 
             var keyString = $"{authorizationRequest.Action}:{resourcePaths}:{authorizationRequest.ExpandResourceTypePaths}:{authorizationRequest.IncludeRoles}:{authorizationRequest.IncludeActions}:{userIdentity}";
 


### PR DESCRIPTION
# Remove identity name from the cache key

## The issue or feature being addressed

Remove the identity principal name since we do not use that for auth checks. This enables situations where we want to cache impersonation-based auth requests.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
