### PR TITLE
Disable sending a prompt while uploading

### DIFF
--- a/src/ui/UserPortal/components/ChatInput.vue
+++ b/src/ui/UserPortal/components/ChatInput.vue
@@ -312,7 +312,7 @@
 		</div>
 
 		<Button
-			:disabled="disabled || isCurrentAgentExpired"
+			:disabled="disabled || isCurrentAgentExpired || isUploading"
 			class="submit"
 			icon="pi pi-send"
 			label="Send"
@@ -536,7 +536,7 @@ export default {
 		},
 
 		handleKeydown(event: KeyboardEvent) {
-			if (event.key === 'Enter' && !event.shiftKey && !this.agentListOpen) {
+			if (event.key === 'Enter' && !event.shiftKey && !this.agentListOpen && !this.disabled && !this.isCurrentAgentExpired && !this.isUploading) {
 				event.preventDefault();
 				this.handleSend();
 			}


### PR DESCRIPTION
# Disable sending a prompt while uploading

## The issue or feature being addressed

Disables the send button and hitting enter to send while file(s) upload. Also, updated the keyboard Enter event to check for the same disabled status as the send button.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
