### PR TITLE
Fix issue with conversation id not being propagated to LangChain API

### DIFF
--- a/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
@@ -328,6 +328,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
             new LLMCompletionRequest
             {
                 OperationId = completionRequest.OperationId,
+                SessionId = completionRequest.SessionId,
                 UserPrompt = completionRequest.UserPrompt!,
                 UserPromptRewrite = completionRequest.UserPromptRewrite,
                 MessageHistory = completionRequest.MessageHistory,

--- a/src/python/FoundationaLLMAgentPlugins/requirements.txt
+++ b/src/python/FoundationaLLMAgentPlugins/requirements.txt
@@ -7,7 +7,7 @@ azure-monitor-opentelemetry-exporter==1.0.0b36
 azure-search-documents==11.6.0b9
 azure-storage-blob==12.21.0
 boto3==1.36.13
-foundationallm==0.9.7rc113
+foundationallm==0.9.7rc114
 langchain==0.3.17
 langchain-aws==0.2.12
 langchain_azure_ai==0.1.2

--- a/src/python/FoundationaLLMAgentPlugins/src/foundationallm_agent_plugins/utils/__init__.py
+++ b/src/python/FoundationaLLMAgentPlugins/src/foundationallm_agent_plugins/utils/__init__.py
@@ -1,1 +1,1 @@
-from .azure_ai_search_service_retriever import AzureAISearchServiceRetriever
+from .azure_ai_search_conversation_retriever import AzureAISearchConversationRetriever

--- a/src/python/FoundationaLLMAgentPlugins/src/foundationallm_agent_plugins/workflows/foundationallm_function_calling_workflow.py
+++ b/src/python/FoundationaLLMAgentPlugins/src/foundationallm_agent_plugins/workflows/foundationallm_function_calling_workflow.py
@@ -25,10 +25,10 @@ from foundationallm.models.constants import (
     ContentArtifactTypeNames,
     ResourceObjectIdPropertyNames,
     ResourceObjectIdPropertyValues,
-    ResourceProviderNames,   
+    ResourceProviderNames,
     RunnableConfigKeys,
     AIModelResourceTypeNames,
-    PromptResourceTypeNames    
+    PromptResourceTypeNames
 )
 from foundationallm.models.messages import MessageHistoryItem
 from foundationallm.models.orchestration import (
@@ -112,7 +112,7 @@ class FoundationaLLMFunctionCallingWorkflow(FoundationaLLMWorkflowBase):
                 RunnableConfigKeys.ORIGINAL_USER_PROMPT_REWRITE: user_prompt_rewrite,
                 RunnableConfigKeys.CONVERSATION_ID: conversation_id
             }
-        )     
+        )
 
         # Convert message history to LangChain message types
         langchain_messages = []
@@ -145,7 +145,7 @@ class FoundationaLLMFunctionCallingWorkflow(FoundationaLLMWorkflowBase):
         final_response = None
 
         with self.tracer.start_as_current_span(f'{self.name}_workflow', kind=SpanKind.INTERNAL):
-            
+
             with self.tracer.start_as_current_span(f'{self.name}_workflow_llm_call', kind=SpanKind.INTERNAL):
                 router_start_time = time.time()
                 llm_bound_tools = self.workflow_llm.bind_tools(self.tools)


### PR DESCRIPTION
# Fix issue with conversation id not being propagated to LangChain API

## The issue or feature being addressed

The `SessionId` field of the `LLMCompletionRequest` model is not set in Orchestration API.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
