### PR TITLE
Fix for message attachment rendering

### DIFF
--- a/src/dotnet/Common/Models/Conversation/AttachmentDetail.cs
+++ b/src/dotnet/Common/Models/Conversation/AttachmentDetail.cs
@@ -1,4 +1,5 @@
-﻿using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
+﻿using FoundationaLLM.Common.Models.Context;
+using FoundationaLLM.Common.Models.ResourceProviders.Attachment;
 using System.Text.Json.Serialization;
 
 namespace FoundationaLLM.Common.Models.Conversation
@@ -36,6 +37,18 @@ namespace FoundationaLLM.Common.Models.Conversation
             ObjectId = attachmentFile.ObjectId,
             DisplayName = !string.IsNullOrWhiteSpace(attachmentFile.DisplayName) ? attachmentFile.DisplayName : attachmentFile.OriginalFileName,
             ContentType = attachmentFile.ContentType
+        };
+
+        /// <summary>
+        /// Creates an <see cref="AttachmentDetail"/> instance from a <see cref="ContextFileRecord"/> instance.
+        /// </summary>
+        /// <param name="contextFileRecord">The <see cref="ContextFileRecord"/> used to initialize the instance.</param>
+        /// <returns>The newly created <see cref="AttachmentDetail"/> instance.</returns>
+        public static AttachmentDetail FromContextFileRecord(ContextFileRecord contextFileRecord) => new()
+        {
+            ObjectId = contextFileRecord.Id,
+            DisplayName = contextFileRecord.FileName,
+            ContentType = contextFileRecord.ContentType
         };
     }
 }


### PR DESCRIPTION
# Fix for message attachment rendering

## The issue or feature being addressed

When a conversation was re-loaded in the User Portal, Context API supported attachments on messages indicated the file was no longer available. Adds the path to support Context API attachments when parsing messages and their attachments.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
