### PR TITLE
Fix input box being disabled on failed message

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -470,7 +470,7 @@ export default {
 			deep: true,
 			handler(newMessage, oldMessage) {
 				// There is an issue here if a message that is not the latest has an incomplete status
-				if (newMessage.status === 'Failed' || this.message.status === 'Completed') {
+				if (newMessage.status === 'Failed' || newMessage.status === 'Completed') {
 					this.computedAverageTimePerWord({ ...newMessage }, oldMessage ?? {});
 					this.handleMessageCompleted(newMessage);
 					return;

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -470,7 +470,7 @@ export default {
 			deep: true,
 			handler(newMessage, oldMessage) {
 				// There is an issue here if a message that is not the latest has an incomplete status
-				if (newMessage.status === 'Completed') {
+				if (newMessage.status === 'Failed' || this.message.status === 'Completed') {
 					this.computedAverageTimePerWord({ ...newMessage }, oldMessage ?? {});
 					this.handleMessageCompleted(newMessage);
 					return;


### PR DESCRIPTION
# Fix input box being disabled on failed message

## The issue or feature being addressed
- Fix input box being disabled on failed message

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
