### PR TITLE
Update Set-AzdEnvAksVnet.ps1

### DIFF
--- a/deploy/common/scripts/Set-AzdEnvAksVnet.ps1
+++ b/deploy/common/scripts/Set-AzdEnvAksVnet.ps1
@@ -1,4 +1,4 @@
-#! /usr/bin/pwsh
+#!/usr/bin/pwsh
 <#
 .SYNOPSIS
 Sets the environment variables for Networking in the default environment file.
@@ -33,6 +33,7 @@ directory.
 
 #>
 
+# Parameters for setting environment variables for Networking
 Param(
 	[parameter(Mandatory = $false, HelpMessage = "CIDR block for the AKS Services - e.g., 10.100.0.0/16")][string]
 	$fllmAksServiceCidr = "10.100.0.0/16",
@@ -116,8 +117,9 @@ User Portal Hostname: $($hostnames["chatui"])
 Write-Host -ForegroundColor Yellow $message
 
 foreach ($value in $envValues.GetEnumerator()) {
-	Write-Host -ForegroundColor Yellow "Setting $($value.Name) to $($value.Value)"
-	azd env set $value.Name $value.Value
+	Invoke-CliCommand "Setting $($value.Name) to $($value.Value)" {
+		azd env set $value.Name $value.Value
+	}
 }
 
 $message = @"
@@ -129,3 +131,5 @@ Write-Host -ForegroundColor Blue $message
 Invoke-CliCommand "azd env get-values" {
 	azd env get-values
 }
+
+Stop-Transcript


### PR DESCRIPTION
# Update Set-AzdEnvAksVnet.ps1

## The issue or feature being addressed

This script fails on a clean install host because it tries to read the certs folder before the documentation has guided the user through creating that folder.

## Details on the issue fix or feature implementation

* Updates the script to prompt the user for the information it previously attempted to read from the certs folder.
* Creates the certs folder and subfolders to facilitate easier addition of certificates by users in a later step.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable


