### PR TITLE
Improve management of API raw request quotas on Core API

### DIFF
--- a/docs/concepts/quota/agent-completion-call-rate.md
+++ b/docs/concepts/quota/agent-completion-call-rate.md
@@ -1,1 +1,0 @@
-# Agent Completion Call Rate

--- a/docs/concepts/quota/agent-request-rate.md
+++ b/docs/concepts/quota/agent-request-rate.md
@@ -1,0 +1,5 @@
+# Agent Request Rate
+
+The agent request rate is a quota that limits the number of completion requests made to specific agents. These calls are made to the Core API `Completions` controller and the `context` of the quota definition must be set to `CoreAPI:Completions:<agent_name>`, where `<agent_name>` is the name of the agent.
+
+This quota can be enforced per agent for all users or per specific user principal name (UPN) or user identifier. In most cases, the relationship between user principal name and user identifier is one-to-one, so the quota would be effectively the same if `metric_partition` were set to `UserPrincipalName` or `UserIdentitifer`. In these cases, the recommended value for `metric_partition` is `UserPrincipalName`. However, in some more advanced scenarios (e.g., when calls are made by another service that authenticates against the Core API using a managed identity), the user principal name may not be available, and the quota should be enforced by user identifier. In these cases, the recommended value for `metric_partition` is `UserIdentifier`.

--- a/docs/concepts/quota/api-completion-call-rate.md
+++ b/docs/concepts/quota/api-completion-call-rate.md
@@ -1,1 +1,0 @@
-# API Completion Call Rate

--- a/docs/concepts/quota/api-raw-request-rate.md
+++ b/docs/concepts/quota/api-raw-request-rate.md
@@ -1,0 +1,21 @@
+# API Raw Request Rate
+
+The API raw request rate is a quota that limits the number of raw requests made to API controllers. Currently, only controllers from the Core API are supported.
+
+This quota can be enforced per API controller for all users or per specific user principal name (UPN) or user identifier. In most cases, the relationship between user principal name and user identifier is one-to-one, so the quota would be effectively the same if `metric_partition` were set to `UserPrincipalName` or `UserIdentitifer`. In these cases, the recommended value for `metric_partition` is `UserPrincipalName`. However, in some more advanced scenarios (e.g., when calls are made by another service that authenticates against the Core API using a managed identity), the user principal name may not be available, and the quota should be enforced by user identifier. In these cases, the recommended value for `metric_partition` is `UserIdentifier`.
+
+The following table lists the supported controllers and their contexts:
+
+| Controller | Context |
+| --- | --- |
+| `Completions` | `CoreAPI:Completions` |
+| `CompletionsStatus` | `CoreAPI:CompletionsStatus` * |
+| `Branding` | `CoreAPI:Branding` |
+| `Configuration` | `CoreAPI:Configuration` |
+| `Files` | `CoreAPI:Files` |
+| `OneDriveWorkSchool` | `CoreAPI:OneDriveWorkSchool` |
+| `Sessions` | `CoreAPI:Sessions` |
+| `UserProfiles` | `CoreAPI:UserProfiles` |
+| `Status` | `CoreAPI:Status` |
+
+* Before FoundationaLLM `v0.9.7-rc158`, the `CompletionsStatus` controller was not available, and the `Completions` controller was used to check the status of completions. Starting with FoundationaLLM `v0.9.7-rc158`, the `CompletionsStatus` controller is available, and it is used to check the status of completions. Certain client applications (the User Portal being the most notable example) require extensive use of the completions status endpoint, in order to provide a better user experience. Since the number of requests asking for the status of completions is significantly higher than the number of requests asking for completions defining an effective API raw request rate limit for the `Completions` controller is not practical prior to version `v0.9.7-rc158` and is not recommended. Starting with `v0.9.7-rc158`, separate raw request rate limits can be defined for the `Completions` and `CompletionsStatus` controllers, allowing for a more effective quota enforcement. When defining a quota for the `CompletionsStatus` controller, you need to take into account the value of the `FoundationaLLM:APIEndpoints:CoreAPI:Configuration:CompletionResponsePollingIntervalMilliseconds` configuration setting, which defines the polling interval for the completions status endpoint in the User Portal. The default value is 100 milliseconds, meaning that the User Portal will poll the completions status endpoint every 100 milliseconds to check the status of the completion. This means that if a user has 2 active completions, they will make 20 requests per second to the completions status endpoint, which can quickly add up to a significant number of requests. Therefore, it is recommended to define a separate quota for the `CompletionsStatus` controller with a higher limit than the `Completions` controller.

--- a/docs/concepts/quota/quota-definition.md
+++ b/docs/concepts/quota/quota-definition.md
@@ -4,9 +4,9 @@ The quota definitions are stored in the main FoundationaLLM storage account, in 
 
 ```json
 {
-	"name": "TestAPI01CompletionsUPNRawRequestRateLimit",
-	"description": "Defines a per UPN raw request rate limit on the TestAPI01 Completions controller.",
-	"context": "TestAPI01:Completions",
+	"name": "CoreAPICompletionsUPNRawRequestRateLimit",
+	"description": "Defines a per UPN raw request rate limit on the Core API Completions controller.",
+	"context": "CoreAPI:Completions",
 	"type": "RawRequestRateLimit",
 	"metric_partition": "UserPrincipalName",
 	"metric_limit": 120,
@@ -16,16 +16,27 @@ The quota definitions are stored in the main FoundationaLLM storage account, in 
 }
 ```
 
+The example above defines a quota for the Core API Completions controller that limits the number of raw API requests per user principal name (UPN) to 120 requests in a 60-second window. If the user principal exceeds this limit, they are locked out for 60 seconds before the quota is reset.
+
+>[!NOTE]
+> A user principal name corresponds to either a user or an agent access token. If the same agent access token is shared by multiple applications calling the Core API, the quota is enforced across all applications using that token.
+
+>[!NOTE]
+> FoundationaLLM using a smoothing time window of 20 seconds for the quota enforcement. This means that the quota is enforced every 20 seconds, and the number of requests is averaged over that time window. This helps to smooth out spikes in traffic and provides a more consistent experience for users. In the example above, this means that the specified user principal name can make up to 40 requests every 20 seconds. The first time the user principal name exceeds the limit, they are locked out for 60 seconds. After the lockout period, the user principal name can make requests again, and the quota is reset.
+>
+> It is recommended to set the `metric_window_seconds` to a multiple of 20 seconds to align with the smoothing time window. The standard practice is to set the `metric_window_seconds` to 60 seconds, which makes it easy to understand for the consumers of the API. Also, it is recommended to set the `metric_limit` to a multiple of `metric_window_seconds` divided by 20 seconds, so that you avoid misinterpretation of the quota limits due to roundings. In the example above, since `metric_window_seconds` is set to 60 seconds, `metric_limit` should be set to a multiple of 3 (60 seconds / 20 seconds). Therefore, the value of `metric_limit` is set to 120. If `metric_limit` were set to 3, the user principal name would be allowed to make only 1 request every 20 seconds. It is also important to note that setting `metric_limit` to a value below `metric_windows_seconds` divided by 20 seconds would result in the user principal name being locked out immediately after the first request, which is not a desirable behavior.
+
 The following table provides details about the quota definition properties:
 
 Name | Description | Notes
 --- | --- | ---
 `name` | The name of the quota definition. |
 `description` | A description of the quota definition. |
-`context` | The context of the quota definition. | The format of the context is `<service_name>:<controller_name>` or `<service_name>:<controller_name>:<agent_name>`. Currently the following contexts can be used: `CoreAPI:Completions`, `CoreAPI:Completions:<agent_name>` where `<agent_name>` must be a valid agent name.
-`type` | The type of the quota enforcement applied. | The following types are supported: `RawRequestRateLimit` and `AgentRequestRateLimit`. `RawRequestRateLimt` defines the quota metric to be raw API requests and requires a context of `<service_name>:<controller_name>`. `AgentRequestRateLimit` defines the quota metric to be agent completion requests and requires a context of `<service_name>:<controller_name>:<agent_name>`.
-`metric_partition` | The metric partition used to enforce the quota. | The following partitions are supported: `None` (the metric is not partitioned) `UserPrincipalName` (the metric is partitioned by user principal name) and `UserIdentifier` (the metric is partitioned by user identifier).
+`context` | The context of the quota definition. | The format of the context is `<service_name>:<controller_name>` or `<service_name>:<controller_name>:<agent_name>`. Currently the following contexts can be used: `CoreAPI:<controller_name>`, `CoreAPI:Completions:<agent_name>` where `<agent_name>` must be a valid agent name. For more details on the available controllers and their contexts, see [API Raw Request Rate](api-raw-request-rate.md).
+`type` | The type of the quota enforcement applied. | The following types are supported: `RawRequestRateLimit` and `AgentRequestRateLimit`. `RawRequestRateLimt` defines the quota metric to be raw API requests and requires a context of `<service_name>:<controller_name>`. `AgentRequestRateLimit` defines the quota metric to be agent completion requests and requires a context of `<service_name>:<controller_name>:<agent_name>`. For more details, see [API Raw Request Rate](api-raw-request-rate.md) or [Agent Request Rate](agent-request-rate.md).
+`metric_partition` | The metric partition used to enforce the quota. | The following partitions are supported: `None` (the metric is not partitioned) `UserPrincipalName` (the metric is partitioned by user principal name) and `UserIdentifier` (the metric is partitioned by user identifier). In the example above, the metric is partitioned by user principal name, meaning that each user principal name has its own quota limit. If `metric_partition` were set to `None`, the quota would be enforced globally across all calls, regardless of user principal names, meaning that the limit would apply to all users collectively. If `metric_partition` were set to `UserIdentifier`, the quota would be enforced per user identifier, which is a unique identifier for each user. In most cases, the relationship between user principal name and user identifier is one-to-one, so the quota would be effectively the same as if `metric_partition` were set to `UserPrincipalName`. In these cases, the recommended value for `metric_partition` is `UserPrincipalName`. However, in some more advanced scenarios (e.g., when calls are made by another service that authenticates against the Core API using a managed identity), the user principal name may not be available, and the quota should be enforced by user identifier. In these cases, the recommended value for `metric_partition` is `UserIdentifier`.
 `metric_limit` | The limit of the metric. | The limit is enforced over the `metric_window_seconds`. In the example above, a maximum number of 120 raw API requests are allowed per user principal name in a 60-second window.
 `metric_window_seconds` | The time window in seconds over which the limit is enforced. | In the example above, a maximum number of 120 raw API requests are allowed per user principal name in a 60-second window.
 `lockout_duration_seconds` | The duration in seconds for which the caller is locked out after exceeding the quota. | The lockout duration is applied after the user exceeds the quota limit. The user is locked out for the specified duration before the quota is reset.
-`distributed_enforcement` | Indicates whether the quota is enforced across multiple instances of the same API. | If `true`, the quota is enforced across multiple instances. If `false`, the quota is enforced on a single instance. Currently, only `false` is supported.
+`distributed_enforcement` | Indicates whether the quota is enforced across multiple instances of the same API. | If `true`, the quota is enforced across all the instances of the API. If `false`, the quota is enforced individually on every single instance. In the example above, if the platform in running 5 instances of the Core API, one user principal name can make up to 5 x 120 = 600 raw API requests in a 60-second window. If `distributed_enforcement` were set to `true`, the user principal name would be allowed to make only 120 raw API requests in a 60-second window across all instances of the Core API.
+

--- a/src/dotnet/CoreAPI/Controllers/CompletionsController.cs
+++ b/src/dotnet/CoreAPI/Controllers/CompletionsController.cs
@@ -157,16 +157,6 @@ namespace FoundationaLLM.Core.API.Controllers
         }
 
         /// <summary>
-        /// Gets the status of a completion operation.
-        /// </summary>
-        /// <param name="instanceId">The FoundationaLLM instance id.</param>
-        /// <param name="operationId">The OperationId for which to retrieve the status.</param>
-        /// <returns>Returns a <see cref="LongRunningOperation"/> object containing the OperationId, Status, and result.</returns>
-        [HttpGet("async-completions/{operationId}/status")]
-        public async Task<LongRunningOperation> GetCompletionOperationStatus(string instanceId, string operationId) =>
-            await _coreService.GetCompletionOperationStatus(instanceId, operationId);
-
-        /// <summary>
         /// Retrieves a list of global and private agents.
         /// </summary>
         /// <param name="instanceId">The instance ID of the current request.</param>

--- a/src/dotnet/CoreAPI/Controllers/CompletionsStatusController.cs
+++ b/src/dotnet/CoreAPI/Controllers/CompletionsStatusController.cs
@@ -1,0 +1,76 @@
+using FoundationaLLM.Common.Authentication;
+using FoundationaLLM.Common.Constants.Authorization;
+using FoundationaLLM.Common.Constants.ResourceProviders;
+using FoundationaLLM.Common.Exceptions;
+using FoundationaLLM.Common.Interfaces;
+using FoundationaLLM.Common.Models.Orchestration;
+using FoundationaLLM.Core.Interfaces;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundationaLLM.Core.API.Controllers
+{
+    /// <summary>
+    /// Provides methods for retrieving and managing completions.
+    /// </summary>
+    /// <remarks>
+    /// Constructor for the Completions Controller.
+    /// </remarks>
+    [Authorize(
+        AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme,
+        Policy = AuthorizationPolicyNames.MicrosoftEntraIDStandard)]
+    [Authorize(
+        AuthenticationSchemes = AgentAccessTokenDefaults.AuthenticationScheme,
+        Policy = AuthorizationPolicyNames.FoundationaLLMAgentAccessToken)]
+    [ApiController]
+    [Route("instances/{instanceId}")]
+    public class CompletionsStatusController : ControllerBase
+    {
+        private readonly ICoreService _coreService;
+        private readonly IResourceProviderService _agentResourceProvider;
+        private readonly ILogger<CompletionsController> _logger;
+        private readonly IOrchestrationContext _callContext;
+        private readonly IQuotaService _quotaService;
+
+        /// <summary>
+        /// Methods for orchestration services exposed by the Gatekeeper API service.
+        /// </summary>
+        /// <remarks>
+        /// Constructor for the Orchestration Controller.
+        /// </remarks>
+        /// <param name="coreService">The Core service provides methods for getting
+        /// completions from the orchestrator.</param>
+        /// <param name="callContext">The call context for the request.</param>
+        /// <param name="resourceProviderServices">The list of <see cref="IResourceProviderService"/> resource provider services.</param>
+        /// <param name="quotaService">The quota service.</param>
+        /// <param name="logger">The logging interface used to log under the
+        /// <see cref="CompletionsController"/> type name.</param>
+        public CompletionsStatusController(ICoreService coreService,
+            IOrchestrationContext callContext,
+            IEnumerable<IResourceProviderService> resourceProviderServices,
+            IQuotaService quotaService,
+            ILogger<CompletionsController> logger)
+        {
+            _coreService = coreService;
+            var resourceProviderServicesDictionary = resourceProviderServices.ToDictionary<IResourceProviderService, string>(
+                rps => rps.Name);
+            if (!resourceProviderServicesDictionary.TryGetValue(ResourceProviderNames.FoundationaLLM_Agent, out var agentResourceProvider))
+                throw new ResourceProviderException($"The resource provider {ResourceProviderNames.FoundationaLLM_Agent} was not loaded.");
+            _agentResourceProvider = agentResourceProvider;
+            _logger = logger;
+            _callContext = callContext;
+            _quotaService = quotaService;
+        }
+
+        /// <summary>
+        /// Gets the status of a completion operation.
+        /// </summary>
+        /// <param name="instanceId">The FoundationaLLM instance id.</param>
+        /// <param name="operationId">The OperationId for which to retrieve the status.</param>
+        /// <returns>Returns a <see cref="LongRunningOperation"/> object containing the OperationId, Status, and result.</returns>
+        [HttpGet("async-completions/{operationId}/status")]
+        public async Task<LongRunningOperation> GetCompletionOperationStatus(string instanceId, string operationId) =>
+            await _coreService.GetCompletionOperationStatus(instanceId, operationId);
+    }
+}

--- a/src/dotnet/CoreAPI/Controllers/OneDriveWorkSchoolController.cs
+++ b/src/dotnet/CoreAPI/Controllers/OneDriveWorkSchoolController.cs
@@ -26,7 +26,7 @@ namespace FoundationaLLM.Core.API.Controllers
         /// The controller for OneDrive integration.
         /// </summary>
         /// <param name="callContext">The <see cref="IOrchestrationContext"/> call context of the request being handled.</param>
-        /// <param name="oneDriveService">The <see cref="IOneDriveWorkSchoolService"/> OneDrive service.</param>
+        /// <param name="oneDriveWorkSchoolService">The <see cref="IOneDriveWorkSchoolService"/> OneDrive service.</param>
         /// <exception cref="ResourceProviderException"></exception>
         public OneDriveWorkSchoolController(
             IOrchestrationContext callContext,


### PR DESCRIPTION
# Improve management of API raw request quotas on Core API

## The issue or feature being addressed

The completion request status and completion request start operations are on the same Core API controller which makes it difficult to enforce efficient raw request quotas.

## Details on the issue fix or feature implementation

Factors out the retrieval of completion request status into a separate controller and updates the quota documentation.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
