### PR TITLE
Show message instead of loading infinitely when session messages fail to load

### DIFF
--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -58,7 +58,9 @@
 		<div class="chat-thread__input">
 			<ChatInput
 				ref="chatInput"
-				:disabled="isLoading || loadingFailed || isMessagePending || $appStore.sessionMessagePending"
+				:disabled="
+					isLoading || loadingFailed || isMessagePending || $appStore.sessionMessagePending
+				"
 				@send="handleSend"
 			/>
 		</div>
@@ -132,7 +134,7 @@ export default {
 
 			try {
 				await this.$appStore.getMessages();
-			} catch(error) {
+			} catch (error) {
 				this.loadingFailed = true;
 			}
 			await this.$appStore.ensureAgentsLoaded();

--- a/src/ui/UserPortal/components/ChatThread.vue
+++ b/src/ui/UserPortal/components/ChatThread.vue
@@ -17,6 +17,18 @@
 				</div>
 			</template>
 
+			<template v-else-if="loadingFailed">
+				<div class="chat-thread__loading" role="status">
+					<i
+						class="pi pi-exclamation-triangle"
+						style="font-size: 1rem; margin-right: 8px"
+						role="img"
+						aria-label="Error"
+					></i>
+					<span>Failed to load session messages.</span>
+				</div>
+			</template>
+
 			<template v-else>
 				<!-- Messages -->
 				<template v-if="messages.length !== 0">
@@ -46,7 +58,7 @@
 		<div class="chat-thread__input">
 			<ChatInput
 				ref="chatInput"
-				:disabled="isLoading || isMessagePending || $appStore.sessionMessagePending"
+				:disabled="isLoading || loadingFailed || isMessagePending || $appStore.sessionMessagePending"
 				@send="handleSend"
 			/>
 		</div>
@@ -83,10 +95,11 @@ export default {
 
 	data() {
 		return {
-			isLoading: true,
-			userSentMessage: false,
-			isMessagePending: false,
-			welcomeMessage: '',
+			isLoading: true as boolean,
+			loadingFailed: false as boolean,
+			userSentMessage: false as boolean,
+			isMessagePending: false as boolean,
+			welcomeMessage: '' as string,
 		};
 	},
 
@@ -114,9 +127,14 @@ export default {
 			if (newSession.sessionId === oldSession?.sessionId || isReplacementForTempSession) return;
 			this.isMessagePending = false;
 			this.isLoading = true;
+			this.loadingFailed = false;
 			this.userSentMessage = false;
 
-			await this.$appStore.getMessages();
+			try {
+				await this.$appStore.getMessages();
+			} catch(error) {
+				this.loadingFailed = true;
+			}
 			await this.$appStore.ensureAgentsLoaded();
 
 			this.$appStore.updateSessionAgentFromMessages(newSession);


### PR DESCRIPTION
# Show message instead of loading infinitely when session messages fail to load

## The issue or feature being addressed
- Show message instead of loading infinitely when session messages fail to load

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [x]  I have provided the required update scripts, where applicable
- [x]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
