### PR TITLE
Fix content item persistence path in data pipelines

### DIFF
--- a/src/dotnet/DataPipelineEngine/Services/DataPipelineStateService.cs
+++ b/src/dotnet/DataPipelineEngine/Services/DataPipelineStateService.cs
@@ -169,7 +169,7 @@ namespace FoundationaLLM.DataPipelineEngine.Services
                     $"{DateTimeOffset.UtcNow:yyyy-MM-dd}",
                     dataPipelineRun.RunId,
                     "content-items",
-                    dataPipelineRunWorkItem.ContentItemCanonicalId,
+                    dataPipelineRunWorkItem.ContentItemCanonicalId.Trim('/').Replace('/', '-'),
                     artifactsNameFilter
                 ]);
 
@@ -211,7 +211,7 @@ namespace FoundationaLLM.DataPipelineEngine.Services
                     $"{DateTimeOffset.UtcNow:yyyy-MM-dd}",
                     dataPipelineRun.RunId,
                     "content-items",
-                    dataPipelineRunWorkItem.ContentItemCanonicalId
+                    dataPipelineRunWorkItem.ContentItemCanonicalId.Trim('/').Replace('/', '-')
                 ]);
 
             var artifactsWithError = new List<string>();
@@ -248,7 +248,7 @@ namespace FoundationaLLM.DataPipelineEngine.Services
                     $"{DateTimeOffset.UtcNow:yyyy-MM-dd}",
                     dataPipelineRun.RunId,
                     "content-items",
-                    dataPipelineRunWorkItem.ContentItemCanonicalId,
+                    dataPipelineRunWorkItem.ContentItemCanonicalId.Trim('/').Replace('/', '-'),
                     "content-parts.parquet"
                 ]);
 
@@ -278,7 +278,7 @@ namespace FoundationaLLM.DataPipelineEngine.Services
                     $"{DateTimeOffset.UtcNow:yyyy-MM-dd}",
                     dataPipelineRun.RunId,
                     "content-items",
-                    dataPipelineRunWorkItem.ContentItemCanonicalId,
+                    dataPipelineRunWorkItem.ContentItemCanonicalId.Trim('/').Replace('/', '-'),
                     "content-parts.parquet"
                 ]);
 


### PR DESCRIPTION
# Fix content item persistence path in data pipelines

## The issue or feature being addressed

Content item paths that contain `/` generate undesired folder structure in the storage account.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
