### PR TITLE
Add support for specifying dimensionality in Gateway API embedding

### DIFF
--- a/src/dotnet/Common/Interfaces/ITextEmbeddingService.cs
+++ b/src/dotnet/Common/Interfaces/ITextEmbeddingService.cs
@@ -13,9 +13,10 @@ namespace FoundationaLLM.Common.Interfaces
         /// </summary>
         /// <param name="textChunks">The list of text chunks which need to be embedded.</param>
         /// <param name="deploymentName"> The name of the model deployment to use for embedding.</param>
-        /// <param name="Prioritized">Indicates whether the request should be prioritized.</param>
+        /// <param name="embeddingDimensions"> The number of dimensions for the embedding model.</param>
+        /// <param name="prioritized">Indicates whether the request should be prioritized.</param>
         /// <returns>A <see cref="TextEmbeddingResult"/> object containing the result of the text embedding operation.</returns>
-        Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string deploymentName, bool Prioritized);
+        Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string deploymentName, int embeddingDimensions, bool prioritized);
 
         /// <summary>
         /// Retrieves the result of a long-running text embedding operation.

--- a/src/dotnet/Common/Models/Gateway/GatewayTextEmbeddingRequest.cs
+++ b/src/dotnet/Common/Models/Gateway/GatewayTextEmbeddingRequest.cs
@@ -1,11 +1,12 @@
-﻿using System.Text.Json.Serialization;
+﻿using FoundationaLLM.Common.Models.Vectorization;
+using System.Text.Json.Serialization;
 
 namespace FoundationaLLM.Common.Models.Gateway
 {
     /// <summary>
     /// Provides metrics related to text embedding requests submitted by the FoundationaLLM Gateway.
     /// </summary>
-    public class GatewayTextEmbeddingRequestMetrics
+    public class GatewayTextEmbeddingRequest
     {
         /// <summary>
         /// The unique identifier of the request.
@@ -30,6 +31,12 @@ namespace FoundationaLLM.Common.Models.Gateway
         /// </summary>
         [JsonPropertyName("model_version")]
         public required string ModelVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of dimensions of the embedding.
+        /// </summary>
+        [JsonPropertyName("embedding_dimensions")]
+        public int EmbeddingDimensions { get; set; }
 
         /// <summary>
         /// The start timestamp of the current token rate window.
@@ -58,22 +65,35 @@ namespace FoundationaLLM.Common.Models.Gateway
         public int RequestRateWindowRequestCount { get; set; }
 
         /// <summary>
-        /// The toal number of tokens used in the current request.
+        /// Gets the total number of tokens used in the request.
         /// </summary>
-        [JsonPropertyName("current_request_token_count")]
-        public int CurrentRequestTokenCount { get; set; }
+        [JsonPropertyName("tokens_count")]
+        public int TokensCount =>
+            TextChunks.Sum(tc => tc.TokensCount);
 
         /// <summary>
-        /// The number of text chunks in the current request.
+        /// Gets the total number of text chunks in the request.
         /// </summary>
-        [JsonPropertyName("current_text_chunk_count")]
-        public int CurrentTextChunkCount { get; set; }
+        [JsonPropertyName("text_chunks_count")]
+        public int TextChunksCount =>
+            TextChunks.Count;
 
         /// <summary>
         /// The details of the embedding operations from the text chunks.
         /// For each embedding operation id, holds the list of the positions of the text chunks from the current request.
         /// </summary>
         [JsonPropertyName("operations_details")]
-        public Dictionary<string, List<int>> OperationsDetails { get; set; } = [];
+        public Dictionary<string, List<int>> OperationsDetails =>
+            TextChunks
+                .GroupBy(tc => tc.OperationId!)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(tc => tc.Position).ToList());
+
+        /// <summary>
+        /// Gets or sets the list of text chunks from the current request.
+        /// </summary>
+        [JsonIgnore]
+        public List<TextChunk> TextChunks { get; set; } = [];
     }
 }

--- a/src/dotnet/Common/Models/Vectorization/TextEmbeddingRequest.cs
+++ b/src/dotnet/Common/Models/Vectorization/TextEmbeddingRequest.cs
@@ -21,6 +21,12 @@ namespace FoundationaLLM.Common.Models.Vectorization
         public string EmbeddingModelName { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or set the number of dimensions for the embedding model.
+        /// </summary>
+        [JsonPropertyName("embedding_model_dimensions")]
+        public int EmbeddingModelDimensions { get; set; } = 1536;
+
+        /// <summary>
         /// Indicates whether the request should be prioritized.
         /// Example: Synchronous vectorization and user prompt embedding for completions.
         /// </summary>

--- a/src/dotnet/Gateway/Models/EmbeddingModelContext.cs
+++ b/src/dotnet/Gateway/Models/EmbeddingModelContext.cs
@@ -82,7 +82,8 @@ namespace FoundationaLLM.Gateway.Models
                                     .Where(tc => tc.Embedding == null)
                                     .Select(tc => operationContext.InputTextChunks[tc.Position - 1]))
                                 {
-                                    if (!DeploymentContexts[currentDeploymentContextIndex].TryAddInputTextChunk(inputTextChunk))
+                                    if (!DeploymentContexts[currentDeploymentContextIndex].TryAddInputTextChunk(
+                                        inputTextChunk, operationContext.EmbeddingModelDimensions))
                                     {
                                         currentDeploymentContextIndex++;
                                         if (currentDeploymentContextIndex == DeploymentContexts.Count)

--- a/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
+++ b/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
@@ -19,14 +19,12 @@ namespace FoundationaLLM.Gateway.Models
         ILoggerFactory loggerFactory,
         GatewayMetrics metrics)
     {
-        private const int OPENAI_MAX_INPUT_SIZE_TOKENS = 8191;
-
         private readonly AzureOpenAIAccountDeployment _deployment = deployment;
         private readonly ILoggerFactory _loggerFactory = loggerFactory;
         private readonly ILogger<EmbeddingModelDeploymentContext> _logger = loggerFactory.CreateLogger<EmbeddingModelDeploymentContext>();
         private readonly GatewayMetrics _metrics = metrics;
 
-        private List<TextChunk> _inputTextChunks = [];
+        private readonly Dictionary<int, GatewayTextEmbeddingRequest> _embeddingRequests = [];
 
         private readonly ITextEmbeddingService _textEmbeddingService = new AzureOpenAITextEmbeddingService(
                 deployment.AccountEndpoint,
@@ -51,26 +49,47 @@ namespace FoundationaLLM.Gateway.Models
         /// </summary>
         private DateTime _requestRateWindowStart = DateTime.MinValue;
 
-        private int _currentRequestTokenCount = 0;
-
         public bool HasInput =>
-            _inputTextChunks.Count > 0;
+            _embeddingRequests.Count > 0;
 
-        public bool TryAddInputTextChunk(TextChunk textChunk)
+        public bool TryAddInputTextChunk(TextChunk textChunk, int embeddingDimensions)
         {
             UpdateRateWindows();
 
             if (_tokenRateWindowTokenCount + textChunk.TokensCount > _deployment.TokenRateLimit)
-                // Adding a new text chunk would push us over to the token rate limit, so we need to refuse.
+                // Adding a new text chunk would push us over the token rate limit, so we need to refuse.
                 return false;
 
             if (_requestRateWindowRequestCount == _deployment.RequestRateLimit)
                 // We have already reached the allowed number of requests, so we need to refuse.
                 return false;
 
-            _inputTextChunks.Add(textChunk);
+            if (!_embeddingRequests.ContainsKey(embeddingDimensions))
+            {
+                if (_requestRateWindowRequestCount + 1 == _deployment.RequestRateLimit)
+                    // Adding a new embedding dimension would result in at least one additional reques
+                    // which would push us over the request rate limit, so we need to refuse.
+                    return false;
+
+                _embeddingRequests[embeddingDimensions] =
+                    new GatewayTextEmbeddingRequest
+                    {
+                        Id = Guid.NewGuid().ToString().ToLower(),
+                        AccountName = _deployment.AccountEndpoint,
+                        ModelName = _deployment.ModelName,
+                        ModelVersion = _deployment.ModelVersion,
+                        EmbeddingDimensions = embeddingDimensions,
+                        TokenRateWindowStart = _tokenRateWindowStart,
+                        RequestRateWindowStart = _requestRateWindowStart,
+                        TextChunks = [textChunk]
+                    };
+            }
+            else
+            {
+                _embeddingRequests[embeddingDimensions].TextChunks.Add(textChunk);
+            }
+
             _tokenRateWindowTokenCount += textChunk.TokensCount;
-            _currentRequestTokenCount += textChunk.TokensCount;
 
             return true;
         }
@@ -79,52 +98,54 @@ namespace FoundationaLLM.Gateway.Models
         {
             try
             {
-                var gatewayMetrics = new GatewayTextEmbeddingRequestMetrics
+                var embeddingRequestsTasks = _embeddingRequests
+                    .Select(async x => await ProcessEmbeddingRequest(x.Value))
+                    .ToArray();
+
+                await Task.WhenAll(embeddingRequestsTasks);
+
+                return new TextEmbeddingResult
                 {
-                    Id = Guid.NewGuid().ToString().ToLower(),
-                    AccountName = _deployment.AccountEndpoint,
-                    ModelName = _deployment.ModelName,
-                    ModelVersion = _deployment.ModelVersion,
-                    TokenRateWindowStart = _tokenRateWindowStart,
-                    RequestRateWindowStart = _requestRateWindowStart,
-                    TokenRateWindowTokenCount = _tokenRateWindowTokenCount,
-                    RequestRateWindowRequestCount = _requestRateWindowRequestCount,
-                    CurrentRequestTokenCount = _currentRequestTokenCount,
-                    CurrentTextChunkCount = _inputTextChunks.Count,
-                    OperationsDetails = _inputTextChunks
-                        .GroupBy(tc => tc.OperationId!)
-                        .ToDictionary(
-                            g => g.Key,
-                            g => g.Select(tc => tc.Position).ToList())
+                    InProgress = false,
+                    TextChunks = [.. embeddingRequestsTasks.SelectMany(task => task.Result.TextChunks)]
                 };
-
-                _logger.LogInformation("Submitting text embedding request with id {RequestId} and the following metrics: {RequestMetrics}",
-                    gatewayMetrics.Id,
-                    JsonSerializer.Serialize<GatewayTextEmbeddingRequestMetrics>(gatewayMetrics, _jsonSerializerOptions));
-
-                // Priority is false since the embedding operation context is already added to the queue.
-                var embeddingResult =
-                    await _textEmbeddingService.GetEmbeddingsAsync(_inputTextChunks, _deployment.Name, false);
-
-                if (embeddingResult.Failed)
-                    _logger.LogWarning("The text embedding request with id {RequestId} failed with the following error: {ErrorMessage}",
-                        gatewayMetrics.Id,
-                        embeddingResult.ErrorMessage!);
-                else
-                {
-                    _metrics.IncrementTextChunksEmbedded(_inputTextChunks.Count);
-                    _metrics.IncrementTextChunksSizeTokens(_inputTextChunks.Sum(tc => tc.TokensCount));
-                }
-
-                return embeddingResult;
             }
             finally
             {
-                _requestRateWindowRequestCount++;
+                _requestRateWindowRequestCount += _embeddingRequests.Count;
 
-                _inputTextChunks.Clear();
-                _currentRequestTokenCount = 0;
+                _embeddingRequests.Clear();
             }
+        }
+
+        private async Task<TextEmbeddingResult> ProcessEmbeddingRequest(
+            GatewayTextEmbeddingRequest embeddingRequest)
+        {
+            Interlocked.Increment(ref _requestRateWindowRequestCount);
+
+            embeddingRequest.TokenRateWindowTokenCount = _tokenRateWindowTokenCount;
+            embeddingRequest.RequestRateWindowRequestCount = _requestRateWindowRequestCount;
+
+            _logger.LogInformation("Submitting text embedding request with id {RequestId} and the following metrics: {RequestMetrics}",
+                embeddingRequest.Id,
+                JsonSerializer.Serialize<GatewayTextEmbeddingRequest>(embeddingRequest, _jsonSerializerOptions));
+
+            // Priority is false since the embedding operation context is already added to the queue.
+            var embeddingResult =
+                await _textEmbeddingService.GetEmbeddingsAsync(
+                    embeddingRequest.TextChunks, _deployment.Name, embeddingRequest.EmbeddingDimensions, false);
+
+            if (embeddingResult.Failed)
+                _logger.LogWarning("The text embedding request with id {RequestId} failed with the following error: {ErrorMessage}",
+                    embeddingRequest.Id,
+                    embeddingResult.ErrorMessage!);
+            else
+            {
+                _metrics.IncrementTextChunksEmbedded(embeddingRequest.TextChunksCount);
+                _metrics.IncrementTextChunksSizeTokens(embeddingRequest.TokensCount);
+            }
+
+            return embeddingResult;
         }
 
         private void UpdateRateWindows()
@@ -135,8 +156,9 @@ namespace FoundationaLLM.Gateway.Models
             {
                 _tokenRateWindowStart = refTime;
 
-                // Reset the rate window token count to the sum of token counts of all current input text chunks.
-                _tokenRateWindowTokenCount = _inputTextChunks.Sum(tc => tc.TokensCount);
+                // Reset the rate window token count to the sum of token counts of all current embedding requests.
+                _tokenRateWindowTokenCount = _embeddingRequests
+                    .Sum(er => er.Value.TokensCount);
             }
 
             if ((refTime - _requestRateWindowStart).TotalSeconds >= _deployment.RequestRateRenewalPeriod)

--- a/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
+++ b/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
@@ -32,7 +32,7 @@ namespace FoundationaLLM.Gateway.Models
                 deployment.AccountEndpoint,
                 loggerFactory.CreateLogger<AzureOpenAITextEmbeddingService>());
 
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions { WriteIndented = true };
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
 
         /// <summary>
         /// The cummulated number of tokens for the current token rate window.

--- a/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
+++ b/src/dotnet/Gateway/Models/EmbeddingModelDeploymentContext.cs
@@ -112,8 +112,6 @@ namespace FoundationaLLM.Gateway.Models
             }
             finally
             {
-                _requestRateWindowRequestCount += _embeddingRequests.Count;
-
                 _embeddingRequests.Clear();
             }
         }

--- a/src/dotnet/Gateway/Models/EmbeddingOperationContext.cs
+++ b/src/dotnet/Gateway/Models/EmbeddingOperationContext.cs
@@ -26,6 +26,11 @@ namespace FoundationaLLM.Gateway.Models
         public bool Prioritized { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets the number of dimensions to be used for embedding.
+        /// </summary>
+        public int EmbeddingModelDimensions { get; set; } = 1536;
+
+        /// <summary>
         /// Sets a specified error message on the context of the embedding operation.
         /// </summary>
         /// <param name="errorMessage">The error message to be set.</param>

--- a/src/dotnet/Gateway/Services/AzureOpenAITextEmbeddingService.cs
+++ b/src/dotnet/Gateway/Services/AzureOpenAITextEmbeddingService.cs
@@ -30,13 +30,15 @@ namespace FoundationaLLM.Gateway.Services
         }
 
         /// <inheritdoc/>
-        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string deploymentName, bool prioritized)
+        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string deploymentName, int embeddingDimensions, bool prioritized)
         {
             // Priority not relevant as the text embedding context has already been queued at a higher level.
             try
             {
                 var embeddingClient = _azureOpenAIClient.GetEmbeddingClient(deploymentName);
-                var result = await embeddingClient.GenerateEmbeddingsAsync(textChunks.Select(tc => tc.Content!).ToList());
+                var result = await embeddingClient.GenerateEmbeddingsAsync(
+                    textChunks.Select(tc => tc.Content!).ToList(),
+                    new OpenAI.Embeddings.EmbeddingGenerationOptions { Dimensions = embeddingDimensions });
 
                 return new TextEmbeddingResult
                 {

--- a/src/dotnet/Gateway/Services/AzureOpenAITextEmbeddingService.cs
+++ b/src/dotnet/Gateway/Services/AzureOpenAITextEmbeddingService.cs
@@ -43,12 +43,12 @@ namespace FoundationaLLM.Gateway.Services
                 return new TextEmbeddingResult
                 {
                     InProgress = false,
-                    TextChunks = Enumerable.Range(0, result.Value.Count).Select(i =>
+                    TextChunks = [.. Enumerable.Range(0, result.Value.Count).Select(i =>
                     {
                         var textChunk = textChunks[i];
                         textChunk.Embedding = new Embedding(result.Value[i].ToFloats());
                         return textChunk;
-                    }).ToList()
+                    })]
                 };
             }
             catch (Exception ex)

--- a/src/dotnet/Gateway/Services/GatewayCore.cs
+++ b/src/dotnet/Gateway/Services/GatewayCore.cs
@@ -149,24 +149,25 @@ namespace FoundationaLLM.Gateway.Services
             var operationId = Guid.NewGuid().ToString().ToLower();
             var embeddingOperationContext = new EmbeddingOperationContext
             {
-                InputTextChunks = embeddingRequest.TextChunks.Select(tc => new TextChunk
+                InputTextChunks = [.. embeddingRequest.TextChunks.Select(tc => new TextChunk
                 {
                     OperationId = operationId,
                     Position = tc.Position,
                     Content = tc.Content,
                     TokensCount = tc.TokensCount
-                }).ToList(),
+                })],
                 Result = new TextEmbeddingResult
                 {
                     InProgress = true,
                     OperationId = operationId,
-                    TextChunks = embeddingRequest.TextChunks.Select(tc => new TextChunk
+                    TextChunks = [.. embeddingRequest.TextChunks.Select(tc => new TextChunk
                     {
                         Position = tc.Position
-                    }).ToList(),
+                    })],
                     TokenCount = 0
                 },
-                Prioritized = embeddingRequest.Prioritized
+                Prioritized = embeddingRequest.Prioritized,
+                EmbeddingModelDimensions = embeddingRequest.EmbeddingModelDimensions
             };
 
             embeddingModel.AddEmbeddingOperationContext(embeddingOperationContext);

--- a/src/dotnet/SemanticKernel/Services/SemanticKernelTextEmbeddingService.cs
+++ b/src/dotnet/SemanticKernel/Services/SemanticKernelTextEmbeddingService.cs
@@ -44,11 +44,12 @@ namespace FoundationaLLM.SemanticKernel.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string modelName = "text-embedding-ada-002", bool Prioritized=false)
+        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string modelName = "text-embedding-ada-002", int embeddingDimensions = 1536, bool Prioritized=false)
         {
             try
             {
-                var embeddings = await _textEmbeddingService.GenerateEmbeddingsAsync(textChunks.Select(tc => tc.Content!).ToList());
+                var embeddings = await _textEmbeddingService.GenerateEmbeddingsAsync(
+                    [.. textChunks.Select(tc => tc.Content!)]);
                 return new TextEmbeddingResult
                 {
                     InProgress = false,

--- a/src/dotnet/VectorizationEngine/Handlers/EmbeddingHandler.cs
+++ b/src/dotnet/VectorizationEngine/Handlers/EmbeddingHandler.cs
@@ -99,6 +99,7 @@ namespace FoundationaLLM.Vectorization.Handlers
                         TokensCount = tpa.Size
                     }).ToList(),
                     embeddingModelName,
+                    1536,
                     prioritized);
 
                 if (embeddingResult.InProgress)

--- a/src/dotnet/VectorizationEngine/Services/Text/GatewayTextEmbeddingService.cs
+++ b/src/dotnet/VectorizationEngine/Services/Text/GatewayTextEmbeddingService.cs
@@ -25,15 +25,15 @@ namespace FoundationaLLM.Vectorization.Services.Text
         private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
         /// <inheritdoc/>
-        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string modelName, bool Prioritized)
+        public async Task<TextEmbeddingResult> GetEmbeddingsAsync(IList<TextChunk> textChunks, string modelName, int embeddingDimensions, bool Prioritized)
         {
             var gatewayClient = await GetGatewayServiceClientAsync();
             return await gatewayClient.StartEmbeddingOperation(_instanceSettings.Id, new TextEmbeddingRequest
             {
                 EmbeddingModelName = modelName,
+                EmbeddingModelDimensions = embeddingDimensions,
                 TextChunks = textChunks,
                 Prioritized = Prioritized
-
             });
         }          
 


### PR DESCRIPTION
# Add support for specifying dimensionality in Gateway API embedding

## The issue or feature being addressed

Enable support for specifying the number of embedding dimensions in embedding requests sent to the Gateway API.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
