### PR TITLE
Limit the details included in quota limit errors

### DIFF
--- a/src/dotnet/Common/Models/Quota/QuotaMetricPartitionState.cs
+++ b/src/dotnet/Common/Models/Quota/QuotaMetricPartitionState.cs
@@ -22,6 +22,7 @@ namespace FoundationaLLM.Common.Models.Quota
         /// <summary>
         /// Gets or sets the identifier of the quota metric partition used for evaluation.
         /// </summary>
+        [JsonIgnore]
         public required string QuotaMetricPartitionId { get; set; }
 
         /// <summary>
@@ -40,17 +41,20 @@ namespace FoundationaLLM.Common.Models.Quota
         /// Gets or sets the number of units of the quota metric that have a local origin
         /// (the service instance hosting the quota metric sequence).
         /// </summary>
+        [JsonIgnore]
         public int LocalMetricCount { get; set; }
 
         /// <summary>
         /// Gets or sets the number of units of the quota metric that have a remote origin
         /// (other service instances than the one hosting the quota metric sequence).
         /// </summary>
+        [JsonIgnore]
         public int RemoteMetricCount { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of units of the quota metric, both local and remote.
         /// </summary>
+        [JsonIgnore]
         public int TotalMetricCount { get; set; }
     }
 }


### PR DESCRIPTION
# Limit the details included in quota limit errors

## The issue or feature being addressed

Removes several properties from serialization to avoid returning unnecessary information to clients in quota limit error responses.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
