### PR TITLE
Agent main model properties as overrides and making operations manager optional on workflow factory init.

### DIFF
--- a/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
+++ b/src/python/PythonSDK/foundationallm/langchain/agents/langchain_knowledge_management_agent.py
@@ -302,8 +302,13 @@ class LangChainKnowledgeManagementAgent(LangChainAgentBase):
         )
         prompt_object_id = prompt_object_properties.object_id
         prompt = ObjectUtils.get_object_by_id(prompt_object_id, request.objects, MultipartPrompt)
+        
+        agent_model_overrides = ai_model_object_properties.properties.get('model_parameters', None)
         language_model_factory = LanguageModelFactory(request.objects, self.config)
-        llm = language_model_factory.get_language_model(ai_model_object_id)
+        llm = language_model_factory.get_language_model(
+            ai_model_object_id=ai_model_object_id,
+            agent_model_parameter_overrides=agent_model_overrides
+        )                
 
         # Used by image analysis and LCEL chain only
         ai_model = ObjectUtils.get_object_by_id(ai_model_object_id, request.objects, AIModelBase)

--- a/src/python/PythonSDK/foundationallm/langchain/language_models/language_model_factory.py
+++ b/src/python/PythonSDK/foundationallm/langchain/language_models/language_model_factory.py
@@ -26,7 +26,8 @@ class LanguageModelFactory:
     
     def get_language_model(self,
                            ai_model_object_id:str,
-                           override_operation_type: OperationTypes = None
+                           override_operation_type: OperationTypes = None,
+                           agent_model_parameter_overrides:dict = None,
                           ) -> BaseLanguageModel:
         """
         Create a language model using the specified endpoint settings.
@@ -243,9 +244,15 @@ class LanguageModelFactory:
                     credentials=service_account_credentials
                 )
 
-        # Set model parameters.
-        for key, value in ai_model.model_parameters.items():
-            if hasattr(language_model, key):
+        # Set model parameters.        
+        for key, value in ai_model.model_parameters.items():            
+            if hasattr(language_model, key):                
                 setattr(language_model, key, value)
         
+        # Set agent model overrides.        
+        if agent_model_parameter_overrides is not None:           
+            for key, value in agent_model_parameter_overrides.items():                
+                if hasattr(language_model, key):                    
+                    setattr(language_model, key, value)
+
         return language_model

--- a/src/python/PythonSDK/foundationallm/langchain/workflows/workflow_factory.py
+++ b/src/python/PythonSDK/foundationallm/langchain/workflows/workflow_factory.py
@@ -15,7 +15,7 @@ class WorkflowFactory:
     """
     Factory class for creating an external agent workflow instance based on the Agent workflow configuration.
     """   
-    def __init__(self, plugin_manager: PluginManager, operations_manager: OperationsManager):
+    def __init__(self, plugin_manager: PluginManager, operations_manager: OperationsManager = None):
         """
         Initializes the workflow factory.
 


### PR DESCRIPTION
# Agent main model properties as overrides and making operations manager optional on workflow factory init.

## The issue or feature being addressed

Applies properties set in a workflow main model properties dictionary to the model creation in LangChain language model factory.

Makes operations_manager optional on workflow factory init.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
