### PR TITLE
Fix issue with triggering data pipeline for uploaded file

### DIFF
--- a/src/dotnet/Common/Clients/PollingResourceRunner`2.cs
+++ b/src/dotnet/Common/Clients/PollingResourceRunner`2.cs
@@ -67,8 +67,7 @@ namespace FoundationaLLM.Common.Clients
                         totalPollingTime.TotalSeconds);
 
                     var existingResource = await resourceProviderService.GetResourceAsync<TResource>(
-                    instanceId,
-                    upsertResult.Resource!.Name,
+                    upsertResult.Resource!.ObjectId!,
                     userIdentity);
                     runnableResource = existingResource as IRunnableResource;
 

--- a/src/dotnet/DataPipeline/ResourceProviders/DataPipelineResourceProviderService.cs
+++ b/src/dotnet/DataPipeline/ResourceProviders/DataPipelineResourceProviderService.cs
@@ -98,6 +98,12 @@ namespace FoundationaLLM.DataPipeline.ResourceProviders
                     {
                         IncludeRoles = resourcePath.IsResourceTypePath
                     }),
+                DataPipelineResourceTypeNames.DataPipelineRuns => await _dataPipelineServiceClient.GetDataPipelineRunAsync(
+                        resourcePath.InstanceId!,
+                        resourcePath.ResourceId!,
+                        userIdentity)
+                        ?? throw new ResourceProviderException("The requested data pipeline run could not be loaded.",
+                            StatusCodes.Status404NotFound),
                 _ => throw new ResourceProviderException($"The resource type {resourcePath.ResourceTypeName} is not supported by the {_name} resource provider.",
                         StatusCodes.Status400BadRequest)
             };
@@ -244,10 +250,10 @@ namespace FoundationaLLM.DataPipeline.ResourceProviders
                 Type t when t == typeof(DataPipelineRun) =>
                     await _dataPipelineServiceClient.GetDataPipelineRunAsync(
                         resourcePath.InstanceId!,
-                        resourcePath.MainResourceId!,
+                        resourcePath.ResourceId!,
                         userIdentity) as T
-                        ?? throw new ResourceProviderException("The object definition is invalid.",
-                            StatusCodes.Status400BadRequest),
+                        ?? throw new ResourceProviderException("The data pipeline run resource could not be loaded.",
+                            StatusCodes.Status404NotFound),
                 _ => throw new ResourceProviderException(
                         $"The resource type {typeof(T).Name} is not supported by the {_name} resource provider.",
                             StatusCodes.Status400BadRequest)


### PR DESCRIPTION
# Fix issue with triggering data pipeline for uploaded file

## The issue or feature being addressed

The FoundationaLLM.DataPipeline resource provider uses an incorrect resource path when attempting to create a data pipeline run for a file uploaded via the User Portal.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
