### PR TITLE
Improve inputs to the user prompt rewrite service

### DIFF
--- a/src/dotnet/Common/Models/Conversation/MessageHistoryItem.cs
+++ b/src/dotnet/Common/Models/Conversation/MessageHistoryItem.cs
@@ -4,20 +4,33 @@ using System.Text.Json.Serialization;
 namespace FoundationaLLM.Common.Models.Conversation
 {
     /// <summary>
-    /// Represents an historic message sender and text item.
+    /// Represents an item in the message history.
     /// </summary>
-    public class MessageHistoryItem
+    /// <param name="sender">The sender of the message (e.g., "Agent", "User")</param>
+    /// <param name="text">The message text.</param>
+    /// <param name="textRewrite">The rewritten message text.</param>
+    public class MessageHistoryItem(string sender, string text, string? textRewrite)
     {
         /// <summary>
         /// The sender of the message (e.g. "Agent", "User").
         /// </summary>
         [JsonPropertyName("sender")]
-        public string Sender { get; set; }
+        public string Sender { get; set; } = sender;
         /// <summary>
         /// The message text.
         /// </summary>
         [JsonPropertyName("text")]
-        public string Text { get; set; }
+        public string Text { get; set; } = text;
+
+        /// <summary>
+        /// Gets or sets the rewritten text.
+        /// </summary>
+        /// <remarks>
+        /// The rewritten text is filled in if the agent's text rewriting feature is enabled.
+        /// If set, it contains an unambiguous version of the original text.
+        /// </remarks>
+        [JsonPropertyName("text_rewrite")]
+        public string? TextRewrite { get; set; } = textRewrite;
 
         /// <summary>
         /// Gets or sets the list <see cref="ContentArtifact"/> objects.
@@ -28,16 +41,5 @@ namespace FoundationaLLM.Common.Models.Conversation
         /// </remarks>
         [JsonPropertyName("content_artifacts")]
         public List<ContentArtifact>? ContentArtifacts { get; set; }
-
-        /// <summary>
-        /// Message history item
-        /// </summary>
-        /// <param name="sender">The sender of the message (e.g., "Agent", "User")</param>
-        /// <param name="text">The message text.</param>
-        public MessageHistoryItem(string sender, string text)
-        {
-            Sender = sender;
-            Text = text;
-        }
     }
 }

--- a/src/dotnet/Common/Models/Orchestration/Request/LLMCompletionRequest.cs
+++ b/src/dotnet/Common/Models/Orchestration/Request/LLMCompletionRequest.cs
@@ -360,11 +360,5 @@ namespace FoundationaLLM.Common.Models.Orchestration.Request
                 return _indexingProfiles;
             }
         }
-
-        private void EnsureIsValid()
-        {
-            if (_valid)
-                throw new OrchestrationException("The request is either invalid or has not been validated yet.");
-        }
     }
 }

--- a/src/dotnet/Core/Services/CoreService.cs
+++ b/src/dotnet/Core/Services/CoreService.cs
@@ -964,6 +964,7 @@ public partial class CoreService(
         foreach (var message in messages)
         {
             var messageText = message.Text;
+            var messageTextRewrite = message.TextRewrite;
             if (message.Content is { Count: > 0 })
             {
                 StringBuilder text = new();
@@ -976,7 +977,7 @@ public partial class CoreService(
 
             if (!string.IsNullOrWhiteSpace(messageText))
             {
-                var messageHistoryItem = new MessageHistoryItem(message.Sender, messageText)
+                var messageHistoryItem = new MessageHistoryItem(message.Sender, messageText, messageTextRewrite)
                 {
                     ContentArtifacts = message.ContentArtifacts?.Where(ca => contentArtifactTypes.Contains(ca.Type ?? string.Empty)).ToList()
                 };

--- a/src/dotnet/Orchestration/Services/UserPromptRewriteService.cs
+++ b/src/dotnet/Orchestration/Services/UserPromptRewriteService.cs
@@ -38,7 +38,7 @@ namespace FoundationaLLM.Orchestration.Core.Services
         private readonly ILogger<UserPromptRewriteService> _logger;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SemanticCacheService"/> class.
+        /// Initializes a new instance of the <see cref="UserPromptRewriteService"/> class.
         /// </summary>
         /// <param name="resourceProviderServices">A list of <see cref="IResourceProviderService"/> resource providers hashed by resource provider name.</param>
         /// <param name="configuration">The <see cref="IConfiguration"/> used to retrieve app settings from configuration.</param>
@@ -126,7 +126,7 @@ namespace FoundationaLLM.Orchestration.Core.Services
                     .TakeLast(agentRewriter.Settings.UserPromptsWindowSize * 2)
                     .Select<MessageHistoryItem, ChatMessage>(m => m.Sender switch
                     {
-                        nameof(Participants.User) => new UserChatMessage(m.Text),
+                        nameof(Participants.User) => new UserChatMessage(m.TextRewrite ?? m.Text),
                         nameof(Participants.Agent) => new AssistantChatMessage(m.Text),
                         _ => throw new OrchestrationException($"Unknown message sender {m.Sender}.")
                     })

--- a/tests/dotnet/Common.Tests/Models/Chat/MessageHistoryItemTests.cs
+++ b/tests/dotnet/Common.Tests/Models/Chat/MessageHistoryItemTests.cs
@@ -50,7 +50,7 @@ namespace FoundationaLLM.Common.Tests.Models.Chat
 
         public MessageHistoryItem CreateMessageHistoryItem(string sender, string text)
         {
-            return new MessageHistoryItem(sender, text);
+            return new MessageHistoryItem(sender, text, text);
         }
     }
 }

--- a/tests/dotnet/Common.Tests/Models/Orchestration/CompletionRequestTests.cs
+++ b/tests/dotnet/Common.Tests/Models/Orchestration/CompletionRequestTests.cs
@@ -12,8 +12,8 @@ namespace FoundationaLLM.Common.Tests.Models.Orchestration
             string expectedPrompt = "Generate some text";
             var expectedMessageHistory = new List<MessageHistoryItem>
             {
-                new MessageHistoryItem("Sender_1", "Test"),
-                new MessageHistoryItem("Sender_2", "Test")
+                new MessageHistoryItem("Sender_1", "Test", "Test"),
+                new MessageHistoryItem("Sender_2", "Test", "Test")
             };
 
             // Act


### PR DESCRIPTION
# Improve inputs to the user prompt rewrite service

## The issue or feature being addressed

Conversations with multiple ambiguous questions impact the accuracy of the user prompt rewrite service.

## Details on the issue fix or feature implementation

Allow the user prompt rewrite service to use the rewrites of previous questions from the conversation history.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
