### PR TITLE
Fix role assignment evaluation

### DIFF
--- a/src/dotnet/Common/Constants/ResourceProviders/AgentResourceProviderMetadata.cs
+++ b/src/dotnet/Common/Constants/ResourceProviders/AgentResourceProviderMetadata.cs
@@ -62,7 +62,8 @@ namespace FoundationaLLM.Common.Constants.ResourceProviders
                             {
                                 AllowedTypes = [
                                     new ResourceTypeAllowedTypes(HttpMethod.Get.Method, AuthorizableOperations.Read, [], [], [typeof(ResourceProviderGetResult<AgentAccessToken>)]),
-                                    new ResourceTypeAllowedTypes(HttpMethod.Post.Method, $"{AuthorizableOperations.Write}|{RoleDefinitionNames.Agent_Access_Tokens_Contributor}", [], [typeof(AgentAccessToken)], [typeof(ResourceProviderUpsertResult)]),
+                                    // The ! in the authorization requirements string indicates that role assignment evaluation is mandatory.
+                                    new ResourceTypeAllowedTypes(HttpMethod.Post.Method, $"{AuthorizableOperations.Write}|{RoleDefinitionNames.Agent_Access_Tokens_Contributor}!", [], [typeof(AgentAccessToken)], [typeof(ResourceProviderUpsertResult)]),
                                     new ResourceTypeAllowedTypes(HttpMethod.Delete.Method, AuthorizableOperations.Delete, [], [], [])
                                 ],
                                 Actions = [


### PR DESCRIPTION
# Fix role assignment evaluation

## The issue or feature being addressed

Fixes and issue with the order of evaluation of role assignments which results in some cases in failing to consider the assignment of the `Agent Access Tokens Contributor` role.

## Details on the issue fix or feature implementation

{Detail}

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
