### PR TITLE
Disable agent edit button if user does not have write access

### DIFF
--- a/src/ui/ManagementPortal/components/AgentsList.vue
+++ b/src/ui/ManagementPortal/components/AgentsList.vue
@@ -94,7 +94,13 @@
 				}"
 			>
 				<template #body="{ data }">
-					<NuxtLink :to="'/agents/edit/' + data.resource.name" class="table__button" tabindex="-1">
+					<NuxtLink
+						:to="'/agents/edit/' + data.resource.name"
+						class="table__button"
+						tabindex="-1"
+						:aria-disabled="!data.actions.includes('FoundationaLLM.Agent/agents/write')"
+						:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.Agent/agents/write') ? 'none' : 'auto' }"
+					>
 						<VTooltip :auto-hide="false" :popper-triggers="['hover']">
 							<Button
 								link


### PR DESCRIPTION
# Disable agent edit button if user does not have write access

## The issue or feature being addressed

Fixes an issue where users who do not have edit rights on an agent could still click on the edit button although it is grayed out.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
