### PR TITLE
Fix an issue with deleting code session files in Context API

### DIFF
--- a/src/dotnet/Context/Services/AzureContainerAppsCustomContainerService.cs
+++ b/src/dotnet/Context/Services/AzureContainerAppsCustomContainerService.cs
@@ -106,20 +106,11 @@ namespace FoundationaLLM.Context.Services
         {
             var httpClient = await CreateHttpClient();
 
-            var itemsToDelete = await GetCodeSessionFileStoreItems(
-                codeSessionId,
-                endpoint,
-                httpClient,
-                includeFolders: true);
-
-            foreach (var item in itemsToDelete)
-            {
-                var url = $"{endpoint}/files/{item.Name}?api-version=2024-10-02-preview&identifier={codeSessionId}&path={item.ParentPath}";
-                var responseMessage = await httpClient.DeleteAsync(url);
-                if (!responseMessage.IsSuccessStatusCode)
-                    _logger.LogError("Unable to delete file {FileName} from code session {CodeSession}.",
-                        item.Name, codeSessionId);
-            }
+            var url = $"{endpoint}/files/delete?api-version=2024-10-02-preview&identifier={codeSessionId}";
+            var responseMessage = await httpClient.PostAsync(url, null);
+            if (!responseMessage.IsSuccessStatusCode)
+                _logger.LogError("Unable to delete the existing files from code session {CodeSession}.",
+                    codeSessionId);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
# Fix an issue with deleting code session files in Context API

## The issue or feature being addressed

Context API is not deleting correctly the files from a custom container code session.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
