### PR TITLE
Fix resource deletions not propagating through service instances

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/ResourceReference.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourceReference.cs
@@ -41,5 +41,57 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
         /// </remarks>
         [JsonIgnore]
         public virtual Type ResourceType { get; } = typeof(ResourceBase);
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ResourceReference"/> are equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="ResourceReference"/> to compare.</param>
+        /// <param name="right">The second <see cref="ResourceReference"/> to compare.</param>
+        /// <returns>true if the two <see cref="ResourceReference"/> instances are equal; otherwise, false.</returns>
+        public static bool operator ==(ResourceReference left, ResourceReference right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+
+            if (left is null || right is null)
+                return false;
+
+            return left.ObjectId == right.ObjectId &&
+                   left.Name == right.Name &&
+                   left.Filename == right.Filename &&
+                   left.Type == right.Type &&
+                   left.Deleted == right.Deleted;
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ResourceReference"/> are not equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="ResourceReference"/> to compare.</param>
+        /// <param name="right">The second <see cref="ResourceReference"/> to compare.</param>
+        /// <returns>true if the two <see cref="ResourceReference"/> instances are not equal; otherwise, false.</returns>
+        public static bool operator !=(ResourceReference left, ResourceReference right) =>
+            !(left == right);
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current <see cref="ResourceReference"/>.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current <see cref="ResourceReference"/>.</param>
+        /// <returns>true if the specified object is equal to the current <see cref="ResourceReference"/>; otherwise, false.</returns>
+        public override bool Equals(object? obj)
+        {
+            if (obj is ResourceReference other)
+            {
+                return this == other;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="ResourceReference"/>.</returns>
+        public override int GetHashCode() =>
+            HashCode.Combine(ObjectId, Name, Filename, Type, Deleted);
+
     }
 }

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderResourceReferenceStore`1.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderResourceReferenceStore`1.cs
@@ -310,7 +310,14 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
 
             foreach (var reference in persistedReferencesList.ResourceReferences)
             {
-                if (!_resourceReferences.ContainsKey(reference.Name))
+                if (_resourceReferences.TryGetValue(reference.Name, out var existingReference))
+                {
+                    if (!existingReference.Equals(reference))
+                    {
+                        _resourceReferences[reference.Name] = reference;
+                    }
+                }
+                else
                 {
                     _resourceReferences[reference.Name] = reference;
                 }


### PR DESCRIPTION
# Fix resource deletions not propagating through service instances

## The issue or feature being addressed

Other instances were not picking up the change when deleting a resource, such as an Agent. For example, the Agent would still appear in the User Portal after deleting it in the Management Portal, or it would reappear in the Management Portal when hitting a different instance of the Management API.

## Details on the issue fix or feature implementation

Adds custom equality operators to the `ResourceReference` class and evaluates in-memory resource references against the list of persisted references, updating the in-memory reference if it is different.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
