### PR TITLE
Handle rate-limiting and other error types in the User Portal

### DIFF
--- a/src/ui/UserPortal/js/fileService.ts
+++ b/src/ui/UserPortal/js/fileService.ts
@@ -15,7 +15,7 @@ export async function fetchBlobUrl(content: MessageContent) {
 			appStore.addToast({
 				severity: 'error',
 				summary: 'Error downloading file',
-				detail: `Failed to download "${content.fileName}". ${error.message || error}`,
+				detail: `Failed to download "${content.fileName}".`,
 			});
 			content.error = true;
 		} finally {

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -186,12 +186,8 @@ export interface OneDriveWorkSchool {
 export interface RateLimitError {
 	quota_name: string;
 	quota_context: string;
-	quotaMetricPartitionId: string;
 	quota_exceeded: boolean;
 	time_until_retry_seconds: number;
-	localMetricCount: number;
-	remoteMetricCount: number;
-	totalMetricCount: number;
 }
 
 export interface MessageResponse {

--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -98,6 +98,7 @@ export interface LongRunningOperation {
 	ttl: number;
 	prompt_tokens: number;
 	result?: Message;
+	isCompleted: boolean;
 }
 
 export interface CompletionPrompt {
@@ -180,4 +181,22 @@ export interface OneDriveWorkSchool {
 	name?: string;
 	mimeType?: string;
 	access_token?: string;
+}
+
+export interface RateLimitError {
+	quota_name: string;
+	quota_context: string;
+	quotaMetricPartitionId: string;
+	quota_exceeded: boolean;
+	time_until_retry_seconds: number;
+	localMetricCount: number;
+	remoteMetricCount: number;
+	totalMetricCount: number;
+}
+
+export interface MessageResponse {
+	status: string;
+	result?: Message;
+	operation_id?: string;
+	status_message?: string;
 }

--- a/src/ui/UserPortal/stores/appStore.ts
+++ b/src/ui/UserPortal/stores/appStore.ts
@@ -15,6 +15,7 @@ import type {
 	ResourceProviderDeleteResults,
 	Attachment,
 	MessageContent,
+	RateLimitError,
 } from '@/js/types';
 import api from '@/js/api';
 import { isAgentExpired } from '@/js/helpers';
@@ -424,7 +425,7 @@ export const useAppStore = defineStore('app', {
 		 * @param text - The text of the message to send.
 		 * @returns A boolean indicating whether to wait for a polling operation to complete.
 		 */
-		async sendMessage(text: string): boolean {
+		async sendMessage(text: string): Promise<boolean> {
 			let waitForPolling = false;
 			if (!text) return waitForPolling;
 
@@ -481,52 +482,111 @@ export const useAppStore = defineStore('app', {
 			}
 
 			const initialSession = this.currentSession?.sessionId;
-			const message = await api.sendMessage(
-				this.currentSession!.sessionId,
-				text,
-				agent,
-				relevantAttachments.map((attachment) => String(attachment.id)),
-			);
+			
+			try {
+				const message = await api.sendMessage(
+					this.currentSession!.sessionId,
+					text,
+					agent,
+					relevantAttachments.map((attachment) => String(attachment.id)),
+				);
 
-			if (message.status === 'Completed') {
-				// The endpoint likely returned the final message, so we can update the last message in the list.
-				const completedMessage = message.result as Message;
-				// Replace the last message with the completed message.
-				this.currentMessages[this.currentMessages.length - 1] = completedMessage;
-				this.calculateMessageProcessingTime();
+				if (message.status === 'Completed') {
+					// The endpoint likely returned the final message, so we can update the last message in the list.
+					const completedMessage = message.result as Message;
+					// Replace the last message with the completed message.
+					this.currentMessages[this.currentMessages.length - 1] = completedMessage;
+					this.calculateMessageProcessingTime();
+					return waitForPolling;
+				}
+
+				this.currentMessages[this.currentMessages.length - 1] = {
+					...tempAssistantMessage,
+					...message,
+					sender: 'Agent',
+					type: 'Message',
+					text: message.status_message,
+				};
+
+				this.attachments = this.attachments.filter(
+					(attachment) => attachment.sessionId !== sessionId,
+				);
+
+				// If the session has changed before above completes we need to prevent polling
+				if (initialSession !== this.currentSession?.sessionId) return waitForPolling;
+
+				// If the operation failed to start prevent polling
+				if (message.status === 'Failed') return waitForPolling;
+
+				waitForPolling = true;
+
+				// For older messages that have a status of "Pending" but no operation id, assume
+				// it is complete and do no initiate polling as it will return empty data
+				if (message.operation_id) this.startPolling(message, this.currentSession?.sessionId);
+
+				// Remove the new session if matches this one, now that we have sent the first message.
+				if (this.newSession && this.newSession.sessionId === initialSession) {
+					this.newSession = null;
+				}
+
 				return waitForPolling;
+			} catch (error: any) {
+				// Remove the temporary messages we added
+				this.currentMessages = this.currentMessages.slice(0, -2);
+				
+				// Check if the error is a rate limit error
+				if (error.data?.quota_exceeded) {
+					const rateLimitError = error.data as RateLimitError;
+					const waitTime = rateLimitError.time_until_retry_seconds;
+					
+					// Format the wait time in a more natural way
+					let timeString;
+					if (waitTime < 60) {
+						timeString = `${waitTime} second${waitTime !== 1 ? 's' : ''}`;
+					} else {
+						const minutes = Math.floor(waitTime / 60);
+						const seconds = waitTime % 60;
+						if (seconds === 0) {
+							timeString = `${minutes} minute${minutes !== 1 ? 's' : ''}`;
+						} else {
+							timeString = `${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${seconds !== 1 ? 's' : ''}`;
+						}
+					}
+					
+					this.addToast({
+						severity: 'warn',
+						summary: 'Rate Limited',
+						detail: `You have sent too many messages in a short period of time. Please wait ${timeString} before trying again.`,
+						life: 5000,
+					});
+				} else {
+					// Handle different types of errors
+					let errorMessage = 'Failed to send message. Please try again.';
+					
+					if (error.message?.includes('Failed to fetch')) {
+						errorMessage = 'Unable to connect to the server. Please check your internet connection and try again.';
+					} else if (error.message?.includes('NetworkError')) {
+						errorMessage = 'Network error occurred. Please check your connection and try again.';
+					} else if (error.message?.includes('timeout')) {
+						errorMessage = 'The request timed out. Please try again.';
+					} else if (error.message) {
+						// If there's a specific error message, use it but clean it up
+						errorMessage = error.message
+							.replace(/^https?:\/\/[^/]+\//, '') // Remove URL prefix
+							.replace(/<no response>/g, '') // Remove "no response" text
+							.trim();
+					}
+					
+					this.addToast({
+						severity: 'error',
+						summary: 'Error',
+						detail: errorMessage,
+						life: 5000,
+					});
+				}
+				
+				return false;
 			}
-
-			this.currentMessages[this.currentMessages.length - 1] = {
-				...tempAssistantMessage,
-				...message,
-				sender: 'Agent',
-				type: 'Message',
-				text: message.status_message,
-			};
-
-			this.attachments = this.attachments.filter(
-				(attachment) => attachment.sessionId !== sessionId,
-			);
-
-			// If the session has changed before above completes we need to prevent polling
-			if (initialSession !== this.currentSession?.sessionId) return waitForPolling;
-
-			// If the operation failed to start prevent polling
-			if (message.status === 'Failed') return waitForPolling;
-
-			waitForPolling = true;
-
-			// For older messages that have a status of "Pending" but no operation id, assume
-			// it is complete and do no initiate polling as it will return empty data
-			if (message.operation_id) this.startPolling(message, this.currentSession?.sessionId);
-
-			// Remove the new session if matches this one, now that we have sent the first message.
-			if (this.newSession && this.newSession.sessionId === initialSession) {
-				this.newSession = null;
-			}
-
-			return waitForPolling;
 		},
 
 		getPollingRateMS() {


### PR DESCRIPTION
# Handle rate-limiting and other error types in the User Portal

## The issue or feature being addressed

When a user sends a completion in the User Portal that results in a 429 (rate-limiting error), display a user-friendly message informing the user they have been rate-limited and how long to wait before trying again. Also handles other types of errors when sending completions, showing user-friendly messages for each type.

## Details on the issue fix or feature implementation

In addition to the above, also improves TypeScript interface enforcement in the API library.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
