### PR TITLE
Improve handing of index updates in the Azure AI Search indexing plugin

### DIFF
--- a/src/dotnet/Common/Services/Azure/AzureAISearchService.cs
+++ b/src/dotnet/Common/Services/Azure/AzureAISearchService.cs
@@ -131,8 +131,7 @@ namespace FoundationaLLM.Common.Services.Azure
             var options = new SearchOptions
             {
                 Filter = filter,
-                Select = { keyFieldName },
-                Size = 1000 // Adjust as needed for batch size
+                Select = { keyFieldName }
             };
 
             var keysToDelete = new List<string>();

--- a/src/dotnet/DataPipelinePlugins/PluginPackageManager.cs
+++ b/src/dotnet/DataPipelinePlugins/PluginPackageManager.cs
@@ -420,7 +420,7 @@ namespace FoundationaLLM.Plugins.DataPipeline
             PluginNames.TEXTEXTRACTION_DATAPIPELINESTAGE => new TextExtractionDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
             PluginNames.TEXTPARTITIONING_DATAPIPELINESTAGE => new TextPartitioningDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
             PluginNames.GATEWAYTEXTEMBEDDING_DATAPIPELINESTAGE => new GatewayTextEmbeddingDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
-            PluginNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE => new AzureAIIndexingDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
+            PluginNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE => new AzureAISearchIndexingDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
             PluginNames.KNOWLEDGEEXTRACTION_DATAPIPELINESTAGE => new KnowledgeExtractionDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
             PluginNames.KNOWLEDGEGRAPH_DATAPIPELINESTAGE => new KnowledgeGraphDataPipelineStagePlugin(pluginParameters, this, serviceProvider),
             _ => throw new NotImplementedException($"The data pipeline stage plugin '{pluginName}' is not implemented.")

--- a/src/dotnet/DataPipelinePlugins/Plugins/DataPipelineStage/AzureAISearchIndexingDataPipelineStagePlugin.cs
+++ b/src/dotnet/DataPipelinePlugins/Plugins/DataPipelineStage/AzureAISearchIndexingDataPipelineStagePlugin.cs
@@ -13,8 +13,6 @@ using FoundationaLLM.Common.Models.ResourceProviders.Vector;
 using FoundationaLLM.Common.Services.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace FoundationaLLM.Plugins.DataPipeline.Plugins.DataPipelineStage
 {
@@ -24,7 +22,7 @@ namespace FoundationaLLM.Plugins.DataPipeline.Plugins.DataPipelineStage
     /// <param name="pluginParameters">The dictionary containing the plugin parameters.</param>
     /// <param name="packageManager">The package manager for the plugin.</param>
     /// <param name="serviceProvider">The service provider of the dependency injection container.</param>
-    public class AzureAIIndexingDataPipelineStagePlugin(
+    public class AzureAISearchIndexingDataPipelineStagePlugin(
         Dictionary<string, object> pluginParameters,
         IPluginPackageManager packageManager,
         IServiceProvider serviceProvider)
@@ -154,12 +152,12 @@ namespace FoundationaLLM.Plugins.DataPipeline.Plugins.DataPipelineStage
                     cip.IndexEntryId!, vectorStoreId!, cip.Content!, cip.Embedding!, cip.Metadata!
                 })]);
 
-            await _dataPipelineStateService.SaveDataPipelineRunWorkItemParts<DataPipelineContentItemContentPart>(
-                dataPipelineDefinition,
-                dataPipelineRun,
-                dataPipelineRunWorkItem,
-                contentItemParts,
-                CONTENT_PARTS_FILE_NAME);
+            //await _dataPipelineStateService.SaveDataPipelineRunWorkItemParts<DataPipelineContentItemContentPart>(
+            //    dataPipelineDefinition,
+            //    dataPipelineRun,
+            //    dataPipelineRunWorkItem,
+            //    contentItemParts,
+            //    CONTENT_PARTS_FILE_NAME);
 
             return new PluginResult(true, false);
         }

--- a/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_AzureAISearchIndexingDataPipelineStage.cs
+++ b/tests/dotnet/Core.Examples/Concepts/Plugins/Example_DataPipelinePlugins_AzureAISearchIndexingDataPipelineStage.cs
@@ -1,0 +1,84 @@
+﻿using FoundationaLLM.Common.Authentication;
+using FoundationaLLM.Common.Constants.ResourceProviders;
+using FoundationaLLM.Common.Interfaces;
+using FoundationaLLM.Common.Models.ResourceProviders.DataPipeline;
+using FoundationaLLM.Core.Examples.Setup;
+using FoundationaLLM.Plugins.DataPipeline;
+using Xunit.Abstractions;
+
+namespace FoundationaLLM.Core.Examples.Concepts.Plugins
+{
+    /// <summary>
+    /// Example class for testing the SharePoint Online Data Source Plugin in Data Pipelines.
+    /// </summary>
+    public class Example_DataPipelinePlugins_AzureAISearchIndexingDataPipelineStage : TestBase, IClassFixture<TestFixture>
+    {
+        public Example_DataPipelinePlugins_AzureAISearchIndexingDataPipelineStage(ITestOutputHelper output, TestFixture fixture)
+            : base(1, output, fixture)
+        {
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task DataPipelinePlugins_AzureAISearchIndexingDataPipelineStage_ProcessWorkItem(
+            string dataPipelineRunWorkItemId,
+            string dataPipelineRunId,
+            Dictionary<string, object> pluginParameters)
+        {
+            // Wait for all required initialization tasks to complete.
+            await Task.WhenAll([
+                StartEventsWorkers()
+            ]);
+
+            var packageManager = new PluginPackageManager();
+            var dataPipelineStateService = GetService<IDataPipelineStateService>();
+            var dataPipelineResourceProviderService = GetService<IEnumerable<IResourceProviderService>>()
+                .Single(rp => rp.Name == ResourceProviderNames.FoundationaLLM_DataPipeline);
+            var dataPipelineRunWorkItem = await dataPipelineStateService.GetDataPipelineRunWorkItem(
+                dataPipelineRunWorkItemId,
+                dataPipelineRunId);
+            var dataPipelineRun = await dataPipelineStateService.GetDataPipelineRun(dataPipelineRunId);
+            var dataPipelineDefinitionSnapshot = await dataPipelineResourceProviderService.GetResourceAsync<DataPipelineDefinitionSnapshot>(
+                dataPipelineRun!.DataPipelineObjectId,
+                ServiceContext.ServiceIdentity!);
+
+            WriteLine("============ FoundationaLLM Data Pipeline Plugins - Azure AI Indexing Data Pipeline Stage Tests ============");
+
+            var dataSourcePlugin = packageManager.GetDataPipelineStagePlugin(
+                PluginNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE,
+                pluginParameters,
+                MainServiceContainer.ServiceProvider);
+
+            var pluginResult = await dataSourcePlugin.ProcessWorkItem(
+                dataPipelineDefinitionSnapshot.DataPipelineDefinition,
+                dataPipelineRun,
+                dataPipelineRunWorkItem!);
+
+            Assert.True(pluginResult.Success, "The plugin should have succeeded.");
+        }
+
+        public static TheoryData<string, string, Dictionary<string, object>> TestData =>
+        new()
+        {
+            {
+                "work-item-HvoV4HxTCEm1sqIdu4MGPA",
+                "run-20250630-165745-JmaV2TETeU2G4S6EwUDjDQ-TAfGit69y0OhQOwAAtltKw",
+                new Dictionary<string, object>
+                {
+                    {
+                        PluginParameterNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE_VECTORDATABASEOBJECTID,
+                        "instances/8ac6074c-bdde-43cb-a140-ec0002d96d2b/providers/FoundationaLLM.Vector/vectorDatabases/SPO-Test"
+                    },
+                    {
+                        PluginParameterNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE_VECTORSTOREOBJECTID,
+                        "instances/8ac6074c-bdde-43cb-a140-ec0002d96d2b/providers/FoundationaLLM.Vector/vectorDatabases/SPO-Test/vectorStores/Test-Store-01"
+                    },
+                    {
+                        PluginParameterNames.AZUREAISEARCHINDEXING_DATAPIPELINESTAGE_EMBEDDINGDIMENSIONS,
+                        2048
+                    }
+                }
+            }
+        };
+    }
+}

--- a/tests/dotnet/Core.Examples/Core.Examples.csproj
+++ b/tests/dotnet/Core.Examples/Core.Examples.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="..\..\..\src\dotnet\ManagementClient\ManagementClient.csproj" />
     <ProjectReference Include="..\..\..\src\dotnet\Prompt\Prompt.csproj" />
     <ProjectReference Include="..\..\..\src\dotnet\SemanticKernel\SemanticKernel.csproj" />
+    <ProjectReference Include="..\..\..\src\dotnet\Vector\Vector.csproj" />
     <ProjectReference Include="..\TestUtils\TestUtils.csproj" />
   </ItemGroup>
 

--- a/tests/dotnet/Core.Examples/Setup/DependencyInjectionContainerInitializer.cs
+++ b/tests/dotnet/Core.Examples/Setup/DependencyInjectionContainerInitializer.cs
@@ -218,6 +218,7 @@ namespace FoundationaLLM.Core.Examples.Setup
             services.AddRemoteDataPipelineServiceClient(configuration);
             services.AddDataPipelineStateService(configuration);
             services.AddPromptResourceProvider(configuration);
+            services.AddVectorResourceProvider(configuration);
         }
 
         private static void RegisterOtherServices(IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
# Improve handing of index updates in the Azure AI Search indexing plugin

## The issue or feature being addressed

Index entries are not replaced in subsequent runs of a data pipeline with an indexing step.

## Details on the issue fix or feature implementation

The Azure AI Search Indexing data stage plugin replaces all index entries related to a given content item.

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
