### PR TITLE
Fixing flawed implementation of MemoryCacheEntryOptions

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -3,6 +3,22 @@
 > [!NOTE]
 > This section is for changes that are not yet released but will affect future releases.
 
+## Starting with 0.9.4-rc100
+
+### Configuration changes
+
+## App configuration settings
+
+The following App Config properties make cache settings for the resource providers configurable:
+
+| Name | Description | Default Value  |
+|---|---|---|
+| `FoundationaLLM:ResourceProvidersCache:EnableCache` | Indicates whether resource providers should cache resources or not.| `true` |
+| `FoundationaLLM:ResourceProvidersCache:AbsoluteCacheExpirationSeconds` | Absolute cache expiration in seconds.| 300 |
+| `FoundationaLLM:ResourceProvidersCache:SlidingCacheExpirationSeconds` | Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed. This will not extend the entry lifetime beyond the absolute expiration (if set). | 120 |
+| `FoundationaLLM:ResourceProvidersCache:CacheSizeLimit` | The maximum number of items that can be stored in the cache. | 10000 |
+| `FoundationaLLM:ResourceProvidersCache:CacheExpirationScanFrequencySeconds` | Gets or sets the minimum length of time between successive scans for expired items in seconds. | 30 |
+
 ## Starting with 0.9.3-rc016
 
 ### Configuration Resource Provider
@@ -186,6 +202,7 @@ The following App Config properties make cache settings for the `AuthorizationSe
 
 | Name                              | Description                                                                                                                   | Default Value  |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------|
+| `FoundationaLLM:APIEndpoints:AuthorizationAPI:Essentials:EnableCache`    | Indicates whether calls to the Authorization API should be cached or not.                                                                                         | `false`    |
 | `FoundationaLLM:APIEndpoints:AuthorizationAPI:Essentials:AbsoluteCacheExpirationSeconds`    | Absolute cache expiration in seconds.                                                                                         | 300    |
 | `FoundationaLLM:APIEndpoints:AuthorizationAPI:Essentials:SlidingCacheExpirationSeconds`     | Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed. This will not extend the entry lifetime beyond the absolute expiration (if set). | 120    |
 | `FoundationaLLM:APIEndpoints:AuthorizationAPI:Essentials:CacheSizeLimit`                    | The maximum number of items that can be stored in the cache.                                                                   | 10000  |

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -9,6 +9,9 @@
 
 ## App configuration settings
 
+>[!IMPORTANT]
+> The App Config setting `FoundationaLLM:Instance:EnableResourceProvidersCache` is obsolete and should be removed from the App Config settings.
+
 The following App Config properties make cache settings for the resource providers configurable:
 
 | Name | Description | Default Value  |

--- a/src/dotnet/AIModel/ResourceProviders/AIModelResourceProviderService.cs
+++ b/src/dotnet/AIModel/ResourceProviders/AIModelResourceProviderService.cs
@@ -9,6 +9,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.Events;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
@@ -26,6 +27,7 @@ namespace FoundationaLLM.AIModel.ResourceProviders
     /// Implements the FoundationaLLM.AIModel resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -34,6 +36,7 @@ namespace FoundationaLLM.AIModel.ResourceProviders
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to provide loggers for logging.</param>
     public class AIModelResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_AIModel)] IStorageService storageService,
         IEventService eventService,
@@ -42,6 +45,7 @@ namespace FoundationaLLM.AIModel.ResourceProviders
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<AIModelReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/AIModel/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/AIModel/ResourceProviders/DependencyInjection.cs
@@ -4,6 +4,7 @@ using FoundationaLLM.AIModel.Validation;
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.AIModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,6 +32,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, AIModelResourceProviderService>(sp =>
                 new AIModelResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_AIModel),

--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -13,6 +13,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent.AgentAccessTokens;
@@ -37,6 +38,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
     /// Implements the FoundationaLLM.Agent resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -46,6 +48,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to provide loggers for logging.</param>
     public class AgentResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Agent)] IStorageService storageService,
         IEventService eventService,
@@ -55,6 +58,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<AgentReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/Agent/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Agent/ResourceProviders/DependencyInjection.cs
@@ -4,6 +4,7 @@ using FoundationaLLM.Agent.Validation.Metadata;
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Agent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -34,6 +35,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, AgentResourceProviderService>(sp =>
                 new AgentResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Agent),

--- a/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
+++ b/src/dotnet/Attachments/ResourceProviders/AttachmentResourceProviderService.cs
@@ -8,6 +8,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using FoundationaLLM.Common.Services.ResourceProviders;
@@ -23,6 +24,7 @@ namespace FoundationaLLM.Attachment.ResourceProviders
     /// Implements the FoundationaLLM.Attachment resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -32,6 +34,7 @@ namespace FoundationaLLM.Attachment.ResourceProviders
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to provide loggers for logging.</param>
     public class AttachmentResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Attachment)] IStorageService storageService,
         IEventService eventService,
@@ -41,6 +44,7 @@ namespace FoundationaLLM.Attachment.ResourceProviders
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<AttachmentReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/Attachments/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Attachments/ResourceProviders/DependencyInjection.cs
@@ -4,6 +4,7 @@ using FoundationaLLM.Attachment.Validation;
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,6 +32,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, AttachmentResourceProviderService>(sp =>
                 new AttachmentResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Attachment),

--- a/src/dotnet/Authorization/ResourceProviders/AuthorizationResourceProviderService.cs
+++ b/src/dotnet/Authorization/ResourceProviders/AuthorizationResourceProviderService.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 using FoundationaLLM.Common.Constants.Authentication;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 
 namespace FoundationaLLM.Authorization.ResourceProviders
 {
@@ -20,18 +21,21 @@ namespace FoundationaLLM.Authorization.ResourceProviders
     /// Implements the FoundationaLLM.Authorization resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationServiceClient">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="resourceValidatorFactory">The <see cref="IResourceValidatorFactory"/> providing the factory to create resource validators.</param>
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> of the main dependency injection container.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to provide loggers for logging.</param>
     public class AuthorizationResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationServiceClient,
         IResourceValidatorFactory resourceValidatorFactory,
         IServiceProvider serviceProvider,
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<ResourceReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationServiceClient,
             null,
             null,

--- a/src/dotnet/Authorization/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Authorization/ResourceProviders/DependencyInjection.cs
@@ -3,6 +3,7 @@ using FoundationaLLM.Authorization.ResourceProviders;
 using FoundationaLLM.Authorization.Validation;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,6 +28,10 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, AuthorizationResourceProviderService>(sp =>
                 new AuthorizationResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    Options.Create<ResourceProviderCacheSettings>(new ResourceProviderCacheSettings
+                    {
+                        EnableCache = false
+                    }),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IResourceValidatorFactory>(),
                     sp,

--- a/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
+++ b/src/dotnet/AzureOpenAI/ResourceProviders/AzureOpenAIResourceProviderService.cs
@@ -13,6 +13,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.AzureOpenAI;
 using FoundationaLLM.Common.Services.ResourceProviders;
@@ -29,6 +30,7 @@ namespace FoundationaLLM.AzureOpenAI.ResourceProviders
     /// Implements the FoundationaLLM.AzureOpenAI resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -38,6 +40,7 @@ namespace FoundationaLLM.AzureOpenAI.ResourceProviders
     /// <param name="logger">The <see cref="ILogger"/> used for logging.</param>
     public class AzureOpenAIResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_AzureOpenAI)] IStorageService storageService,
         IEventService eventService,
@@ -47,6 +50,7 @@ namespace FoundationaLLM.AzureOpenAI.ResourceProviders
         ILogger<AzureOpenAIResourceProviderService> logger)
         : ResourceProviderServiceBase<ResourceReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/AzureOpenAI/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/AzureOpenAI/ResourceProviders/DependencyInjection.cs
@@ -2,6 +2,7 @@
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -40,6 +41,7 @@ namespace FoundationaLLM
             services.AddSingleton<IResourceProviderService, AzureOpenAIResourceProviderService>(sp =>
                 new AzureOpenAIResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_AzureOpenAI),

--- a/src/dotnet/Common/Constants/Data/AppConfiguration.json
+++ b/src/dotnet/Common/Constants/Data/AppConfiguration.json
@@ -37,14 +37,6 @@
 				"value": "",
 				"content_type": "",
 				"first_version": "0.8.0"
-			},
-			{
-				"name": "EnableResourceProvidersCache",
-				"description": "Enable caching for resource providers.",
-				"secret": "",
-				"value": "false",
-				"content_type": "",
-				"first_version": "0.9.1"
 			}
 		]
 	},
@@ -112,6 +104,55 @@
 				"value": "{\\\"DynamicSessionsEndpoints\\\": []}",
 				"content_type": "application/json",
 				"first_version": "0.9.1"
+			}
+		]
+	},
+	{
+		"namespace": "ResourceProvidersCache",
+		"dependency_injection_key": null,
+		"configuration_section": {
+			"description": "Configuration section used to identify settings for resource providers caching."
+		},
+		"configuration_keys": [
+			{
+				"name": "EnableCache",
+				"description": "Setting that indicates whether the resource providers should use caching.",
+				"secret": "",
+				"value": "false",
+				"content_type": "",
+				"first_version": "0.9.4"
+			},
+			{
+				"name": "AbsoluteCacheExpirationSeconds",
+				"description": "Absolute cache expiration in seconds.",
+				"secret": "",
+				"value": "300",
+				"content_type": "",
+				"first_version": "0.9.4"
+			},
+			{
+				"name": "SlidingCacheExpirationSeconds",
+				"description": "Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed. This will not extend the entry lifetime beyond the absolute expiration (if set).",
+				"secret": "",
+				"value": "120",
+				"content_type": "",
+				"first_version": "0.9.4"
+			},
+			{
+				"name": "CacheSizeLimit",
+				"description": "The maximum number of items that can be stored in the cache.",
+				"secret": "",
+				"value": "10000",
+				"content_type": "",
+				"first_version": "0.9.4"
+			},
+			{
+				"name": "CacheExpirationScanFrequencySeconds",
+				"description": "Gets or sets the minimum length of time between successive scans for expired items in seconds.",
+				"secret": "",
+				"value": "30",
+				"content_type": "",
+				"first_version": "0.9.4"
 			}
 		]
 	},

--- a/src/dotnet/Common/Models/Cache/CacheSettings.cs
+++ b/src/dotnet/Common/Models/Cache/CacheSettings.cs
@@ -1,0 +1,32 @@
+﻿namespace FoundationaLLM.Common.Models.Cache
+{
+    /// <summary>
+    /// Provides a standard set of settings for caching.
+    /// </summary>
+    public record CacheSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether caching is enabled or not.
+        /// </summary>
+        public bool EnableCache { get; set; } = false;
+
+        /// <summary>
+        /// Absolute cache expiration in seconds.
+        /// </summary>
+        public double? AbsoluteCacheExpirationSeconds { get; set; } = 300;
+
+        /// Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed.
+        /// This will not extend the entry lifetime beyond the absolute expiration (if set).
+        public double? SlidingCacheExpirationSeconds { get; set; } = 120;
+
+        /// <summary>
+        /// The maximum number of items that can be stored in the cache.
+        /// </summary>
+        public long? CacheSizeLimit { get; set; } = 10000;
+
+        /// <summary>
+        /// Gets or sets the minimum length of time between successive scans for expired items in seconds.
+        /// </summary>
+        public double? CacheExpirationScanFrequencySeconds { get; set; } = 30;
+    }
+}

--- a/src/dotnet/Common/Models/Configuration/Authorization/AuthorizationServiceClientSettings.cs
+++ b/src/dotnet/Common/Models/Configuration/Authorization/AuthorizationServiceClientSettings.cs
@@ -1,9 +1,11 @@
-﻿namespace FoundationaLLM.Common.Models.Configuration.Authorization
+﻿using FoundationaLLM.Common.Models.Cache;
+
+namespace FoundationaLLM.Common.Models.Configuration.Authorization
 {
     /// <summary>
     /// Authorization service client settings
     /// </summary>
-    public record AuthorizationServiceClientSettings
+    public record AuthorizationServiceClientSettings : CacheSettings
     {
         /// <summary>
         /// Provides the API URL of the Authorization service.
@@ -14,29 +16,5 @@
         /// Provides the API scope of the Authorization service.
         /// </summary>
         public required string APIScope { get; set; }
-
-        /// <summary>
-        /// Indicates whether to use caching in the Authorization service client.
-        /// </summary>
-        public bool EnableCache { get; set; } = false;
-
-        /// <summary>
-        /// Absolute cache expiration in seconds.
-        /// </summary>
-        public double? AbsoluteCacheExpirationSeconds { get; set; } = 300;
-
-        /// Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed.
-        /// This will not extend the entry lifetime beyond the absolute expiration (if set).
-        public double? SlidingCacheExpirationSeconds { get; set; } = 120;
-
-        /// <summary>
-        /// The maximum number of items that can be stored in the cache.
-        /// </summary>
-        public long? CacheSizeLimit { get; set; } = 10000;
-
-        /// <summary>
-        /// Gets or sets the minimum length of time between successive scans for expired items in seconds.
-        /// </summary>
-        public double? CacheExpirationScanFrequencySeconds { get; set; } = 30;
     }
 }

--- a/src/dotnet/Common/Models/Configuration/Instance/InstanceSettings.cs
+++ b/src/dotnet/Common/Models/Configuration/Instance/InstanceSettings.cs
@@ -25,10 +25,5 @@
         /// The Regex pattern used to validate the values allowed as User Principal Name (UPN) substitutes in the X-USER-IDENTITY header.
         /// </summary>
         public string? IdentitySubstitutionUserPrincipalNamePattern { get; set; }
-
-        /// <summary>
-        /// Enabling caching for resource providers.
-        /// </summary>
-        public bool EnableResourceProvidersCache { get; set; } = false;
     }
 }

--- a/src/dotnet/Common/Models/Configuration/ResourceProviders/ResourceProviderCacheSettings.cs
+++ b/src/dotnet/Common/Models/Configuration/ResourceProviders/ResourceProviderCacheSettings.cs
@@ -1,0 +1,11 @@
+﻿using FoundationaLLM.Common.Models.Cache;
+
+namespace FoundationaLLM.Common.Models.Configuration.ResourceProviders
+{
+    /// <summary>
+    /// Provides settings for the resource provider cache.
+    /// </summary>
+    public record ResourceProviderCacheSettings : CacheSettings
+    {
+    }
+}

--- a/src/dotnet/Common/Services/Cache/DependencyInjection.cs
+++ b/src/dotnet/Common/Services/Cache/DependencyInjection.cs
@@ -1,0 +1,22 @@
+﻿using FoundationaLLM.Common.Constants.Configuration;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FoundationaLLM
+{
+    /// <summary>
+    /// Global dependency injection extensions.
+    /// </summary>
+    public static partial class DependencyInjection
+    {
+        /// <summary>
+        /// Registers the resource provider settings with the dependency injection container.
+        /// </summary>
+        /// <param name="builder">The application builder.</param>
+        public static void AddResourceProviderCacheSettings(this IHostApplicationBuilder builder) =>
+            builder.Services.AddOptions<ResourceProviderCacheSettings>()
+                .Bind(builder.Configuration.GetSection(
+                    AppConfigurationKeySections.FoundationaLLM_ResourceProvidersCache));
+    }
+}

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -10,6 +10,7 @@ using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Events;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.Events;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Services.Cache;
@@ -41,6 +42,7 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         private readonly bool _useInternalReferencesStore;
         private readonly SemaphoreSlim _lock = new(1, 1);
 
+        private readonly ResourceProviderCacheSettings _cacheSettings;
         private readonly IResourceProviderResourceCacheService? _resourceCache;
         private const string CACHE_WARMUP_FILE_NAME = "_cache_warmup.json";
 
@@ -121,6 +123,7 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         /// Creates a new instance of the resource provider.
         /// </summary>
         /// <param name="instanceSettings">The <see cref="InstanceSettings"/> that provides instance-wide settings.</param>
+        /// <param name="cacheSettings">The <see cref="ResourceProviderCacheSettings"/> that provides settings for the resource provider cache.</param>
         /// <param name="authorizationServiceClient">The <see cref="IAuthorizationServiceClient"/> providing authorization services to the resource provider.</param>
         /// <param name="storageService">The <see cref="IStorageService"/> providing storage services to the resource provider.</param>
         /// <param name="eventService">The <see cref="IEventService"/> providing event services to the resource provider.</param>
@@ -131,6 +134,7 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         /// <param name="useInternalReferencesStore">Indicates whether the resource provider should use the internal resource references store or provide one of its own.</param>
         public ResourceProviderServiceBase(
             InstanceSettings instanceSettings,
+            ResourceProviderCacheSettings cacheSettings,
             IAuthorizationServiceClient authorizationServiceClient,
             IStorageService storageService,
             IEventService eventService,
@@ -147,14 +151,17 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
             _logger = logger;
             _serviceProvider = serviceProvider;
             _instanceSettings = instanceSettings;
+            _cacheSettings = cacheSettings;
             _eventTypesToSubscribe = eventTypesToSubscribe;
             _useInternalReferencesStore = useInternalReferencesStore;
 
             logger.LogInformation("Resource provider caching {CacheStatusString} enabled.",
-                _instanceSettings.EnableResourceProvidersCache ? "is" : "is not");
+                _cacheSettings.EnableCache ? "is" : "is not");
 
-            if (_instanceSettings.EnableResourceProvidersCache)
-                _resourceCache = new ResourceProviderResourceCacheService(_logger);
+            if (_cacheSettings.EnableCache)
+                _resourceCache = new ResourceProviderResourceCacheService(
+                    _cacheSettings,
+                    _logger);
 
             _allowedResourceProviders = [_name];
             _allowedResourceTypes = GetResourceTypes();
@@ -229,7 +236,7 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         {
             try
             {
-                if (!_instanceSettings.EnableResourceProvidersCache)
+                if (!_cacheSettings.EnableCache)
                     return;
 
                 _logger.LogInformation("Starting to warm up the cache for the {ResourceProvider} resource provider...", _name);

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -203,10 +203,10 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
                     _localEventService.SubscribeToEventTypes(_eventTypesToSubscribe);
                     _localEventService.StartLocalEventProcessing(HandleEvents);
                 }
-
+                
                 _isInitialized = true;
 
-                if (_useInternalReferencesStore)
+                if (_useInternalReferencesStore && _cacheSettings.EnableCache)
                     await WarmupCache();
 
                 _logger.LogInformation("The {ResourceProvider} resource provider was successfully initialized.", _name);

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -206,7 +206,8 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
 
                 _isInitialized = true;
 
-                await WarmupCache();
+                if (_useInternalReferencesStore)
+                    await WarmupCache();
 
                 _logger.LogInformation("The {ResourceProvider} resource provider was successfully initialized.", _name);
             }

--- a/src/dotnet/Common/Templates/AppConfigurationKeyFilters.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeyFilters.cs
@@ -37,6 +37,12 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:Code:CodeExecution:*";
         
         /// <summary>
+        /// Filter for the configuration section used to identify settings for resource providers caching.
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache =
+            "FoundationaLLM:ResourceProvidersCache:*";
+        
+        /// <summary>
         /// Filter for the configuration section used to identify the storage settings for the FoundationaLLM.AIModel resource provider.
         /// </summary>
         public const string FoundationaLLM_ResourceProviders_AIModel_Storage =

--- a/src/dotnet/Common/Templates/AppConfigurationKeySections.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeySections.cs
@@ -37,6 +37,12 @@ namespace FoundationaLLM.Common.Constants.Configuration
             "FoundationaLLM:Code:CodeExecution";
         
         /// <summary>
+        /// Configuration section used to identify settings for resource providers caching.
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache =
+            "FoundationaLLM:ResourceProvidersCache";
+        
+        /// <summary>
         /// Configuration section used to identify the storage settings for the FoundationaLLM.AIModel resource provider.
         /// </summary>
         public const string FoundationaLLM_ResourceProviders_AIModel_Storage =

--- a/src/dotnet/Common/Templates/AppConfigurationKeys.cs
+++ b/src/dotnet/Common/Templates/AppConfigurationKeys.cs
@@ -41,13 +41,6 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_Instance_IdentitySubstitutionUserPrincipalNamePattern =
             "FoundationaLLM:Instance:IdentitySubstitutionUserPrincipalNamePattern";
-        
-        /// <summary>
-        /// The app configuration key for the FoundationaLLM:Instance:EnableResourceProvidersCache setting.
-        /// <para>Value description:<br/>Enable caching for resource providers.</para>
-        /// </summary>
-        public const string FoundationaLLM_Instance_EnableResourceProvidersCache =
-            "FoundationaLLM:Instance:EnableResourceProvidersCache";
 
         #endregion
 
@@ -95,6 +88,45 @@ namespace FoundationaLLM.Common.Constants.Configuration
         /// </summary>
         public const string FoundationaLLM_Code_CodeExecution_AzureContainerAppsDynamicSessions =
             "FoundationaLLM:Code:CodeExecution:AzureContainerAppsDynamicSessions";
+
+        #endregion
+
+        #region FoundationaLLM:ResourceProvidersCache
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:ResourceProvidersCache:EnableCache setting.
+        /// <para>Value description:<br/>Setting that indicates whether the resource providers should use caching.</para>
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache_EnableCache =
+            "FoundationaLLM:ResourceProvidersCache:EnableCache";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:ResourceProvidersCache:AbsoluteCacheExpirationSeconds setting.
+        /// <para>Value description:<br/>Absolute cache expiration in seconds.</para>
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache_AbsoluteCacheExpirationSeconds =
+            "FoundationaLLM:ResourceProvidersCache:AbsoluteCacheExpirationSeconds";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:ResourceProvidersCache:SlidingCacheExpirationSeconds setting.
+        /// <para>Value description:<br/>Sets how many seconds the cache entry can be inactive (e.g. not accessed) before it will be removed. This will not extend the entry lifetime beyond the absolute expiration (if set).</para>
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache_SlidingCacheExpirationSeconds =
+            "FoundationaLLM:ResourceProvidersCache:SlidingCacheExpirationSeconds";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:ResourceProvidersCache:CacheSizeLimit setting.
+        /// <para>Value description:<br/>The maximum number of items that can be stored in the cache.</para>
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache_CacheSizeLimit =
+            "FoundationaLLM:ResourceProvidersCache:CacheSizeLimit";
+        
+        /// <summary>
+        /// The app configuration key for the FoundationaLLM:ResourceProvidersCache:CacheExpirationScanFrequencySeconds setting.
+        /// <para>Value description:<br/>Gets or sets the minimum length of time between successive scans for expired items in seconds.</para>
+        /// </summary>
+        public const string FoundationaLLM_ResourceProvidersCache_CacheExpirationScanFrequencySeconds =
+            "FoundationaLLM:ResourceProvidersCache:CacheExpirationScanFrequencySeconds";
 
         #endregion
 

--- a/src/dotnet/Common/Templates/appconfig.template.json
+++ b/src/dotnet/Common/Templates/appconfig.template.json
@@ -36,13 +36,6 @@
             "tags": {}
         },
         {
-            "key": "FoundationaLLM:Instance:EnableResourceProvidersCache",
-            "value": "false",
-            "label": null,
-            "content_type": "",
-            "tags": {}
-        },
-        {
             "key": "FoundationaLLM:Configuration:KeyVaultURI",
             "value": "${env:AZURE_KEY_VAULT_ENDPOINT}",
             "label": null,
@@ -75,6 +68,41 @@
             "value": "{\"DynamicSessionsEndpoints\": []}",
             "label": null,
             "content_type": "application/json",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:ResourceProvidersCache:EnableCache",
+            "value": "false",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:ResourceProvidersCache:AbsoluteCacheExpirationSeconds",
+            "value": "300",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:ResourceProvidersCache:SlidingCacheExpirationSeconds",
+            "value": "120",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:ResourceProvidersCache:CacheSizeLimit",
+            "value": "10000",
+            "label": null,
+            "content_type": "",
+            "tags": {}
+        },
+        {
+            "key": "FoundationaLLM:ResourceProvidersCache:CacheExpirationScanFrequencySeconds",
+            "value": "30",
+            "label": null,
+            "content_type": "",
             "tags": {}
         },
         {

--- a/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
+++ b/src/dotnet/Configuration/Services/ConfigurationResourceProviderService.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 
 namespace FoundationaLLM.Configuration.Services
 {
@@ -31,6 +32,7 @@ namespace FoundationaLLM.Configuration.Services
     /// Implements the FoundationaLLM.Configuration resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -42,6 +44,7 @@ namespace FoundationaLLM.Configuration.Services
     /// <param name="logger">The <see cref="ILogger"/> used for logging.</param>
     public class ConfigurationResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Configuration)] IStorageService storageService,
         IEventService eventService,
@@ -53,6 +56,7 @@ namespace FoundationaLLM.Configuration.Services
         ILogger<ConfigurationResourceProviderService> logger)
         : ResourceProviderServiceBase<APIEndpointReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/Configuration/Services/DependencyInjection.cs
+++ b/src/dotnet/Configuration/Services/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Services;
 using FoundationaLLM.Common.Services.Azure;
 using FoundationaLLM.Configuration.Services;
@@ -38,6 +39,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, ConfigurationResourceProviderService>(sp =>
                 new ConfigurationResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Configuration),

--- a/src/dotnet/Conversation/ResourceProviders/ConversationResourceProviderService.cs
+++ b/src/dotnet/Conversation/ResourceProviders/ConversationResourceProviderService.cs
@@ -12,6 +12,7 @@ using FoundationaLLM.Common.Services.Storage;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 
 namespace FoundationaLLM.Conversation.ResourceProviders
 {
@@ -19,6 +20,7 @@ namespace FoundationaLLM.Conversation.ResourceProviders
     /// Implements the FoundationaLLM.Conversation resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
     /// <param name="resourceValidatorFactory">The <see cref="IResourceValidatorFactory"/> providing the factory to create resource validators.</param>
@@ -27,6 +29,7 @@ namespace FoundationaLLM.Conversation.ResourceProviders
     /// <param name="logger">The <see cref="ILogger"/> used for logging.</param>
     public class ConversationResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         IEventService eventService,
         IResourceValidatorFactory resourceValidatorFactory,
@@ -35,6 +38,7 @@ namespace FoundationaLLM.Conversation.ResourceProviders
         ILogger<ConversationResourceProviderService> logger)
         : ResourceProviderServiceBase<ResourceReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             new NullStorageService(),
             eventService,

--- a/src/dotnet/Conversation/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Conversation/ResourceProviders/DependencyInjection.cs
@@ -1,5 +1,6 @@
 ﻿using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Conversation.ResourceProviders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,7 @@ namespace FoundationaLLM
             services.AddSingleton<IResourceProviderService, ConversationResourceProviderService>(sp =>
                 new ConversationResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEventService>(),
                     sp.GetRequiredService<IResourceValidatorFactory>(),

--- a/src/dotnet/CoreAPI/Program.cs
+++ b/src/dotnet/CoreAPI/Program.cs
@@ -48,6 +48,8 @@ namespace FoundationaLLM.Core.API
                 });
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Branding);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_CosmosDB);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_Entra);
@@ -95,8 +97,12 @@ namespace FoundationaLLM.Core.API
                 builder.Configuration,
                 AppConfigurationKeySections.FoundationaLLM_Events_Profiles_CoreAPI);
 
-            // Add resource providers
+            //----------------------------
+            // Resource providers
+            //----------------------------
+            builder.AddResourceProviderCacheSettings();
             builder.Services.AddSingleton<IResourceValidatorFactory, ResourceValidatorFactory>();
+
             builder.AddAgentResourceProvider();
             builder.AddAttachmentResourceProvider();
             builder.AddConfigurationResourceProvider();

--- a/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
+++ b/src/dotnet/DataSource/ResourceProviders/DataSourceResourceProviderService.cs
@@ -8,6 +8,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.Events;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.DataSource;
@@ -25,6 +26,7 @@ namespace FoundationaLLM.DataSource.ResourceProviders
     /// Implements the FoundationaLLM.DataSource resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -33,6 +35,7 @@ namespace FoundationaLLM.DataSource.ResourceProviders
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to provide loggers for logging.</param>
     public class DataSourceResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_DataSource)] IStorageService storageService,
         IEventService eventService,
@@ -41,6 +44,7 @@ namespace FoundationaLLM.DataSource.ResourceProviders
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<DataSourceReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/DataSource/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/DataSource/ResourceProviders/DependencyInjection.cs
@@ -2,6 +2,7 @@
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.DataSource;
 using FoundationaLLM.DataSource.ResourceProviders;
 using FoundationaLLM.DataSource.Validation;
@@ -35,6 +36,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, DataSourceResourceProviderService>(sp =>
                 new DataSourceResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_DataSource),

--- a/src/dotnet/GatekeeperAPI/Program.cs
+++ b/src/dotnet/GatekeeperAPI/Program.cs
@@ -47,6 +47,8 @@ namespace FoundationaLLM.Gatekeeper.API
                 });
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_GatekeeperAPI_Configuration);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_GatekeeperAPI_Essentials);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_CosmosDB);
@@ -90,8 +92,12 @@ namespace FoundationaLLM.Gatekeeper.API
                 builder.Configuration,
                 AppConfigurationKeySections.FoundationaLLM_Events_Profiles_GatekeeperAPI);
 
-            // Add resource providers
+            //----------------------------
+            // Resource providers
+            //----------------------------
+            builder.AddResourceProviderCacheSettings();
             builder.Services.AddSingleton<IResourceValidatorFactory, ResourceValidatorFactory>();
+
             builder.AddConfigurationResourceProvider();
 
             // Register the downstream services and HTTP clients.

--- a/src/dotnet/GatewayAPI/Program.cs
+++ b/src/dotnet/GatewayAPI/Program.cs
@@ -30,6 +30,8 @@ builder.Configuration.AddAzureAppConfiguration(options =>
     });
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+    options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_GatewayAPI_Essentials);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_GatewayAPI_Configuration);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_AuthorizationAPI_Essentials);
@@ -79,6 +81,8 @@ builder.AddAuthorizationServiceClient();
 //----------------------------
 // Resource providers
 //----------------------------
+builder.AddResourceProviderCacheSettings();
+
 builder.AddAgentResourceProvider();
 builder.AddAttachmentResourceProvider();
 builder.AddConfigurationResourceProvider();

--- a/src/dotnet/ManagementAPI/Program.cs
+++ b/src/dotnet/ManagementAPI/Program.cs
@@ -43,6 +43,8 @@ namespace FoundationaLLM.Management.API
 
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_CoreAPI_Configuration_CosmosDB);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Branding);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_ManagementAPI_Configuration_Entra);
@@ -98,6 +100,8 @@ namespace FoundationaLLM.Management.API
             //----------------------------
             // Resource providers
             //----------------------------
+            builder.AddResourceProviderCacheSettings();
+
             builder.AddAuthorizationResourceProvider();
             builder.AddConfigurationResourceProvider();
             builder.AddVectorizationResourceProvider();

--- a/src/dotnet/OrchestrationAPI/Program.cs
+++ b/src/dotnet/OrchestrationAPI/Program.cs
@@ -46,6 +46,7 @@ namespace FoundationaLLM.Orchestration.API
                 });
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
 
                 //TODO: Replace this with a more granular approach that would only bring in the configuration namespaces that are actually needed.
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints);
@@ -136,6 +137,8 @@ namespace FoundationaLLM.Orchestration.API
             //----------------------------
             // Resource providers
             //----------------------------
+            builder.AddResourceProviderCacheSettings();
+
             builder.AddAgentResourceProvider();
             builder.AddPromptResourceProvider();
             builder.AddVectorizationResourceProvider();

--- a/src/dotnet/Prompt/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Prompt/ResourceProviders/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Prompt.ResourceProviders;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -25,6 +26,7 @@ namespace FoundationaLLM
             builder.Services.AddSingleton<IResourceProviderService, PromptResourceProviderService>(sp =>
                 new PromptResourceProviderService(
                     sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Prompt),

--- a/src/dotnet/Prompt/ResourceProviders/PromptResourceProviderService.cs
+++ b/src/dotnet/Prompt/ResourceProviders/PromptResourceProviderService.cs
@@ -6,6 +6,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Prompt;
 using FoundationaLLM.Common.Services.ResourceProviders;
@@ -22,6 +23,7 @@ namespace FoundationaLLM.Prompt.ResourceProviders
     /// Implements the FoundationaLLM.Prompt resource provider.
     /// </summary>
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -30,6 +32,7 @@ namespace FoundationaLLM.Prompt.ResourceProviders
     /// <param name="logger">The <see cref="ILogger"/> used for logging.</param>
     public class PromptResourceProviderService(
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Prompt)] IStorageService storageService,
         IEventService eventService,
@@ -38,6 +41,7 @@ namespace FoundationaLLM.Prompt.ResourceProviders
         ILogger<PromptResourceProviderService> logger)
         : ResourceProviderServiceBase<PromptReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/SemanticKernelAPI/Program.cs
+++ b/src/dotnet/SemanticKernelAPI/Program.cs
@@ -45,6 +45,8 @@ namespace FoundationaLLM.SemanticKernel.API
                 });
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+                options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_Events_Profiles_VectorizationAPI);
                 options.Select(AppConfigurationKeyFilters.FoundationaLLM_APIEndpoints_SemanticKernelAPI_Configuration);
@@ -85,7 +87,11 @@ namespace FoundationaLLM.SemanticKernel.API
             // Add Azure ARM services
             builder.AddAzureResourceManager();
 
+            //----------------------------
             // Resource providers
+            //----------------------------
+            builder.AddResourceProviderCacheSettings();
+
             builder.AddConfigurationResourceProvider();
             builder.AddAIModelResourceProvider();
 

--- a/src/dotnet/Vectorization/ResourceProviders/DependencyInjection.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/DependencyInjection.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using FoundationaLLM.Common.Constants.Configuration;
 using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.Vectorization;
 using FoundationaLLM.Common.Models.Vectorization;
 using FoundationaLLM.Vectorization.ResourceProviders;
@@ -36,7 +37,8 @@ namespace FoundationaLLM
             // Register the resource provider services (cannot use Keyed singletons due to the Microsoft Identity package being incompatible):
             builder.Services.AddSingleton<IResourceProviderService>(sp => 
                 new VectorizationResourceProviderService(                   
-                    sp.GetRequiredService<IOptions<InstanceSettings>>(),                    
+                    sp.GetRequiredService<IOptions<InstanceSettings>>(),
+                    sp.GetRequiredService<IOptions<ResourceProviderCacheSettings>>(),
                     sp.GetRequiredService<IAuthorizationServiceClient>(),
                     sp.GetRequiredService<IEnumerable<IStorageService>>()
                         .Single(s => s.InstanceName == DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Vectorization),

--- a/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
+++ b/src/dotnet/Vectorization/ResourceProviders/VectorizationResourceProviderService.cs
@@ -9,6 +9,7 @@ using FoundationaLLM.Common.Interfaces;
 using FoundationaLLM.Common.Models.Authentication;
 using FoundationaLLM.Common.Models.Authorization;
 using FoundationaLLM.Common.Models.Configuration.Instance;
+using FoundationaLLM.Common.Models.Configuration.ResourceProviders;
 using FoundationaLLM.Common.Models.Events;
 using FoundationaLLM.Common.Models.ResourceProviders;
 using FoundationaLLM.Common.Models.ResourceProviders.DataSource;
@@ -32,6 +33,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
     /// Implements the FoundationaLLM.Vectorization resource provider.
     /// </summary>    
     /// <param name="instanceOptions">The options providing the <see cref="InstanceSettings"/> with instance settings.</param>    
+    /// <param name="cacheOptions">The options providing the <see cref="ResourceProviderCacheSettings"/> with settings for the resource provider cache.</param>
     /// <param name="authorizationService">The <see cref="IAuthorizationServiceClient"/> providing authorization services.</param>
     /// <param name="storageService">The <see cref="IStorageService"/> providing storage services.</param>
     /// <param name="eventService">The <see cref="IEventService"/> providing event services.</param>
@@ -40,6 +42,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
     /// <param name="loggerFactory">The factory responsible for creating loggers.</param>    
     public class VectorizationResourceProviderService(        
         IOptions<InstanceSettings> instanceOptions,
+        IOptions<ResourceProviderCacheSettings> cacheOptions,
         IAuthorizationServiceClient authorizationService,
         [FromKeyedServices(DependencyInjectionKeys.FoundationaLLM_ResourceProviders_Vectorization)] IStorageService storageService,
         IEventService eventService,
@@ -48,6 +51,7 @@ namespace FoundationaLLM.Vectorization.ResourceProviders
         ILoggerFactory loggerFactory)
         : ResourceProviderServiceBase<ResourceReference>(
             instanceOptions.Value,
+            cacheOptions.Value,
             authorizationService,
             storageService,
             eventService,

--- a/src/dotnet/VectorizationAPI/Program.cs
+++ b/src/dotnet/VectorizationAPI/Program.cs
@@ -47,6 +47,8 @@ builder.Configuration.AddAzureAppConfiguration(options =>
     });
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+    options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_Queues);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_Steps);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_StateService_Storage);
@@ -150,7 +152,11 @@ builder.Services.AddSingleton<IVectorizationRequestProcessor, LocalVectorization
 // Resource validation
 builder.Services.AddSingleton<IResourceValidatorFactory, ResourceValidatorFactory>();
 
+//----------------------------
 // Resource providers
+//----------------------------
+builder.AddResourceProviderCacheSettings();
+
 builder.AddConfigurationResourceProvider();
 builder.AddDataSourceResourceProvider();
 builder.AddVectorizationResourceProvider();

--- a/src/dotnet/VectorizationWorker/Program.cs
+++ b/src/dotnet/VectorizationWorker/Program.cs
@@ -43,6 +43,8 @@ builder.Configuration.AddAzureAppConfiguration(options =>
     });
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Instance);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Configuration);
+    options.Select(AppConfigurationKeyFilters.FoundationaLLM_ResourceProvidersCache);
+
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_Queues);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_Steps);
     options.Select(AppConfigurationKeyFilters.FoundationaLLM_Vectorization_StateService_Storage);
@@ -141,7 +143,11 @@ builder.Services.AddSingleton<IVectorizationStateService, BlobStorageVectorizati
 // Resource validation
 builder.Services.AddSingleton<IResourceValidatorFactory, ResourceValidatorFactory>();
 
-// Add resource providers
+//----------------------------
+// Resource providers
+//----------------------------
+builder.AddResourceProviderCacheSettings();
+
 builder.AddDataSourceResourceProvider();
 builder.AddConfigurationResourceProvider();
 builder.AddVectorizationResourceProvider();


### PR DESCRIPTION
# Fixing flawed implementation of MemoryCacheEntryOptions

## Details on the issue fix or feature implementation

Moving away from using a predefined `MemoryCacheEntryOptions` object to using a function to get a new instance of this every time an item is cached.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
