### PR TITLE
Fix issue with parsing resource paths for FoundationaLLM.Knowledge

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
@@ -526,6 +526,7 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
                 ResourceProviderNames.FoundationaLLM_DataPipeline => DataPipelineResourceProviderMetadata.AllowedResourceTypes,
                 ResourceProviderNames.FoundationaLLM_Plugin => PluginResourceProviderMetadata.AllowedResourceTypes,
                 ResourceProviderNames.FoundationaLLM_Vector => VectorResourceProviderMetadata.AllowedResourceTypes,
+                ResourceProviderNames.FoundationaLLM_Knowledge => KnowledgeResourceProviderMetadata.AllowedResourceTypes,
                 _ => []
             };
 

--- a/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
+++ b/src/dotnet/Orchestration/Orchestration/OrchestrationBuilder.cs
@@ -559,6 +559,10 @@ namespace FoundationaLLM.Orchestration.Core.Orchestration
                             }                            
                             break;
 
+                        case KnowledgeResourceTypeNames.KnowledgeSources:
+                            // No need to send in the details of the knowledge source.
+                            break;
+
                         default:
                             throw new OrchestrationException($"Unknown resource type '{resourcePath.MainResourceTypeName}'.");
                     }


### PR DESCRIPTION
# Fix issue with parsing resource paths for FoundationaLLM.Knowledge

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
