### PR TITLE
Only return the roles scoped to the resource

### DIFF
--- a/src/dotnet/AuthorizationEngine/Services/AuthorizationCore.cs
+++ b/src/dotnet/AuthorizationEngine/Services/AuthorizationCore.cs
@@ -424,8 +424,9 @@ namespace FoundationaLLM.AuthorizationEngine.Services
                 if (authorizationRequest.IncludeRoles
                     && allRoleAssignments.Count > 0)
                 {
-                    // Include the display names of the roles in the result.
+                    // Include the display names of the roles in the result that match the scope of the resource.
                     result.Roles = allRoleAssignments
+                        .Where(ra => resourcePath.IncludesResourcePath(ra.ScopeResourcePath!))
                         .Select(ra => ra.RoleDefinition!.DisplayName!)
                         .Distinct()
                         .ToList();


### PR DESCRIPTION
# Only return the roles scoped to the resource

## The issue or feature being addressed

Only returns the scopes in the resource results that apply to the resource.

## Details on the issue fix or feature implementation

Resource results that return the list of roles for each resource should only include the roles that apply to the resource, as defined by the scope in the RBAC/PBAC policies. To better illustrate this example, when a user views the My Agents list in the Management Portal, they should only see the agents to which they have been assigned the Owner role. Without this fix, if they are assigned an owner to anything at all, then that role is included on every agent. This only impacts the visibility of roles on resources and not the enforcement thereof. Meaning, without this fix, they would not be able to save an agent for which they are not an owner. With this fix, they can only see the agents for which they are an owner within the My Agents list.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
