### PR TITLE
Promote FoundationaLLMContentSearchTool to core product

### DIFF
--- a/src/python/Experimental/requirements.txt
+++ b/src/python/Experimental/requirements.txt
@@ -6,7 +6,7 @@ azure-monitor-opentelemetry-exporter==1.0.0b28
 azure-search-documents==11.6.0b9
 azure-storage-blob==12.21.0
 boto3==1.36.13
-foundationallm==0.9.3rc15
+foundationallm==0.9.3rc16
 langchain==0.3.17
 langchain-aws==0.2.12
 langchain-experimental==0.3.4

--- a/src/python/PythonSDK/PythonSDK.pyproj
+++ b/src/python/PythonSDK/PythonSDK.pyproj
@@ -34,6 +34,7 @@
     <Compile Include="foundationallm\langchain\common\foundationallm_workflow_base.py" />
     <Compile Include="foundationallm\langchain\common\__init__.py" />
     <Compile Include="foundationallm\langchain\language_models\language_model_factory.py" />
+    <Compile Include="foundationallm\langchain\tools\foundationallm_content_search_tool.py" />
     <Compile Include="foundationallm\langchain\workflows\workflow_factory.py" />
     <Compile Include="foundationallm\langchain\workflows\__init__.py" />
     <Compile Include="foundationallm\models\agents\agent_tool.py" />

--- a/src/python/PythonSDK/foundationallm/langchain/tools/__init__.py
+++ b/src/python/PythonSDK/foundationallm/langchain/tools/__init__.py
@@ -1,2 +1,3 @@
 from .dalle_image_generation_tool import DALLEImageGenerationTool
+from .foundationallm_content_search_tool import FoundationaLLMContentSearchTool
 from .tool_factory import ToolFactory

--- a/src/python/PythonSDK/foundationallm/langchain/tools/foundationallm_content_search_tool.py
+++ b/src/python/PythonSDK/foundationallm/langchain/tools/foundationallm_content_search_tool.py
@@ -11,7 +11,8 @@ from foundationallm.models.constants import (
     AIModelResourceTypeNames,
     ResourceObjectIdPropertyNames,
     ResourceObjectIdPropertyValues,
-    ResourceProviderNames)
+    ResourceProviderNames,
+    VectorizationResourceTypeNames)
 from foundationallm.models.orchestration import CompletionRequestObjectKeys, ContentArtifact
 from foundationallm.models.resource_providers import ResourcePath
 from foundationallm.models.resource_providers.configuration import APIEndpointConfiguration
@@ -71,6 +72,7 @@ class FoundationaLLMContentSearchTool(FoundationaLLMToolBase):
         #    content = rag_prompt,
         #    source = "tool",
         #    type = "full_prompt"))
+        print(completion.content)
         return completion.content, content_artifacts
 
     def _get_document_retriever(self):
@@ -81,7 +83,7 @@ class FoundationaLLMContentSearchTool(FoundationaLLMToolBase):
 
         text_embedding_profile_definition = self.tool_config.get_resource_object_id_properties(
             ResourceProviderNames.FOUNDATIONALLM_VECTORIZATION,
-            "textEmbeddingProfiles",
+            VectorizationResourceTypeNames.EMBEDDING_PROFILE,
             ResourceObjectIdPropertyNames.OBJECT_ROLE,
             ResourceObjectIdPropertyValues.EMBEDDING_PROFILE)
         
@@ -94,13 +96,11 @@ class FoundationaLLMContentSearchTool(FoundationaLLMToolBase):
         text_embedding_model_name = text_embedding_profile.settings[EmbeddingProfileSettingsKeys.MODEL_NAME]
 
         # There can be multiple indexing_profile role objects in the resource object ids.        
-        indexing_profile_definitions = [
-            v for v in self.tool_config.resource_object_ids.values() \
-                if v.resource_path.resource_provider == ResourceProviderNames.FOUNDATIONALLM_VECTORIZATION \
-                    and v.resource_path.main_resource_type == "indexingProfiles" \
-                        and ResourceObjectIdPropertyNames.OBJECT_ROLE in v.properties \
-                            and v.properties[ResourceObjectIdPropertyNames.OBJECT_ROLE] == ResourceObjectIdPropertyValues.INDEXING_PROFILE
-        ]
+        indexing_profile_definitions = self.tool_config.get_many_resource_object_id_properties(
+            ResourceProviderNames.FOUNDATIONALLM_VECTORIZATION,
+            VectorizationResourceTypeNames.INDEXING_PROFILE,
+            ResourceObjectIdPropertyNames.OBJECT_ROLE,
+            ResourceObjectIdPropertyValues.INDEXING_PROFILE)
 
         # Only supporting GatewayTextEmbedding
         # Objects dictionary has the gateway API endpoint configuration by default.
@@ -153,4 +153,3 @@ class FoundationaLLMContentSearchTool(FoundationaLLMToolBase):
             ResourceObjectIdPropertyNames.OBJECT_ROLE,
             ResourceObjectIdPropertyValues.MAIN_MODEL)
         return language_model_factory.get_language_model(ai_model_definition.object_id)
-        

--- a/src/python/PythonSDK/foundationallm/langchain/tools/tool_factory.py
+++ b/src/python/PythonSDK/foundationallm/langchain/tools/tool_factory.py
@@ -5,7 +5,7 @@ Description: Factory class for creating tools based on the AgentTool configurati
 from foundationallm.config import Configuration, UserIdentity
 from foundationallm.langchain.common import FoundationaLLMToolBase
 from foundationallm.langchain.exceptions import LangChainException
-from foundationallm.langchain.tools import DALLEImageGenerationTool
+from foundationallm.langchain.tools import DALLEImageGenerationTool, FoundationaLLMContentSearchTool
 from foundationallm.models.agents import AgentTool
 from foundationallm.plugins import PluginManager, PluginManagerTypes
 
@@ -15,6 +15,7 @@ class ToolFactory:
     """
     FLLM_PACKAGE_NAME = "FoundationaLLM"
     DALLE_IMAGE_GENERATION_TOOL_NAME = "DALLEImageGeneration"
+    FOUNDATIONALLM_CONTENT_SEARCH_TOOL = "FoundationaLLMContentSearchTool"
 
     def __init__(self, plugin_manager: PluginManager):
         """
@@ -51,7 +52,10 @@ class ToolFactory:
                 case self.DALLE_IMAGE_GENERATION_TOOL_NAME:
                     tool = DALLEImageGenerationTool(tool_config, objects, user_identity, config)
                     self.plugin_manager.object_cache[cache_key] = tool
-                    return tool
+                case self.FOUNDATIONALLM_CONTENT_SEARCH_TOOL:
+                    tool = FoundationaLLMContentSearchTool(tool_config, objects, user_identity, config)
+            if tool is not None:
+                return tool
         else:
             tool_plugin_manager = None
 

--- a/src/python/PythonSDK/foundationallm/models/agents/resource_object_ids_model_base.py
+++ b/src/python/PythonSDK/foundationallm/models/agents/resource_object_ids_model_base.py
@@ -53,9 +53,9 @@ class ResourceObjectIdsModelBase(BaseModel):
             List[ResourceObjectIdProperties]: A list of resource object identifier properties.
         """
         return [
-            v for v in self.resource_object_ids.values()
-            if v.resource_path.resource_provider == resource_provider_name
-            and v.resource_path.main_resource_type == resource_type_name
-            and property_name in v.properties
-            and v.properties[property_name] == "value"
+            v for v in self.resource_object_ids.values() \
+                if v.resource_path.resource_provider == resource_provider_name \
+                    and v.resource_path.main_resource_type == resource_type_name \
+                        and property_name in v.properties \
+                            and v.properties[property_name] == property_value
         ]

--- a/src/python/PythonSDK/foundationallm/models/agents/resource_object_ids_model_base.py
+++ b/src/python/PythonSDK/foundationallm/models/agents/resource_object_ids_model_base.py
@@ -53,7 +53,7 @@ class ResourceObjectIdsModelBase(BaseModel):
             List[ResourceObjectIdProperties]: A list of resource object identifier properties.
         """
         return [
-            v for v in self.tool_config.resource_object_ids.values()
+            v for v in self.resource_object_ids.values()
             if v.resource_path.resource_provider == resource_provider_name
             and v.resource_path.main_resource_type == resource_type_name
             and property_name in v.properties

--- a/src/python/PythonSDK/foundationallm/models/constants/__init__.py
+++ b/src/python/PythonSDK/foundationallm/models/constants/__init__.py
@@ -5,3 +5,4 @@ from .resource_provider_names import ResourceProviderNames
 
 from .ai_model_resource_type_names import AIModelResourceTypeNames
 from .prompt_resource_type_names import PromptResourceTypeNames
+from .vectorization_resource_type_names import VectorizationResourceTypeNames


### PR DESCRIPTION
# Promote FoundationaLLMContentSearchTool to core product

## The issue or feature being addressed

Fixes error with ResourceObjectIdModelBase.get_many_resource_object_id_properties method.
Includes omission of vectorization resource provider type names constants.
Promote FoundationaLLMContentSearchTool to core product

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable
