### PR TITLE
Gatekeeper Integration API Crash Fix

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -1,4 +1,4 @@
-name: Pre-release Build
+name: Base Docker Images Build
 
 on:
   push:

--- a/src/python/Base/Dockerfile
+++ b/src/python/Base/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache libpq gcc git cmake && \
 WORKDIR /code
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
-RUN python3 -m pip install --no-cache-dir --upgrade setuptools==70.3.0
+RUN python3 -m pip install --no-cache-dir --upgrade setuptools==78.1.1
 
 RUN git clone --no-checkout https://github.com/apache/arrow.git /arrow \
     && cd /arrow \

--- a/src/python/GatekeeperIntegrationAPI/Dockerfile
+++ b/src/python/GatekeeperIntegrationAPI/Dockerfile
@@ -1,10 +1,13 @@
-ARG FOUNDATIONALLM_REGISTRY="ghcr.io/solliancenet/foundationallm"
-ARG PYTHON_FLLM_BASE_VERSION="latest"
-ARG BASE_IMAGE="${FOUNDATIONALLM_REGISTRY}/fllm-python-base:${PYTHON_FLLM_BASE_VERSION}"
-FROM ${BASE_IMAGE}
+# ARG FOUNDATIONALLM_REGISTRY="ghcr.io/solliancenet/foundationallm"
+# ARG PYTHON_FLLM_BASE_VERSION="latest"
+# ARG BASE_IMAGE="${FOUNDATIONALLM_REGISTRY}/fllm-python-base:${PYTHON_FLLM_BASE_VERSION}"
+# FROM ${BASE_IMAGE}
+FROM python:3.11-slim
 ARG FOUNDATIONALLM_VERSION
 ENV FOUNDATIONALLM_VERSION=${FOUNDATIONALLM_VERSION:-0.0.0}
 ENV APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL=true
+
+RUN python3 -m pip install --no-cache-dir --upgrade setuptools==78.1.1
 
 WORKDIR /code
 COPY ./GatekeeperIntegrationAPI/requirements.txt /code/requirements.txt


### PR DESCRIPTION
# Gatekeeper Integration API Crash Fix

## Details on the issue fix or feature implementation

Modified docker build for Gatekeeper Integration API to use python:3.11-slim instead of python:3.11-alpine because of an OS incompatibility issue with pytorch on Alpine.  Also updated setuptools package to 78.1.1 to account for CVE-2025-47273 critical vulnerability.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
