### PR TITLE
Trigger pipelines using data pipeline resource paths in Management API

### DIFF
--- a/src/dotnet/Common/Constants/ResourceProviders/DataPipelineResourceProviderMetadata.cs
+++ b/src/dotnet/Common/Constants/ResourceProviders/DataPipelineResourceProviderMetadata.cs
@@ -1,6 +1,5 @@
 ﻿using FoundationaLLM.Common.Constants.Authorization;
 using FoundationaLLM.Common.Models.ResourceProviders;
-using FoundationaLLM.Common.Models.ResourceProviders.Configuration;
 using FoundationaLLM.Common.Models.ResourceProviders.DataPipeline;
 
 namespace FoundationaLLM.Common.Constants.ResourceProviders
@@ -32,6 +31,9 @@ namespace FoundationaLLM.Common.Constants.ResourceProviders
                         ]),
                         new ResourceTypeAction(ResourceProviderActions.Deactivate, true, false, [
                             new ResourceTypeAllowedTypes(HttpMethod.Post.Method, AuthorizableOperations.Write, [], [], [typeof(ResourceProviderActionResult)])
+                        ]),
+                        new ResourceTypeAction(ResourceProviderActions.Trigger, true, false, [
+                            new ResourceTypeAllowedTypes(HttpMethod.Post.Method, AuthorizableOperations.Write, [], [typeof(DataPipelineTriggerRequest)], [typeof(ResourceProviderActionResult)])
                         ]),
                         new ResourceTypeAction(ResourceProviderActions.Purge, true, false, [
                             new ResourceTypeAllowedTypes(HttpMethod.Post.Method, AuthorizableOperations.Delete, [], [], [typeof(ResourceProviderActionResult)])

--- a/src/dotnet/Common/Models/ResourceProviders/DataPipeline/DataPipelineRun.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/DataPipeline/DataPipelineRun.cs
@@ -1,6 +1,7 @@
 ﻿using FoundationaLLM.Common.Constants.DataPipelines;
 using FoundationaLLM.Common.Constants.ResourceProviders;
 using FoundationaLLM.Common.Interfaces;
+using FoundationaLLM.Common.Models.Authentication;
 using System.Text.Json.Serialization;
 
 namespace FoundationaLLM.Common.Models.ResourceProviders.DataPipeline
@@ -101,6 +102,13 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.DataPipeline
         public Dictionary<string, DataPipelineStageMetrics> StagesMetrics { get; set; } = [];
 
         /// <summary>
+        /// Gets or sets the list of errors encountered during the data pipeline run.
+        /// </summary>
+        [JsonPropertyName("errors")]
+        [JsonPropertyOrder(14)]
+        public List<string>? Errors { get; set; }
+
+        /// <summary>
         /// Set default property values.
         /// </summary>
         public DataPipelineRun() =>
@@ -131,6 +139,30 @@ namespace FoundationaLLM.Common.Models.ResourceProviders.DataPipeline
                 Processor = processor,
 
                 ObjectId = ResourcePath.Join(dataPipelineObjectId, "dataPipelineRuns/new"),
+                Name = string.Empty,
+                Id = string.Empty,
+                InstanceId = string.Empty,
+                TriggeringUPN = string.Empty
+            };
+
+        /// <summary>
+        /// Creates a new <see cref="DataPipelineRun"/> instance from a data pipeline trigger request.
+        /// </summary>
+        /// <param name="request">The data pipeline trigger request used to create the run.</param>
+        /// <param name="ownerUserIdentity">The identity of the user that owns the newly created data pipeline run.</param>
+        /// <returns>The newly created data pipeline run object.</returns>
+        public static DataPipelineRun FromTriggerRequest(
+            DataPipelineTriggerRequest request,
+            UnifiedUserIdentity ownerUserIdentity) =>
+            new()
+            {
+                DataPipelineObjectId = request.DataPipelineObjectId,
+                TriggerName = request.TriggerName,
+                TriggerParameterValues = request.TriggerParameterValues,
+                UPN = ownerUserIdentity.UPN!,
+                Processor = request.Processor,
+
+                ObjectId = ResourcePath.Join(request.DataPipelineObjectId, "dataPipelineRuns/new"),
                 Name = string.Empty,
                 Id = string.Empty,
                 InstanceId = string.Empty,

--- a/src/dotnet/Common/Models/ResourceProviders/DataPipeline/DataPipelineTriggerRequest.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/DataPipeline/DataPipelineTriggerRequest.cs
@@ -1,0 +1,42 @@
+﻿using FoundationaLLM.Common.Constants.DataPipelines;
+using System.Text.Json.Serialization;
+
+namespace FoundationaLLM.Common.Models.ResourceProviders.DataPipeline
+{
+    /// <summary>
+    /// Represents a request to trigger a data pipeline run.
+    /// </summary>
+    public class DataPipelineTriggerRequest
+    {
+        /// <summary>
+        /// Gets or sets the object identifier of the data pipeline.
+        /// </summary>
+        [JsonPropertyName("data_pipeline_object_id")]
+        [JsonPropertyOrder(1)]
+        public required string DataPipelineObjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the manual trigger used to start the pipeline.
+        /// </summary>
+        [JsonPropertyName("trigger_name")]
+        [JsonPropertyOrder(2)]
+        public required string TriggerName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary that contains the parameter values required to trigger the pipeline.
+        /// </summary>
+        [JsonPropertyName("trigger_parameter_values")]
+        [JsonPropertyOrder(3)]
+        public required Dictionary<string, object> TriggerParameterValues { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the name of the processor that is used to process the data pipeline run.
+        /// </summary>
+        /// <remarks>
+        /// Must be one of the values from <see cref="DataPipelineRunProcessors"/>.
+        /// </remarks>
+        [JsonPropertyName("processor")]
+        [JsonPropertyOrder(4)]
+        public required string Processor { get; set; }
+    }
+}

--- a/src/dotnet/Common/Models/ResourceProviders/ResourceProviderUpsertResult`1.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourceProviderUpsertResult`1.cs
@@ -16,5 +16,15 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
         /// </remarks>
         [JsonPropertyName("resource")]
         public new T? Resource { get; set; }
+
+        /// <summary>
+        /// Converts the upsert result to an action result.
+        /// </summary>
+        /// <returns>The action result created from the upsert result.</returns>
+        public ResourceProviderActionResult<T> ToActionResult() =>
+            new(ObjectId, true)
+            {
+                Resource = Resource
+            };
     }
 }

--- a/src/dotnet/DataPipeline/ResourceProviders/DataPipelineResourceProviderService.cs
+++ b/src/dotnet/DataPipeline/ResourceProviders/DataPipelineResourceProviderService.cs
@@ -140,6 +140,21 @@ namespace FoundationaLLM.DataPipeline.ResourceProviders
             UnifiedUserIdentity userIdentity) =>
             resourcePath.ResourceTypeName switch
             {
+                DataPipelineResourceTypeNames.DataPipelines =>
+                    resourcePath.Action switch
+                    {
+                        ResourceProviderActions.Trigger => (await CreateDataPipelineRun(
+                            resourcePath,
+                            DataPipelineRun.FromTriggerRequest(
+                                JsonSerializer.Deserialize<DataPipelineTriggerRequest>(serializedAction)
+                                    ?? throw new ResourceProviderException("The data pipeline trigger request is invalid.",
+                                        StatusCodes.Status400BadRequest),
+                                userIdentity),
+                            userIdentity)).ToActionResult(), 
+                        _ => throw new ResourceProviderException(
+                            $"The action {resourcePath.Action} on resource type {DataPipelineResourceTypeNames.DataPipelines} is not supported by the {_name} resource provider.",
+                                StatusCodes.Status400BadRequest)
+                    },
                 DataPipelineResourceTypeNames.DataPipelineRuns =>
                     resourcePath.Action switch
                     {

--- a/src/dotnet/DataPipelineEngine/Services/CosmosDB/AzureCosmosDBDataPipelineService.cs
+++ b/src/dotnet/DataPipelineEngine/Services/CosmosDB/AzureCosmosDBDataPipelineService.cs
@@ -119,11 +119,12 @@ namespace FoundationaLLM.DataPipelineEngine.Services.CosmosDB
             Dictionary<string, object?> propertyValues,
             CancellationToken cancellationToken = default)
         {
+            var patchOperations = propertyValues.Keys
+                .Select(key => PatchOperation.Set(key, propertyValues[key])).ToArray();
             var response = await _dataPipelineContainer.PatchItemAsync<T>(
                 id: id,
                 partitionKey: new PartitionKey(partitionKey),
-                patchOperations: propertyValues.Keys
-                    .Select(key => PatchOperation.Set(key, propertyValues[key])).ToArray(),
+                patchOperations: patchOperations,
                 cancellationToken: cancellationToken
             );
             return response.Resource;

--- a/src/dotnet/DataPipelineEngine/Services/DataPipelineStateService.cs
+++ b/src/dotnet/DataPipelineEngine/Services/DataPipelineStateService.cs
@@ -63,6 +63,9 @@ namespace FoundationaLLM.DataPipelineEngine.Services
         {
             try
             {
+                // There is a Cosmos DB limit of up to 10 properties that can be patched at once.
+                // We will patch the properties in two separate calls to avoid this limit.
+
                 await _cosmosDBService.PatchItemPropertiesAsync<DataPipelineRun>(
                     dataPipelineRun.RunId,
                     dataPipelineRun.Id,
@@ -74,6 +77,16 @@ namespace FoundationaLLM.DataPipelineEngine.Services
                         { "/stages_metrics", dataPipelineRun.StagesMetrics },
                         { "/completed", dataPipelineRun.Completed },
                         { "/successful", dataPipelineRun.Successful },
+                        { "/errors", dataPipelineRun.Errors }
+                    });
+
+                await _cosmosDBService.PatchItemPropertiesAsync<DataPipelineRun>(
+                    dataPipelineRun.RunId,
+                    dataPipelineRun.Id,
+                    new Dictionary<string, object?>
+                    {
+                        { "/completed_on", DateTimeOffset.UtcNow },
+                        { "/completed_by", ServiceContext.ServiceIdentity!.UPN },
                         { "/updated_on", DateTimeOffset.UtcNow },
                         { "/updated_by", ServiceContext.ServiceIdentity!.UPN }
                     });


### PR DESCRIPTION
# Trigger pipelines using data pipeline resource paths in Management API

## The issue or feature being addressed

Data pipelines cannot be started with a `trigger` action on a data pipeline object.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
