### PR TITLE
Add Agent Access Token PBAC assignments to deployment artifacts

### DIFF
--- a/deploy/quick-start/azd-hooks/postprovision.ps1
+++ b/deploy/quick-start/azd-hooks/postprovision.ps1
@@ -78,6 +78,8 @@ $env:POLICYGUID03 = $($(New-Guid).Guid)
 $env:POLICYGUID04 = $($(New-Guid).Guid)
 $env:POLICYGUID05 = $($(New-Guid).Guid)
 $env:POLICYGUID06 = $($(New-Guid).Guid)
+$env:POLICYGUID07 = $($(New-Guid).Guid)
+$env:POLICYGUID08 = $($(New-Guid).Guid)
 
 Invoke-AndRequireSuccess "Create New OpenAI Assistant" {
     $accountInfo = $(az resource show --ids $env:AZURE_OPENAI_ID --query "{resourceGroup:resourceGroup,name:name}" | ConvertFrom-Json)

--- a/deploy/quick-start/data/policy-assignments/DefaultPolicyAssignments.template.json
+++ b/deploy/quick-start/data/policy-assignments/DefaultPolicyAssignments.template.json
@@ -84,6 +84,34 @@
             "updated_on": "${env:DEPLOY_TIME}",
             "created_by": "SYSTEM",
             "updated_by": "SYSTEM"
+        },
+        {
+            "name": "${env:POLICYGUID07}",
+            "type": "FoundationaLLM.Authorization/policyAssignments",
+            "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/${env:POLICYGUID07}",
+            "description": "Ownership on attachment resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.Attachment resource provider.",
+            "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+            "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+            "principal_type": "Group",
+            "scope": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.Attachment/attachments",
+            "created_on": "${env:DEPLOY_TIME}",
+            "updated_on": "${env:DEPLOY_TIME}",
+            "created_by": "SYSTEM",
+            "updated_by": "SYSTEM"
+        },
+        {
+            "name": "${env:POLICYGUID08}",
+            "type": "FoundationaLLM.Authorization/policyAssignments",
+            "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/${env:POLICYGUID08}",
+            "description": "Ownership on file mapping resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.AzureOpenAI resource provider.",
+            "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+            "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+            "principal_type": "Group",
+            "scope": "/instances/${env:FOUNDATIONALLM_INSTANCE_ID}/providers/FoundationaLLM.AzureOpenAI/fileMappings",
+            "created_on": "${env:DEPLOY_TIME}",
+            "updated_on": "${env:DEPLOY_TIME}",
+            "created_by": "SYSTEM",
+            "updated_by": "SYSTEM"
         }
     ]
   }

--- a/deploy/standard/azd-hooks/utility/Generate-Config.ps1
+++ b/deploy/standard/azd-hooks/utility/Generate-Config.ps1
@@ -250,6 +250,8 @@ $tokens.configReadAccessGuid3 = $(New-Guid).Guid
 $tokens.configReadAccessGuid4 = $(New-Guid).Guid
 $tokens.pbacConversationsOwnerGuid = $(New-Guid).Guid
 $tokens.pbacConversationMappingsGuid = $(New-Guid).Guid
+$tokens.pbacAttachmentsOwnerGuid = $(New-Guid).Guid
+$tokens.pbacFileMappingsGuid = $(New-Guid).Guid
 
 $tokens.subscriptionId = $subscriptionId
 $tokens.storageResourceGroup = $resourceGroups.storage

--- a/deploy/standard/data/policy-assignments/DefaultPolicyAssignments.template.json
+++ b/deploy/standard/data/policy-assignments/DefaultPolicyAssignments.template.json
@@ -84,6 +84,34 @@
             "updated_on": "{{deployTime}}",
             "created_by": "SYSTEM",
             "updated_by": "SYSTEM"
+        },
+        {
+            "name": "{{pbacAttachmentsOwnerGuid}}",
+            "type": "FoundationaLLM.Authorization/policyAssignments",
+            "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/{{pbacAttachmentsOwnerGuid}}",
+            "description": "Ownership on attachment resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.Attachment resource provider.",
+            "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+            "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+            "principal_type": "Group",
+            "scope": "/instances/{{instanceId}}/providers/FoundationaLLM.Attachment/attachments",
+            "created_on": "{{deployTime}}",
+            "updated_on": "{{deployTime}}",
+            "created_by": "SYSTEM",
+            "updated_by": "SYSTEM"
+        },
+        {
+            "name": "{{pbacFileMappingsGuid}}",
+            "type": "FoundationaLLM.Authorization/policyAssignments",
+            "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/{{pbacFileMappingsGuid}}",
+            "description": "Ownership on file mapping resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.AzureOpenAI resource provider.",
+            "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+            "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+            "principal_type": "Group",
+            "scope": "/instances/{{instanceId}}/providers/FoundationaLLM.AzureOpenAI/fileMappings",
+            "created_on": "{{deployTime}}",
+            "updated_on": "{{deployTime}}",
+            "created_by": "SYSTEM",
+            "updated_by": "SYSTEM"
         }
 	]
 }

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -56,6 +56,34 @@ This version introduces the concept of a well-known virtual security group (`All
     "updated_on": "{{deployTime}}",
     "created_by": "SYSTEM",
     "updated_by": "SYSTEM"
+},
+{
+    "name": "{{pbacAttachmentsOwnerGuid}}",
+    "type": "FoundationaLLM.Authorization/policyAssignments",
+    "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/{{pbacAttachmentsOwnerGuid}}",
+    "description": "Ownership on attachment resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.Attachment resource provider.",
+    "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+    "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+    "principal_type": "Group",
+    "scope": "/instances/{{instanceId}}/providers/FoundationaLLM.Attachment/attachments",
+    "created_on": "{{deployTime}}",
+    "updated_on": "{{deployTime}}",
+    "created_by": "SYSTEM",
+    "updated_by": "SYSTEM"
+},
+{
+    "name": "{{pbacFileMappingsGuid}}",
+    "type": "FoundationaLLM.Authorization/policyAssignments",
+    "object_id": "/providers/FoundationaLLM.Authorization/policyAssignments/{{pbacFileMappingsGuid}}",
+    "description": "Ownership on file mapping resources for AllAgentsVirtualSecurityGroup managed by the FoundationaLLM.AzureOpenAI resource provider.",
+    "policy_definition_id": "/providers/FoundationaLLM.Authorization/policyDefinitions/00000000-0000-0000-0001-000000000001",
+    "principal_id": "5bb493a2-5909-4771-93ba-d83b7b5a1de9",
+    "principal_type": "Group",
+    "scope": "/instances/{{instanceId}}/providers/FoundationaLLM.AzureOpenAI/fileMappings",
+    "created_on": "{{deployTime}}",
+    "updated_on": "{{deployTime}}",
+    "created_by": "SYSTEM",
+    "updated_by": "SYSTEM"
 }
 ```
 


### PR DESCRIPTION
# Add Agent Access Token PBAC assignments to deployment artifacts

## The issue or feature being addressed

Adds two new PBAC assignments to the All Agents well-known security group to allow file uploading when using Agent Access Tokens.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
