### PR TITLE
Improve operation id tracking

### DIFF
--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -946,7 +946,6 @@ public partial class CoreService(
     /// <returns>The updated completion request with pre-processing applied.</returns>
     private async Task<CompletionRequest> PrepareCompletionRequest(CompletionRequest request, AgentBase agent, bool longRunningOperation = false)
     {
-        request.OperationId = Guid.NewGuid().ToString();
         request.LongRunningOperation = longRunningOperation;
 
         if (string.IsNullOrWhiteSpace(request.SessionId) ||

--- a/src/dotnet/CoreAPI/Controllers/CompletionsController.cs
+++ b/src/dotnet/CoreAPI/Controllers/CompletionsController.cs
@@ -73,6 +73,10 @@ namespace FoundationaLLM.Core.API.Controllers
         [HttpPost("completions", Name = "GetCompletion")]
         public async Task<IActionResult> GetCompletion(string instanceId, [FromBody] CompletionRequest completionRequest)
         {
+            // Ensure we always have a deterministic way to track the operation.
+            if (string.IsNullOrWhiteSpace(completionRequest.OperationId))
+                completionRequest.OperationId = Guid.NewGuid().ToString().ToLower();
+
             using var telemetryActivity = TelemetryActivitySources.CoreAPIActivitySource.StartActivity(
                 TelemetryActivityNames.CoreAPI_Completions_GetCompletion,
                 ActivityKind.Server,
@@ -80,8 +84,8 @@ namespace FoundationaLLM.Core.API.Controllers
                 tags: new Dictionary<string, object?>
                 {
                     { TelemetryActivityTagNames.InstanceId, instanceId },
+                    { TelemetryActivityTagNames.OperationId, completionRequest.OperationId },
                     { TelemetryActivityTagNames.ConversationId, completionRequest.SessionId ?? "N/A" },
-                    { TelemetryActivityTagNames.OperationId, completionRequest.OperationId ?? "N/A" },
                     { TelemetryActivityTagNames.UPN, _callContext.CurrentUserIdentity?.UPN ?? "N/A" },
                     { TelemetryActivityTagNames.UserId, _callContext.CurrentUserIdentity?.UserId ?? "N/A" }
                 });
@@ -100,6 +104,10 @@ namespace FoundationaLLM.Core.API.Controllers
         [HttpPost("async-completions")]
         public async Task<ActionResult<LongRunningOperation>> StartCompletionOperation(string instanceId, CompletionRequest completionRequest)
         {
+            // Ensure we always have a deterministic way to track the operation.
+            if (string.IsNullOrWhiteSpace(completionRequest.OperationId))
+                completionRequest.OperationId = Guid.NewGuid().ToString().ToLower();
+
             using var telemetryActivity = TelemetryActivitySources.CoreAPIActivitySource.StartActivity(
                 TelemetryActivityNames.CoreAPI_AsyncCompletions_StartCompletionOperation,
                 ActivityKind.Server,
@@ -107,8 +115,8 @@ namespace FoundationaLLM.Core.API.Controllers
                 tags: new Dictionary<string, object?>
                 {
                     { TelemetryActivityTagNames.InstanceId, instanceId },
+                    { TelemetryActivityTagNames.OperationId, completionRequest.OperationId },
                     { TelemetryActivityTagNames.ConversationId, completionRequest.SessionId ?? "N/A" },
-                    { TelemetryActivityTagNames.OperationId, completionRequest.OperationId ?? "N/A" },
                     { TelemetryActivityTagNames.UPN, _callContext.CurrentUserIdentity?.UPN ?? "N/A" },
                     { TelemetryActivityTagNames.UserId, _callContext.CurrentUserIdentity?.UserId ?? "N/A" }
                 });


### PR DESCRIPTION
# Improve operation id tracking

## The issue or feature being addressed

The operation unique identifier is not guaranteed to be set before creating the first OpenTelemetry scope in Core API. This results in difficulties in tracing down individual FoundationaLLM operation ids.

## Details on the issue fix or feature implementation

Ensure the operation id is set on the completion request before creating the first OpenTelemetry span.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
