### PR TITLE
Fix issue with workflow properties

### DIFF
--- a/src/ui/ManagementPortal/js/types.ts
+++ b/src/ui/ManagementPortal/js/types.ts
@@ -64,6 +64,7 @@ export type AgentTool = {
 export type AgentWorkflow = {
 	type: string;
 	assistant_id: string;
+	vector_store_id: string;
 	name: string;
 	package_name: string;
 	workflow_host: string;

--- a/src/ui/ManagementPortal/pages/agents/create.vue
+++ b/src/ui/ManagementPortal/pages/agents/create.vue
@@ -1482,6 +1482,8 @@ export default {
 			workflowMainAIModel: null as AIModel | null,
 			// workflowMainPrompt: '' as string,
 			workflowMainAIModelParameters: {} as object,
+			workflowAssistantId: '' as string,
+			workflowVectorStoreId: '' as string,
 			workflowName: '' as string,
 			workflowPackageName: 'FoundationaLLM' as string,
 			workflowClassName: '' as string,
@@ -1731,6 +1733,8 @@ export default {
 			}
 
 			if (agent.workflow) {
+				this.workflowAssistantId = agent.workflow.assistant_id ?? '';
+				this.workflowVectorStoreId = agent.workflow.vector_store_id ?? '';
 				this.workflowName = agent.workflow.name ?? '';
 				this.workflowPackageName = agent.workflow.package_name ?? '';
 				this.workflowClassName = agent.workflow.class_name ?? '';
@@ -2182,6 +2186,8 @@ export default {
 					workflow = {
 						...this.selectedWorkflow,
 						workflow_host: this.workflowHost,
+						assistant_id: this.workflowAssistantId,
+						vector_store_id: this.workflowVectorStoreId,
 						name: this.workflowName,
 						package_name: this.workflowPackageName,
 						class_name: this.workflowClassName,


### PR DESCRIPTION
# Fix issue with workflow properties

## The issue or feature being addressed

For agents using the Azure Open AI Assistants workflow, the `assistant_id` and `vector_store_id` properties are not loaded (and saved) correctly, which results in new assistants and vector stores being created every time the agent is saved in the Management Portal.

## Details on the issue fix or feature implementation

Added the mappings in the Management Portal UX, ensuring the properties are not overwritten with empty values every time.

>[!NOTE]
>The fix is not complete, there is still a racing condition occurring when a new agent is saved for the first time. If the agent is saved again before being reloaded, a new set of assistant + vector store will be created.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
