### PR TITLE
Bugfixes for the Standard deployment templates

### DIFF
--- a/deploy/common/scripts/Set-AzdEnvEntra.ps1
+++ b/deploy/common/scripts/Set-AzdEnvEntra.ps1
@@ -56,7 +56,7 @@ from the ./foundationallm/deploy/standard directory:
 #>
 
 Param(
-   [parameter(Mandatory = $true, HelpMessage = "Azure EntraID Tenant")][string]$tenantID,
+   [parameter(Mandatory = $false, HelpMessage = "Azure EntraID Tenant")][string]$tenantID = $null,
    [string]$adminGroupName = 'FLLM-Admins',
    [string]$userGroupName = 'FLLM-Users',
    [string]$authAppName = 'FoundationaLLM-Authorization-API',
@@ -77,6 +77,13 @@ $ErrorActionPreference = "Stop"
 $ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Path
 . $ScriptDirectory/Function-Library.ps1
 
+# Retrieve the tenant ID from the current Azure account context if not provided
+if (-not $tenantID) {
+   $tenantID = (az account show --query 'tenantId' --output tsv)
+   if (-not $tenantID) {
+      throw "Unable to retrieve tenant ID from the current Azure account context. Please provide a tenant ID."
+   }
+}
 
 # Set the environment values
 Write-Host -ForegroundColor Blue "Please wait while gathering azd environment values for the ${tenantID} EntraID Tenant."

--- a/deploy/standard/azd-hooks/utility/Load-Certificates.ps1
+++ b/deploy/standard/azd-hooks/utility/Load-Certificates.ps1
@@ -1,9 +1,34 @@
 #! /usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Loads PFX certificates into an Azure Key Vault.
+
+.PARAMETER certificates
+    An array of certificate folder names containing the PFX files to be loaded.
+
+.PARAMETER keyVaultName
+    The name of the Azure Key Vault where the certificates will be imported.
+
+.DESCRIPTION
+    This script loads PFX certificates from specified folders into an Azure Key Vault.
+    It prompts the user for the password of each PFX file and imports the certificates
+    using the Azure CLI. If no password is provided, the certificate is imported without a password.
+
+.NOTES
+    - The script sets strict mode to version 3.0 and stops on any error.
+    - Debugging is disabled by default.
+    - Utility functions are loaded from 'Load-Utility-Functions.ps1'.
+    - The script expects the certificates to be located in the '../certs' directory relative to the script location.
+
+.EXAMPLE
+    .\Load-Certificates.ps1 -certificates @("cert1", "cert2") -keyVaultName "MyKeyVault"
+
+    This command loads the certificates from the 'cert1' and 'cert2' folders into the 'MyKeyVault' Azure Key Vault.
+#>
 
 param(
     [parameter(Mandatory = $true)][array]$certificates,
-    [parameter(Mandatory = $true)][string]$keyVaultName,
-    [parameter(Mandatory = $true)][string]$keyVaultResourceGroup # TODO remove unused parameter
+    [parameter(Mandatory = $true)][string]$keyVaultName
 )
 
 Set-StrictMode -Version 3.0
@@ -13,8 +38,10 @@ Set-PSDebug -Trace 0 # Echo every command (0 to disable, 1 to enable, 2 to enabl
 . ./utility/Load-Utility-Functions.ps1
 
 $directories = @{
-    "certs"  = "../certs"
+    "certs" = "../certs"
 }
+
+$pw = @{}
 
 foreach ($certificateFolder in $certificates) {
     $pfxPath = Join-Path $directories["certs"] $certificateFolder
@@ -22,8 +49,21 @@ foreach ($certificateFolder in $certificates) {
     $keyName = $certificateFolder
 
     $password = Read-Host "Enter password for $($pfx.FullName) certificate (Enter for none): " -AsSecureString
-    if ($password.Length -eq 0)
-    {
+
+    $pw[$certificateFolder] = @{
+        "pfx"      = $pfx
+        "keyName"  = $keyName
+        "password" = $password
+    }
+}
+
+foreach ($certificate in $pw.GetEnumerator()) {
+    $password = $certificate.Value.password
+    $certificateFolder = $certificate.Key
+    $pfx = $certificate.Value.pfx
+    $keyName = $certificate.Value.keyName
+
+    if ($password.Length -eq 0) {
         Invoke-AndRequireSuccess "Load PFX Certificate $($certificateFolder) into Azure Key Vault" {
             az keyvault certificate import `
                 --file $pfx `
@@ -31,8 +71,7 @@ foreach ($certificateFolder in $certificates) {
                 --vault-name $keyVaultName
         }
     }
-    else 
-    {
+    else {
         Invoke-AndRequireSuccess "Load PFX Certificate $($certificateFolder) into Azure Key Vault" {
             az keyvault certificate import `
                 --file $pfx `

--- a/deploy/standard/infra/modules/cosmosdb.bicep
+++ b/deploy/standard/infra/modules/cosmosdb.bicep
@@ -140,6 +140,7 @@ var containers = [
   }
   {
     name: 'Agents'
+    defaultTtl: null
     partitionKey: {
       paths: [
         '/instanceId'
@@ -304,7 +305,7 @@ resource cosmosContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
         }
 
         partitionKey: {
-          kind: 'Hash'
+          kind: length(c.partitionKey.paths) == 1 ? 'Hash' : 'MultiHash'
           paths: c.partitionKey.paths
           version: 2
         }
@@ -353,7 +354,7 @@ resource cosmosContainerWithTtl 'Microsoft.DocumentDB/databaseAccounts/sqlDataba
         }
 
         partitionKey: {
-          kind: 'Hash'
+          kind: length(c.partitionKey.paths) == 1 ? 'Hash' : 'MultiHash'
           paths: c.partitionKey.paths
           version: 2
         }
@@ -406,7 +407,7 @@ resource cosmosContainerWithVecIdx 'Microsoft.DocumentDB/databaseAccounts/sqlDat
         }
 
         partitionKey: {
-          kind: 'Hash'
+          kind: length(c.partitionKey.paths) == 1 ? 'Hash' : 'MultiHash'
           paths: c.partitionKey.paths
           version: 2
         }
@@ -417,7 +418,7 @@ resource cosmosContainerWithVecIdx 'Microsoft.DocumentDB/databaseAccounts/sqlDat
           uniqueKeys: []
         }
 
-        vectorEmbeddingPolicy: c.?vectorEmbeddingPolicy
+       vectorEmbeddingPolicy: c.?vectorEmbeddingPolicy
 
         conflictResolutionPolicy: {
           conflictResolutionPath: '/_ts'

--- a/deploy/standard/infra/modules/search.bicep
+++ b/deploy/standard/infra/modules/search.bicep
@@ -121,7 +121,7 @@ resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' 
 /** Nested Modules **/
 @description('Metric alerts for the resource')
 module metricAlerts 'utility/metricAlerts.bicep' = {
-  name: 'alert-${main.name}-${timestamp}'
+  name: 'alerts-${serviceType}-${timestamp}'
   params: {
     actionGroupId: actionGroupId
     alerts: alerts
@@ -134,7 +134,7 @@ module metricAlerts 'utility/metricAlerts.bicep' = {
 
 @description('Private endpoint for the resource')
 module privateEndpoint 'utility/privateEndpoint.bicep' = {
-  name: 'pe-${main.name}-${timestamp}'
+  name: 'pe-${serviceType}-${timestamp}'
   params: {
     groupId: 'searchService'
     location: location


### PR DESCRIPTION
## The issue or feature being addressed

* Standard deployment: Infer the tenant ID if it is not provided during setup.
* Correct incorrect conditional when checking for Azure CLI extensions.
* The certificate loader prompts the user for all certificate passwords upfront before attempting to add them to Key Vault.
* Cosmos DB template: Add the missing defaultTtl argument to the Agents container, and handle multi-hash partition keys correctly.
* Search template: Shorten the names of nested deployments.


## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable


