### PR TITLE
Fix parameter name for default file upload pipeline

### DIFF
--- a/src/dotnet/Common/Constants/DataPipelines/DataPipelineTriggerParameterNames.cs
+++ b/src/dotnet/Common/Constants/DataPipelines/DataPipelineTriggerParameterNames.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// The vector store identifier for the indexing stage.
         /// </summary>
-        public const string StageIndexVectorStoreObjectId = "Stage.Index.VectorStoreObjectId";
+        public const string StageIndexVectorStoreId = "Stage.Index.VectorStoreId";
     }
 }

--- a/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
+++ b/src/dotnet/Orchestration/Orchestration/AgentOrchestration.cs
@@ -526,10 +526,7 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                             {
                                 { DataPipelineTriggerParameterNames.DataSourceContextFileContextFileObjectId,  contextFileResponse.Result.FileObjectId},
                                 { DataPipelineTriggerParameterNames.StageIndexVectorDatabaseObjectId, knowledgeSearchSettings.FileUploadVectorDatabaseObjectId },
-                                { DataPipelineTriggerParameterNames.StageIndexVectorStoreObjectId,
-                                    ResourcePath.Join(
-                                        knowledgeSearchSettings.FileUploadVectorDatabaseObjectId,
-                                        $"vectorStores/{_vectorStoreId}") }
+                                { DataPipelineTriggerParameterNames.StageIndexVectorStoreId, _vectorStoreId }
                             },
                             _callContext.CurrentUserIdentity!.UPN!,
                             DataPipelineRunProcessors.Frontend);


### PR DESCRIPTION
# Fix parameter name for default file upload pipeline

## The issue or feature being addressed

The default file upload pipeline expects `VectorStoreId` instead of `VectorStoreObjectId`.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
