### PR TITLE
Fix issue with content type detection in test harness

### DIFF
--- a/evaluation/python/agent-test-harness/test_harness.py
+++ b/evaluation/python/agent-test-harness/test_harness.py
@@ -156,8 +156,8 @@ def upload_file_with_progress(file_path, fllm_endpoint, session_id, agent_name):
         
         # Get the MIME type of the file
         mime_type, _ = mimetypes.guess_type(file_path)
-        if not mime_type:
-            mime_type = 'application/octet-stream'  # Default MIME type if none is detected
+        # If the mime type is not recognized, we will leave it as None
+        # as the Core API will make its own attempt to determine it.
         
         # Prepare the multipart form data with MIME type
         files = {


### PR DESCRIPTION
# Fix issue with content type detection in test harness

## The issue or feature being addressed

The Python test harness incorrectly defaults unrecognized content types to octet stream, preventing the Core API from attempting to determine them on its own.

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
