### PR TITLE
Fixes for code interpreter and agent private storage

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -821,6 +821,18 @@ namespace FoundationaLLM.Agent.ResourceProviders
         {
             var errors = new List<AgentFileToolAssociationError>();
 
+            if (!ResourcePath.TryParse(
+                $"/instances/{_instanceSettings.Id}/providers/{_name}/{AgentResourceTypeNames.Agents}/{resourcePath.MainResourceId}/{AgentResourceTypeNames.AgentFiles}",
+                [_name],
+                AgentResourceProviderMetadata.AllowedResourceTypes,
+                false,
+                out var agentFilesResourcePath))
+                throw new ResourceProviderException("The object definition is invalid.",
+                    StatusCodes.Status400BadRequest);
+
+            var agentFileResources = await LoadAgentFiles(agentFilesResourcePath!, userIdentity, new ResourceProviderGetOptions() { LoadContent = false });
+            var agentFiles = agentFileResources.Select(x => x.Resource).ToList();
+
             var agentFileToolAssociationRequest = JsonSerializer.Deserialize<AgentFileToolAssociationRequest>(serializedResource)
                 ?? throw new ResourceProviderException("The object definition is invalid.",
                     StatusCodes.Status400BadRequest);
@@ -835,6 +847,18 @@ namespace FoundationaLLM.Agent.ResourceProviders
             {
                 if (!agentFileToolAssociationRequest.AgentFileToolAssociations.TryGetValue(fileObjectId, out var toolAssociations))
                     continue;
+
+                if (!agentFiles.Any(x => x.ObjectId == fileObjectId))
+                {
+                    errors.Add(new AgentFileToolAssociationError()
+                    {
+                        FileObjectId = fileObjectId,
+                        ToolObjectId = string.Empty,
+                        ErrorMessage = $"The {fileObjectId} file was not found in the {resourcePath.MainResourceId!} agent private storage."
+                    });
+
+                    continue;
+                }
 
                 foreach (var toolObjectId in toolAssociations.Keys)
                 {

--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -854,7 +854,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
                     {
                         FileObjectId = fileObjectId,
                         ToolObjectId = string.Empty,
-                        ErrorMessage = $"The {fileObjectId} file was not found in the {resourcePath.MainResourceId!} agent private storage."
+                        ErrorMessage = $"The file was not found in the agent private storage."
                     });
 
                     continue;

--- a/src/dotnet/Gateway/Services/GatewayCore.cs
+++ b/src/dotnet/Gateway/Services/GatewayCore.cs
@@ -504,7 +504,7 @@ namespace FoundationaLLM.Gateway.Services
 
                 var codeInterpreterToolResources = assistant.Value.ToolResources.CodeInterpreter;
 
-                if (!codeInterpreterToolResources.FileIds.Contains(file))
+                if (codeInterpreterToolResources.FileIds.Contains(file))
                 {
                     codeInterpreterToolResources.FileIds.Remove(file);
                 }


### PR DESCRIPTION
# Fixes for code interpreter and agent private storage

## The issue or feature being addressed

Removed files could still be associated to tools.
Removing code interpreter association did not work properly.

## Details on the issue fix or feature implementation

Checks if a file exists in the agent private storage before updating it's tool associations.
Inverts the condition when removing a file from code interpreter tool.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
