### PR TITLE
Fixes an issue with annotation matches

### DIFF
--- a/src/dotnet/Context/Services/AzureContainerAppsCodeSessionProviderService.cs
+++ b/src/dotnet/Context/Services/AzureContainerAppsCodeSessionProviderService.cs
@@ -97,6 +97,7 @@ namespace FoundationaLLM.Context.Services
             return itemsToReturn;
         }
 
+        /// <inheritdoc/>
         public async Task DeleteCodeSessionFileStoreItems(
             string codeSessionId,
             string endpoint)
@@ -141,7 +142,8 @@ namespace FoundationaLLM.Context.Services
             string codeSessionId,
             string endpoint,
             HttpClient httpClient,
-            bool includeFolders = false)
+            bool includeFolders = false,
+            bool includeLocalPath = false)
         {
             var rootUrl = $"{endpoint}/files?api-version=2024-10-02-preview&identifier={codeSessionId}";
             var rootFileStore = await GetCodeSessionFileStore(
@@ -186,9 +188,17 @@ namespace FoundationaLLM.Context.Services
                 }
             }
 
-            return includeFolders
+            var result = includeFolders
                 ? [.. filesToReturn, .. directoriesToReturn]
                 : filesToReturn;
+
+            return includeLocalPath
+                ? [.. result.Select(x =>
+                    {
+                        x.ParentPath = $"/mnt/data{x.ParentPath}";
+                        return x;
+                    })]
+                : result;
         }
 
         private async Task<CodeSessionFileStore> GetCodeSessionFileStore(

--- a/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
@@ -679,7 +679,11 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             {
                 var startIndex = previousMatch == null ? 0 : previousMatch.Index + previousMatch.Length;
                 output.Add(input[startIndex..match.Index]);
-                var token = input.Substring(match.Index, match.Length);
+                // The file names in the annotations are not prefixed with "sandbox:/mnt/data",
+                // so we need to remove it from the token before checking for a replacement.
+                var token = input
+                    .Substring(match.Index, match.Length)
+                    .Replace("sandbox:/mnt/data", string.Empty);
                 if (codeInterpreterPlaceholders.TryGetValue(token, out var replacement))
                     output.Add(replacement);
                 else


### PR DESCRIPTION
# Fixes an issue with annotation matches

## The issue or feature being addressed

Handles the case when the file names in text annotations are not prefixed with `sandbox:/mnt/data`.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
