### PR TITLE
Agent editing and RBAC assignment fixes

### DIFF
--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -825,14 +825,23 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
         /// <remarks>
         /// See <see cref="EventTypes"/> for a list of event types.
         /// </remarks>
-        protected async Task SendResourceProviderEvent(string eventType, object? data= null) =>
-            // The CloudEvent source is automatically filled in by the event service.            
+        protected async Task SendResourceProviderEvent(string eventType, object? data = null)
+        {
+            if (_eventService == null)
+            {
+                _logger.LogWarning("The resource provider {ResourceProviderName} does not have an event service configured and cannot send events.", _name);
+                return;
+            }
+                
+            // The CloudEvent source is automatically filled in by the event service.
             await _eventService.SendEvent(
                 EventGridTopics.FoundationaLLM_Resource_Providers,
                 new CloudEvent(string.Empty, eventType, data ?? new { })
                 {
                     Subject = _name
                 });
+        }
+            
 
         private async Task HandleEvents(EventTypeEventArgs e)
         {

--- a/src/ui/ManagementPortal/js/api.ts
+++ b/src/ui/ManagementPortal/js/api.ts
@@ -481,49 +481,6 @@ export default {
 			`/instances/${this.instanceId}/providers/FoundationaLLM.Agent/agents/${agentId}?api-version=${this.apiVersion}`,
 		);
 
-		const agent = agentGetResult.resource as Agent;
-
-		const orchestratorTypeToKeyMap: { [key: string]: string } = {
-			LangChain: 'AzureOpenAI',
-			AzureOpenAIDirect: 'AzureOpenAI',
-			AzureAIDirect: 'AzureAI',
-		};
-
-		const orchestratorTypeKey =
-			orchestratorTypeToKeyMap[agent.orchestration_settings?.orchestrator];
-
-		// Retrieve all the app config values for the agent
-		const appConfigFilter = `FoundationaLLM:${orchestratorTypeKey}:${agent.name}:API:*`;
-		const appConfigResults = await this.getAppConfigs(appConfigFilter);
-
-		// Replace the orchestrator endpoint config keys with the real values
-		if (appConfigResults) {
-			for (const appConfigResult of appConfigResults) {
-				const appConfig = appConfigResult.resource;
-				const propertyName = appConfig.name.split(':').pop();
-				agent.orchestration_settings.endpoint_configuration[propertyName as string] = String(
-					appConfig.value,
-				);
-			}
-		} else {
-			for (const [configName /* configValue */] of Object.entries(agent.orchestration_settings)) {
-				const resolvedValue = await this.getAppConfig(
-					agent.orchestration_settings.endpoint_configuration[
-						configName as keyof typeof agent.orchestration_settings.endpoint_configuration
-					],
-				);
-				if (resolvedValue && resolvedValue.resource) {
-					agent.orchestration_settings.endpoint_configuration[configName] = String(
-						resolvedValue.resource.value,
-					);
-				} else {
-					agent.orchestration_settings.endpoint_configuration[configName] = '';
-				}
-			}
-		}
-
-		agentGetResult.resource = agent;
-
 		return agentGetResult;
 	},
 


### PR DESCRIPTION
# Agent editing and RBAC assignment fixes

## The issue or feature being addressed

Fixes errors when attempting to retrieve orchestration-related properties for an agent due to structural changes. Also, adds a null check to the `IEventService` since not all APIs, such as the AuthorizationAPI, registers this service. When saving RBAC, the ManagementAPI was returning a 500 error from the AuthorizationAPI since it attempts to send an Event Grid event after updating the resource.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
