### PR TITLE
Fix maximum conversation history limit in python

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -527,7 +527,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
                 for tool in agent.tools:
                     tools.append(tool_factory.get_tool(agent.name, tool, request.objects, self.user_identity, self.config))
 
-            request.objects['message_history'] = request.message_history[:agent.conversation_history_settings.max_history]
+            request.objects['message_history'] = request.message_history[:agent.conversation_history_settings.max_history*2]
 
             # create the workflow
             workflow_factory = WorkflowFactory(self.plugin_manager)
@@ -540,7 +540,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
 
             # Get message history
             if agent.conversation_history_settings.enabled:
-                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
+                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history*2)
             else:
                 messages = []
 

--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -468,7 +468,7 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
             # Define the graph
             graph = create_react_agent(llm, tools=tools, state_modifier=self.prompt.prefix)
             if agent.conversation_history_settings.enabled:
-                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history)
+                messages = self._build_conversation_history_message_list(request.message_history, agent.conversation_history_settings.max_history*2)
             else:
                 messages = []
 


### PR DESCRIPTION
# Fix max conversation history in python

## Details on the issue fix or feature implementation

Limits the number of messages to retrieve from a conversation.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
