### PR TITLE
Setting Docker context to /src instead of /src/dotnet for csharp-codesession-api

### DIFF
--- a/tests/config/e2e-test-manifest.json
+++ b/tests/config/e2e-test-manifest.json
@@ -178,7 +178,7 @@
         },
         {
             "name": "csharp-codesession-api",
-            "context": "./src/dotnet",
+            "context": "./src",
             "dockerfile": "./src/dotnet/CSharpCodeSessionAPI/Dockerfile",
             "helm_chart": null,
             "azd_env_key": "SERVICE_CSHARPCODESESSIONAPI_IMAGE",


### PR DESCRIPTION
# Setting Docker context to /src instead of /src/dotnet for csharp-codesession-api

## Details on the issue fix or feature implementation

Setting Docker context to /src instead of /src/dotnet for csharp-codesession-api

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
