### PR TITLE
Render non contentized file path links

### DIFF
--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -908,6 +908,7 @@ export default {
 				const content: MessageContent = {
 					type: 'file_path',
 					value: link.dataset.href,
+					origValue: link.dataset.href,
 					fileName: link.dataset.filename || link.textContent,
 				};
 

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -795,8 +795,8 @@ export default {
 					// Append file icon if there's a matching file_path
 					const fileName = matchingFileBlock?.fileName.split('/').pop() ?? '';
 					const fileIcon = matchingFileBlock
-						? `<i class="${this.$getFileIconClass(fileName, true)} attachment-icon" style="margin-right: 4px"></i>`
-						: `<i class="pi pi-file" class="attachment-icon" style="margin-right: 4px"></i>`;
+						? `<i class="${this.$getFileIconClass(fileName, true)} attachment-icon"></i>`
+						: `<i class="pi pi-file" class="attachment-icon"></i>`;
 					return `${fileIcon}<a href="#" data-href="${href}" data-filename="${fileName}" title="${title || ''}" class="file-download-link">${text}</a>`;
 				} else {
 					const linkHTML = `<a href="${href}" title="${title || ''}" target="_blank">${text}</a>`;

--- a/src/ui/UserPortal/components/ChatMessage.vue
+++ b/src/ui/UserPortal/components/ChatMessage.vue
@@ -795,9 +795,9 @@ export default {
 					// Append file icon if there's a matching file_path
 					const fileName = matchingFileBlock?.fileName.split('/').pop() ?? '';
 					const fileIcon = matchingFileBlock
-						? `<i class="${this.$getFileIconClass(fileName, true)}" class="attachment-icon"></i>`
-						: `<i class="pi pi-file" class="attachment-icon"></i>`;
-					return `${fileIcon} &nbsp;<a href="#" data-href="${href}" data-filename="${fileName}" title="${title || ''}" class="file-download-link">${text}</a>`;
+						? `<i class="${this.$getFileIconClass(fileName, true)} attachment-icon" style="margin-right: 4px"></i>`
+						: `<i class="pi pi-file" class="attachment-icon" style="margin-right: 4px"></i>`;
+					return `${fileIcon}<a href="#" data-href="${href}" data-filename="${fileName}" title="${title || ''}" class="file-download-link">${text}</a>`;
 				} else {
 					const linkHTML = `<a href="${href}" title="${title || ''}" target="_blank">${text}</a>`;
 					// Process link html again in case it contains nested markdown content
@@ -945,6 +945,14 @@ export default {
 	}
 };
 </script>
+<style lang="scss">
+.attachment-icon {
+	width: 24px;
+	margin-right: 6px;
+	vertical-align: middle;
+	line-height: 1;
+}	
+</style>
 
 <style lang="scss" scoped>
 @keyframes loading-shimmer {

--- a/src/ui/UserPortal/components/ChatMessageContentBlock.vue
+++ b/src/ui/UserPortal/components/ChatMessageContentBlock.vue
@@ -41,14 +41,13 @@
 
 		<!-- File -->
 		<div v-else-if="content.type === 'file_path'">
-			Download <i :class="$getFileIconClass(content.fileName, true)" class="attachment-icon"></i>
+			<i :class="$getFileIconClass(content.fileName, true)" class="attachment-icon"></i>
 			<a
 				:download="content.fileName ?? content.blobUrl ?? content.origValue"
 				href="#"
 				target="_blank"
 				@click.prevent="handleFileDownload(content)"
-			>
-				{{ content.fileName ?? content.blobUrl ?? content.origValue }}
+			>Download {{ content.fileName ?? content.blobUrl ?? content.origValue }}
 			</a>
 		</div>
 	</div>
@@ -214,12 +213,5 @@ iframe {
 		font-style: italic;
 		line-height: 1.5;
 	}
-}
-
-.attachment-icon {
-	width: 24px;
-	margin-right: 4px;
-	vertical-align: middle;
-	line-height: 1;
 }
 </style>

--- a/src/ui/UserPortal/components/ChatMessageContentBlock.vue
+++ b/src/ui/UserPortal/components/ChatMessageContentBlock.vue
@@ -43,12 +43,12 @@
 		<div v-else-if="content.type === 'file_path'">
 			Download <i :class="$getFileIconClass(content.fileName, true)" class="attachment-icon"></i>
 			<a
-				:download="content.fileName ?? content.blobUrl ?? content.value"
+				:download="content.fileName ?? content.blobUrl ?? content.origValue"
 				href="#"
 				target="_blank"
 				@click.prevent="handleFileDownload(content)"
 			>
-				{{ content.fileName ?? content.blobUrl ?? content.value }}
+				{{ content.fileName ?? content.blobUrl ?? content.origValue }}
 			</a>
 		</div>
 	</div>

--- a/src/ui/UserPortal/js/fileService.ts
+++ b/src/ui/UserPortal/js/fileService.ts
@@ -7,11 +7,11 @@ export async function fetchBlobUrl(content: MessageContent) {
 	if (!content.blobUrl) {
 		content.loading = true;
 		try {
-			const response = await api.fetchDirect(content.value);
+			const response = await api.fetchDirect(content.origValue);
 			const blob = new Blob([response], { type: response.type });
 			content.blobUrl = URL.createObjectURL(blob);
 		} catch (error) {
-			console.error(`Failed to fetch content from ${content.value}`, error);
+			console.error(`Failed to fetch content from ${content.origValue}`, error);
 			appStore.addToast({
 				severity: 'error',
 				summary: 'Error downloading file',


### PR DESCRIPTION
# Render non contentized file path links

## The issue or feature being addressed
- Use origValue instead of processed value for file_path content downloads
- Adjust file download icon styling for consistency

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
