### PR TITLE
Fix issue with max number of inputs in embedding requests

### DIFF
--- a/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_KnowledgeExtractionDataPipelineStage.cs
+++ b/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_KnowledgeExtractionDataPipelineStage.cs
@@ -20,7 +20,7 @@ namespace FoundationaLLM.Core.Examples.Concepts.Plugins
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public async Task DataPipelinePlugins_SharePointOnlineDataSource_GetContentItems(
+        public async Task DataPipelinePlugins_KnowledgeExtractionDataPipelineStage_ProcessWorkItem(
             string dataPipelineRunWorkItemId,
             string dataPipelineRunId,
             Dictionary<string, object> pluginParameters)

--- a/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_KnowledgeGraphDataPipelineStage.cs
+++ b/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_KnowledgeGraphDataPipelineStage.cs
@@ -20,7 +20,7 @@ namespace FoundationaLLM.Core.Examples.Concepts.Plugins
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public async Task DataPipelinePlugins_SharePointOnlineDataSource_GetContentItems(
+        public async Task DataPipelinePlugins_KnowledgeGraphDataPipelineStage_ProcessWorkItem(
             string dataPipelineRunWorkItemId,
             string dataPipelineRunId,
             Dictionary<string, object> pluginParameters)


### PR DESCRIPTION
# Fix issue with max number of inputs in embedding requests

## The issue or feature being addressed

Fixes an issue with text embedding requests that have small text inputs and result in exceeding the 2048 limit on inputs per embedding request.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
