### PR TITLE
Disable Management Portal resource edit and delete buttons if the user does not have access

### DIFF
--- a/src/ui/ManagementPortal/pages/api-endpoints/index.vue
+++ b/src/ui/ManagementPortal/pages/api-endpoints/index.vue
@@ -99,9 +99,16 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/api-endpoints/edit/' + data.resource.name" class="table__button">
-							<Button link>
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+						<NuxtLink
+							:to="'/api-endpoints/edit/' + data.resource.name"
+							:aria-disabled="!data.actions.includes('FoundationaLLM.Configuration/apiEndpointConfigurations/write')"
+							:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.Configuration/apiEndpointConfigurations/write') ? 'none' : 'auto' }"
+							class="table__button">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.Configuration/apiEndpointConfigurations/write')"
+								:aria-label="`Edit ${data.resource.name}`">
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>
@@ -120,8 +127,12 @@
 					}"
 				>
 					<template #body="{ data }">
-						<Button link @click="itemToDelete = data.resource">
-							<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+						<Button
+							link
+							:aria-label="`Delete ${data.resource.name}`"
+							:disabled="!data.actions.includes('FoundationaLLM.Configuration/apiEndpointConfigurations/delete')"
+							@click="itemToDelete = data.resource">
+							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 						</Button>
 					</template>
 				</Column>

--- a/src/ui/ManagementPortal/pages/data-sources/index.vue
+++ b/src/ui/ManagementPortal/pages/data-sources/index.vue
@@ -86,9 +86,14 @@
 							:to="'/data-sources/edit/' + data.resource.name"
 							class="table__button"
 							tabindex="-1"
+							:aria-disabled="!data.actions.includes('FoundationaLLM.DataSource/dataSources/write')"
+							:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.DataSource/dataSources/write') ? 'none' : 'auto' }"
 						>
 							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
-								<Button link :aria-label="`Edit ${data.resource.name}`">
+								<Button
+									link
+									:disabled="!data.actions.includes('FoundationaLLM.DataSource/dataSources/write')"
+									:aria-label="`Edit ${data.resource.name}`">
 									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 								</Button>
 								<template #popper
@@ -116,6 +121,7 @@
 							<Button
 								link
 								:aria-label="`Delete ${data.resource.name}`"
+								:disabled="!data.actions.includes('FoundationaLLM.DataSource/dataSources/delete')"
 								@click="dataSourceToDelete = data.resource"
 							>
 								<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>

--- a/src/ui/ManagementPortal/pages/models/index.vue
+++ b/src/ui/ManagementPortal/pages/models/index.vue
@@ -81,9 +81,16 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/models/edit/' + data.resource.name" class="table__button">
-							<Button link>
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+						<NuxtLink
+							:to="'/models/edit/' + data.resource.name"
+							:aria-disabled="!data.actions.includes('FoundationaLLM.AIModel/aiModels/write')"
+							:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.AIModel/aiModels/write') ? 'none' : 'auto' }"
+							class="table__button">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.AIModel/aiModels/write')"
+								:aria-label="`Edit ${data.resource.name}`">
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>
@@ -102,8 +109,12 @@
 					}"
 				>
 					<template #body="{ data }">
-						<Button link @click="itemToDelete = data.resource">
-							<i class="pi pi-trash" style="font-size: 1.2rem"></i>
+						<Button
+							link
+							:aria-label="`Delete ${data.resource.name}`"
+							:disabled="!data.actions.includes('FoundationaLLM.AIModel/aiModels/delete')"
+							@click="itemToDelete = data.resource">
+							<i class="pi pi-trash" style="font-size: 1.2rem" aria-hidden="true"></i>
 						</Button>
 					</template>
 				</Column>

--- a/src/ui/ManagementPortal/pages/pipelines/index.vue
+++ b/src/ui/ManagementPortal/pages/pipelines/index.vue
@@ -126,9 +126,16 @@
 					}"
 				>
 					<template #body="{ data }">
-						<NuxtLink :to="'/pipelines/edit/' + data.resource.name" class="table__button">
-							<Button link>
-								<i class="pi pi-cog" style="font-size: 1.2rem"></i>
+						<NuxtLink
+							:to="'/pipelines/edit/' + data.resource.name"
+							:aria-disabled="!data.actions.includes('FoundationaLLM.DataPipeline/dataPipelines/write')"
+							:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.DataPipeline/dataPipelines/write') ? 'none' : 'auto' }"
+							class="table__button">
+							<Button
+								link
+								:disabled="!data.actions.includes('FoundationaLLM.DataPipeline/dataPipelines/write')"
+								:aria-label="`Edit ${data.resource.name}`">
+									<i class="pi pi-cog" style="font-size: 1.2rem" aria-hidden="true"></i>
 							</Button>
 						</NuxtLink>
 					</template>

--- a/src/ui/ManagementPortal/pages/prompts/index.vue
+++ b/src/ui/ManagementPortal/pages/prompts/index.vue
@@ -100,6 +100,8 @@
 							:to="'/prompts/edit/' + data.resource.name"
 							class="table__button"
 							tabindex="-1"
+							:aria-disabled="!data.actions.includes('FoundationaLLM.Prompt/prompts/write')"
+							:style="{ pointerEvents: !data.actions.includes('FoundationaLLM.Prompt/prompts/write') ? 'none' : 'auto' }"
 						>
 							<VTooltip :auto-hide="false" :popper-triggers="['hover']">
 								<Button


### PR DESCRIPTION
# Disable Management Portal resource edit and delete buttons if the user does not have access

## The issue or feature being addressed

Disables the edit and delete buttons on resources in the Management Portal if the signed-in user does not have appropriate permissions to perform the action on the resource.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
