### PR TITLE
Fix LaTeX rendering in code blocks

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -213,11 +213,11 @@
 			modal
 			style="max-width: 85%"
 		>
-			<template #footer>
-				<p tabindex="0" style="overflow-x: auto;">
-					<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
-				</p>
+			<p tabindex="0" style="overflow-x: auto;">
+				<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
+			</p>
 
+			<template #footer>
 				<Button
 					:style="{
 						backgroundColor: $appConfigStore.primaryButtonBg,

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -123,7 +123,13 @@
 								:disabled="message.type === 'LoadingMessage'"
 								size="small"
 								text
-								:icon="message.rating === true ? 'pi pi-thumbs-up-fill' : message.rating === false ? 'pi pi-thumbs-down-fill' : 'pi pi-thumbs-up'"
+								:icon="
+									message.rating === true
+										? 'pi pi-thumbs-up-fill'
+										: message.rating === false
+											? 'pi pi-thumbs-down-fill'
+											: 'pi pi-thumbs-up'
+								"
 								label="Rate Message"
 								@click.stop="isRatingModalVisible = true"
 							/>
@@ -205,13 +211,13 @@
 			v-model:visible="selectedContentArtifact"
 			:header="selectedContentArtifact?.title"
 			modal
-			style="max-width: 85%;"
+			style="max-width: 85%"
 		>
-			<p tabindex="0" style="overflow-x: auto;">
-				<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
-			</p>
-
 			<template #footer>
+				<p tabindex="0" style="overflow-x: auto;">
+					<pre>{{ JSON.stringify(selectedContentArtifact, null, 2) }}</pre>
+				</p>
+
 				<Button
 					:style="{
 						backgroundColor: $appConfigStore.primaryButtonBg,
@@ -226,11 +232,7 @@
 		</Dialog>
 
 		<!-- Message Rating Modal -->
-		<Dialog
-			v-model:visible="isRatingModalVisible"
-			header="Rate Message"
-			modal
-		>
+		<Dialog v-model:visible="isRatingModalVisible" header="Rate Message" modal>
 			<label for="rating-textarea">Comments</label>
 			<Textarea
 				id="rating-textarea"
@@ -253,7 +255,7 @@
 					text
 					:icon="message.rating ? 'pi pi-thumbs-up-fill' : 'pi pi-thumbs-up'"
 					:label="message.rating ? 'Message Liked' : 'Like'"
-					@click="message.rating === true ? message.rating = null : message.rating = true"
+					@click="message.rating === true ? (message.rating = null) : (message.rating = true)"
 				/>
 			</span>
 
@@ -266,7 +268,7 @@
 					text
 					:icon="message.rating === false ? 'pi pi-thumbs-down-fill' : 'pi pi-thumbs-down'"
 					:label="message.rating === false ? 'Message Disliked' : 'Dislike'"
-					@click="message.rating === false ? message.rating = null : message.rating = false"
+					@click="message.rating === false ? (message.rating = null) : (message.rating = false)"
 				/>
 			</span>
 
@@ -412,11 +414,7 @@ export default {
 		},
 
 		messageDisplayStatus() {
-			if (
-				this.message.status === 'Failed' ||
-				(this.message.status === 'Completed')
-			)
-				return null;
+			if (this.message.status === 'Failed' || this.message.status === 'Completed') return null;
 
 			if (this.isRenderingMessage && this.messageContent.length > 0) return 'Responding';
 

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -307,7 +307,7 @@ import TimeAgo from '~/components/TimeAgo.vue';
 
 function processLatex(content) {
 	const blockLatexPattern = /\\\[\s*([\s\S]+?)\s*\\\]/g;
-	const inlineLatexPattern = /\\\(([\s\S]+?)\\\)/g;
+	const inlineLatexPattern = /\\\(\s*([\s\S]+?)\s*\\\)/g;
 
 	// Match triple & inline backticks
 	const codeBlockPattern = /```[\s\S]+?```|`[^`]+`/g;


### PR DESCRIPTION
# Fix LaTeX rendering in code blocks

## The issue or feature being addressed
- Do not parse LaTeX in markdown code blocks so LaTeX code examples render properly
- Update inlineLatexPattern regex to match inline LaTeX with spaces

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
